### PR TITLE
Add draggable region to element via attribute

### DIFF
--- a/src/browser/stylesAndElements.ts
+++ b/src/browser/stylesAndElements.ts
@@ -1,3 +1,4 @@
 export const isAppRegionDrag = (e: MouseEvent) => {
-  return e.target?.classList.contains("electrobun-webkit-app-region-drag");
+  return e.target?.classList.contains("electrobun-webkit-app-region-drag") ||
+    e.target?.attributes["electrobun-webkit-app-region-drag"] !== undefined;
 };


### PR DESCRIPTION
Just adds an option for folks who don't want to use a class to enable draggable functionality.