### PR TITLE
Ci builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,10 +43,7 @@ jobs:
         run: bun install
       
       - name: Build for ${{ matrix.platform }}-${{ matrix.arch }}
-        run: |
-          bun run build
-          cd dist
-          tar -czf ../electrobun-${{ matrix.platform }}-${{ matrix.arch }}.tar.gz *
+        run: node scripts/package-release.js
       
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,12 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to release (e.g., v0.0.19)'
+        description: 'Tag to release (e.g., v0.0.19 or v0.0.19-beta.1)'
         required: true
+      prerelease:
+        description: 'Is this a pre-release?'
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -71,3 +75,4 @@ jobs:
           tag_name: ${{ github.event.inputs.tag || github.ref_name }}
           files: artifacts/**/*.tar.gz
           generate_release_notes: true
+          prerelease: ${{ github.event.inputs.prerelease || contains(github.ref_name, '-beta') || contains(github.event.inputs.tag, '-beta') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g., v0.0.19)'
+        required: true
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux
+            arch: x64
+          - os: macos-latest
+            platform: darwin
+            arch: x64
+          - os: macos-latest
+            platform: darwin
+            arch: arm64
+          - os: windows-latest
+            platform: win32
+            arch: x64
+    
+    runs-on: ${{ matrix.os }}
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+      
+      - name: Install dependencies
+        run: bun install
+      
+      - name: Build for ${{ matrix.platform }}-${{ matrix.arch }}
+        run: |
+          bun run build
+          cd dist
+          tar -czf ../electrobun-${{ matrix.platform }}-${{ matrix.arch }}.tar.gz *
+      
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: electrobun-${{ matrix.platform }}-${{ matrix.arch }}
+          path: electrobun-${{ matrix.platform }}-${{ matrix.arch }}.tar.gz
+  
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          files: artifacts/**/*.tar.gz
+          generate_release_notes: true

--- a/.npmignore
+++ b/.npmignore
@@ -4,7 +4,8 @@
 /docs-old
 /documentation
 /playground
-/scripts
+/scripts/*
+!/scripts/postinstall.js
 /src
 /vendors
 /.colab.json
@@ -12,3 +13,18 @@
 /.gitmodules
 /bun.lockb
 /tsconfig.json
+/build.ts
+/CLAUDE.md
+/CLAUDE.local.md
+
+# Exclude heavy binaries (will be downloaded on demand)
+/dist/bun
+/dist/electrobun
+/dist/launcher
+/dist/extractor
+/dist/bsdiff
+/dist/bspatch
+/dist/process_helper
+/dist/libNativeWrapper.*
+/dist/WebView2Loader.dll
+/dist/cef/

--- a/.npmignore
+++ b/.npmignore
@@ -6,7 +6,8 @@
 /playground
 /scripts/*
 !/scripts/postinstall.js
-/src
+/src/*
+!/src/cli/
 /vendors
 /.colab.json
 /.gitignore

--- a/BETA_RELEASE.md
+++ b/BETA_RELEASE.md
@@ -1,0 +1,67 @@
+# Electrobun Beta Releases
+
+## For Users
+
+### Installing Beta Versions
+
+```bash
+# Install latest beta
+npm install electrobun@beta
+
+# Install specific beta version
+npm install electrobun@0.0.19-beta.1
+
+# View available versions
+npm view electrobun versions --json
+```
+
+### Switching Between Stable and Beta
+
+```bash
+# Switch to stable
+npm install electrobun@latest
+
+# Switch to beta
+npm install electrobun@beta
+```
+
+## For Maintainers
+
+### Publishing Beta Releases
+
+1. **Update version:**
+   ```bash
+   # First beta of a new version
+   npm version 0.0.19-beta.1
+   
+   # Increment beta number
+   bun npm:version:beta
+   ```
+
+2. **Create GitHub Release:**
+   ```bash
+   git push origin v0.0.19-beta.1
+   ```
+   Or manually trigger the workflow with the beta tag.
+
+3. **Publish to npm:**
+   ```bash
+   bun npm:publish:beta
+   ```
+
+### Beta Release Workflow
+
+1. Beta versions use semantic versioning: `MAJOR.MINOR.PATCH-beta.NUMBER`
+2. GitHub Actions automatically marks releases with `-beta` as pre-releases
+3. npm publishes to the `beta` dist-tag (not `latest`)
+4. Users on stable versions won't get beta updates
+
+### Promoting Beta to Stable
+
+```bash
+# Update version to stable
+npm version 0.0.19
+
+# Publish as latest
+bun npm:publish
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrobun",
-  "version": "0.0.18",
+  "version": "0.0.19-beta.1",
   "description": "Build ultra fast, tiny, and cross-platform desktop apps with Typescript.",
   "license": "MIT",
   "author": "Blackboard Technologies Inc.",
@@ -32,7 +32,9 @@
     "dev:playground:canary": "bun build:release && cd playground && npm install && bun build:canary && bun start:canary",
     "dev:docs": "cd documentation && bun start",
     "build:docs:release": "cd documentation && bun run build",
-    "npm:publish": "bun build:release && npm publish"
+    "npm:publish": "bun build:release && npm publish",
+    "npm:publish:beta": "bun build:release && npm publish --tag beta",
+    "npm:version:beta": "npm version prerelease --preid=beta"
   },
   "devDependencies": {
     "@types/bun": "1.1.9"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "url": "git+https://github.com/blackboardsh/electrobun.git"
   },
   "scripts": {
+    "postinstall": "node scripts/postinstall.js",
     "start": "bun src/bun/index.ts",
     "check-zig-version": "vendors/zig/zig version",
     "build:dev": "bun build.ts",

--- a/scripts/package-release.js
+++ b/scripts/package-release.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const tar = require('tar');
+
+const platform = process.platform;
+const arch = process.arch;
+
+// Map Node.js platform/arch to our naming
+const platformMap = {
+  'darwin': 'darwin',
+  'linux': 'linux',
+  'win32': 'win32'
+};
+
+const archMap = {
+  'x64': 'x64',
+  'arm64': 'arm64'
+};
+
+const platformName = platformMap[platform] || platform;
+const archName = archMap[arch] || arch;
+
+console.log(`Packaging Electrobun for ${platformName}-${archName}...`);
+
+// Build in CI mode (skips CLI compilation since that happens in postinstall)
+console.log('Building with CI mode...');
+execSync('bun build.ts --release --ci', { stdio: 'inherit' });
+
+// Create the tarball
+const distPath = path.join(__dirname, '..', 'dist');
+const outputFile = path.join(__dirname, '..', `electrobun-${platformName}-${archName}.tar.gz`);
+
+console.log(`Creating tarball: ${outputFile}`);
+
+// Check if dist exists
+if (!fs.existsSync(distPath)) {
+  console.error('Error: dist directory not found');
+  process.exit(1);
+}
+
+// Create tarball
+tar.c({
+  gzip: true,
+  file: outputFile,
+  cwd: distPath,
+  portable: true
+}, ['.'])
+  .then(() => {
+    console.log(`Successfully created ${outputFile}`);
+    
+    // Print file size
+    const stats = fs.statSync(outputFile);
+    const sizeMB = (stats.size / 1024 / 1024).toFixed(2);
+    console.log(`Tarball size: ${sizeMB} MB`);
+  })
+  .catch(err => {
+    console.error('Error creating tarball:', err);
+    process.exit(1);
+  });

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const { createWriteStream, createReadStream } = require('fs');
+const { pipeline } = require('stream');
+const { promisify } = require('util');
+const tar = require('tar');
+const { execSync } = require('child_process');
+
+const pipelineAsync = promisify(pipeline);
+
+const REPO = 'blackboardsh/electrobun';
+const DIST_DIR = path.join(__dirname, '..', 'dist');
+
+function getPlatform() {
+  const platform = process.platform;
+  const arch = process.arch;
+  
+  // Map Node.js platform/arch to our naming
+  const platformMap = {
+    'darwin': 'darwin',
+    'linux': 'linux',
+    'win32': 'win32'
+  };
+  
+  const archMap = {
+    'x64': 'x64',
+    'arm64': 'arm64'
+  };
+  
+  return {
+    platform: platformMap[platform] || platform,
+    arch: archMap[arch] || arch
+  };
+}
+
+async function downloadFile(url, dest) {
+  return new Promise((resolve, reject) => {
+    https.get(url, { headers: { 'User-Agent': 'electrobun-installer' } }, (response) => {
+      if (response.statusCode === 302 || response.statusCode === 301) {
+        // Follow redirect
+        downloadFile(response.headers.location, dest).then(resolve).catch(reject);
+        return;
+      }
+      
+      if (response.statusCode !== 200) {
+        reject(new Error(`Failed to download: ${response.statusCode}`));
+        return;
+      }
+      
+      const file = createWriteStream(dest);
+      response.pipe(file);
+      
+      file.on('finish', () => {
+        file.close();
+        resolve();
+      });
+      
+      file.on('error', (err) => {
+        fs.unlinkSync(dest);
+        reject(err);
+      });
+    }).on('error', reject);
+  });
+}
+
+async function getLatestRelease() {
+  return new Promise((resolve, reject) => {
+    const options = {
+      hostname: 'api.github.com',
+      path: `/repos/${REPO}/releases/latest`,
+      headers: {
+        'User-Agent': 'electrobun-installer',
+        'Accept': 'application/vnd.github.v3+json'
+      }
+    };
+    
+    https.get(options, (res) => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => {
+        try {
+          const release = JSON.parse(data);
+          resolve(release.tag_name);
+        } catch (err) {
+          reject(err);
+        }
+      });
+    }).on('error', reject);
+  });
+}
+
+async function main() {
+  try {
+    // Skip if running in CI or if binaries already exist
+    if (process.env.CI || process.env.ELECTROBUN_SKIP_DOWNLOAD) {
+      console.log('Skipping binary download');
+      return;
+    }
+    
+    // Check if dist already exists with binaries
+    if (fs.existsSync(path.join(DIST_DIR, 'electrobun'))) {
+      console.log('Binaries already exist, skipping download');
+      return;
+    }
+    
+    const { platform, arch } = getPlatform();
+    const binaryName = `electrobun-${platform}-${arch}`;
+    
+    console.log(`Downloading Electrobun binaries for ${platform}-${arch}...`);
+    
+    // Get the latest release tag
+    const version = process.env.ELECTROBUN_VERSION || await getLatestRelease();
+    
+    const downloadUrl = `https://github.com/${REPO}/releases/download/${version}/${binaryName}.tar.gz`;
+    const tempFile = path.join(__dirname, `${binaryName}.tar.gz`);
+    
+    // Download the tarball
+    console.log(`Downloading from ${downloadUrl}...`);
+    await downloadFile(downloadUrl, tempFile);
+    
+    // Create dist directory if it doesn't exist
+    if (!fs.existsSync(DIST_DIR)) {
+      fs.mkdirSync(DIST_DIR, { recursive: true });
+    }
+    
+    // Extract the tarball
+    console.log('Extracting binaries...');
+    await tar.x({
+      file: tempFile,
+      cwd: DIST_DIR
+    });
+    
+    // Clean up
+    fs.unlinkSync(tempFile);
+    
+    // Make binaries executable on Unix-like systems
+    if (platform !== 'win32') {
+      const binaries = ['electrobun', 'bun', 'launcher', 'extractor', 'bsdiff', 'bspatch', 'process_helper'];
+      binaries.forEach(bin => {
+        const binPath = path.join(DIST_DIR, bin);
+        if (fs.existsSync(binPath)) {
+          fs.chmodSync(binPath, 0o755);
+        }
+      });
+    }
+    
+    console.log('Electrobun binaries installed successfully!');
+    
+  } catch (error) {
+    console.error('Failed to download Electrobun binaries:', error.message);
+    console.error('You can manually download from: https://github.com/blackboardsh/electrobun/releases');
+    // Don't fail the installation
+    process.exit(0);
+  }
+}
+
+if (require.main === module) {
+  main();
+}

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -138,7 +138,7 @@ async function main() {
     
     // Make binaries executable on Unix-like systems
     if (platform !== 'win32') {
-      const binaries = ['electrobun', 'bun', 'launcher', 'extractor', 'bsdiff', 'bspatch', 'process_helper'];
+      const binaries = ['bun', 'launcher', 'extractor', 'bsdiff', 'bspatch', 'process_helper'];
       binaries.forEach(bin => {
         const binPath = path.join(DIST_DIR, bin);
         if (fs.existsSync(binPath)) {
@@ -147,7 +147,25 @@ async function main() {
       });
     }
     
-    console.log('Electrobun binaries installed successfully!');
+    // Build the CLI using the downloaded Bun runtime
+    console.log('Building Electrobun CLI...');
+    const bunPath = path.join(DIST_DIR, platform === 'win32' ? 'bun.exe' : 'bun');
+    const cliSource = path.join(__dirname, '..', 'src', 'cli', 'index.ts');
+    const cliOutput = path.join(DIST_DIR, platform === 'win32' ? 'electrobun.exe' : 'electrobun');
+    
+    try {
+      execSync(`"${bunPath}" build "${cliSource}" --compile --outfile "${cliOutput}"`, { stdio: 'inherit' });
+      
+      // Make CLI executable on Unix
+      if (platform !== 'win32') {
+        fs.chmodSync(cliOutput, 0o755);
+      }
+    } catch (error) {
+      console.error('Failed to build CLI:', error.message);
+      console.error('The Electrobun binaries are installed but the CLI may not work properly.');
+    }
+    
+    console.log('Electrobun installed successfully!');
     
   } catch (error) {
     console.error('Failed to download Electrobun binaries:', error.message);


### PR DESCRIPTION
## This PR

- [ ] build electrobun for macos, windows, and linux (ubuntu) in CI
- [ ] tag pre-built binaries
- [ ] publish the electrobun cli via npm
- [ ] the cli should pull pre-built binaries from github as needed to package apps for your target platform
- [ ] add support for beta releases via npm
- [ ] should be able to build a hello world on mac, windows, and linux