### PR TITLE
fix(cli,updater): resolve Windows tar extraction failures in MSYS/Git Bash

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -2,7 +2,7 @@
 
 import { $ } from "bun";
 import { platform, arch } from "os";
-import { join, dirname } from 'path';
+import { join, dirname, relative } from 'path';
 import { existsSync, readdirSync, renameSync, readFileSync, writeFileSync, mkdirSync } from "fs";
 import { parseArgs } from 'util';
 import process from 'process';
@@ -668,7 +668,8 @@ async function vendorCEF() {
             console.log('Note: Windows tar extraction of bz2 files can be slow, please be patient...');
             
             // Windows tar doesn't support many options, just use basic extraction
-            await $`tar -xjf "${tempPath}" -C vendors/cef_temp`;
+            const relativeTempPath = relative('vendors/cef_temp', tempPath);
+            await $`cd vendors/cef_temp && tar -xjf "${relativeTempPath}"`;
             
             // Check what was extracted
             const tempDir = 'vendors/cef_temp';

--- a/src/bun/core/Updater.ts
+++ b/src/bun/core/Updater.ts
@@ -1,10 +1,10 @@
-import { join, dirname, resolve, basename } from "path";
-import { homedir } from "os";
-import { renameSync, unlinkSync, mkdirSync, rmdirSync, statSync, readdirSync, cpSync } from "fs";
-import { execSync } from "child_process";
-import tar from "tar";
 import { ZstdInit } from "@oneidentity/zstd-js/wasm";
-import { OS as currentOS, ARCH as currentArch } from '../../shared/platform';
+import { execSync } from "child_process";
+import { cpSync, mkdirSync, readdirSync, renameSync, rmdirSync, statSync, unlinkSync } from "fs";
+import { homedir } from "os";
+import { basename, dirname, join, relative, resolve } from "path";
+import tar from "tar";
+import { ARCH as currentArch, OS as currentOS } from '../../shared/platform';
 import { native } from '../proc/native';
 
 // setTimeout(async () => {
@@ -379,9 +379,10 @@ const Updater = {
         if (currentOS === 'win') {
           console.log(`Using Windows native tar.exe to extract ${latestTarPath} to ${extractionDir}...`);
           try {
-            execSync(`tar -xf "${latestTarPath}" -C "${extractionDir}"`, { 
+            const relativeTarPath = relative(extractionDir, latestTarPath);
+            execSync(`tar -xf "${relativeTarPath}"`, { 
               stdio: 'inherit',
-              cwd: extractionDir 
+              cwd: extractionDir,
             });
             console.log('Windows tar.exe extraction completed successfully');
             
@@ -678,3 +679,4 @@ start "" launcher.exe
 };
 
 export { Updater };
+

--- a/src/bun/core/Updater.ts
+++ b/src/bun/core/Updater.ts
@@ -1,10 +1,10 @@
-import { ZstdInit } from "@oneidentity/zstd-js/wasm";
-import { execSync } from "child_process";
-import { cpSync, mkdirSync, readdirSync, renameSync, rmdirSync, statSync, unlinkSync } from "fs";
+import { join, dirname, resolve, basename, relative } from "path";
 import { homedir } from "os";
-import { basename, dirname, join, relative, resolve } from "path";
+import { renameSync, unlinkSync, mkdirSync, rmdirSync, statSync, readdirSync, cpSync } from "fs";
+import { execSync } from "child_process";
 import tar from "tar";
-import { ARCH as currentArch, OS as currentOS } from '../../shared/platform';
+import { ZstdInit } from "@oneidentity/zstd-js/wasm";
+import { OS as currentOS, ARCH as currentArch } from '../../shared/platform';
 import { native } from '../proc/native';
 
 // setTimeout(async () => {
@@ -382,7 +382,7 @@ const Updater = {
             const relativeTarPath = relative(extractionDir, latestTarPath);
             execSync(`tar -xf "${relativeTarPath}"`, { 
               stdio: 'inherit',
-              cwd: extractionDir,
+              cwd: extractionDir
             });
             console.log('Windows tar.exe extraction completed successfully');
             
@@ -679,4 +679,3 @@ start "" launcher.exe
 };
 
 export { Updater };
-

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,4 +1,4 @@
-import { join, dirname, basename } from "path";
+import { join, dirname, basename, relative } from "path";
 import {
   existsSync,
   readFileSync,
@@ -192,7 +192,8 @@ async function ensureCoreDependencies(targetOS?: 'macos' | 'win' | 'linux', targ
     // Use Windows native tar.exe on Windows due to npm tar library issues
     if (OS === 'win') {
       console.log('Using Windows native tar.exe for reliable extraction...');
-      execSync(`tar -xf "${tempFile}" -C "${platformDistPath}"`, { 
+      const relativeTempFile = relative(platformDistPath, tempFile);
+      execSync(`tar -xf "${relativeTempFile}"`, { 
         stdio: 'inherit',
         cwd: platformDistPath 
       });
@@ -333,7 +334,8 @@ async function ensureCEFDependencies(targetOS?: 'macos' | 'win' | 'linux', targe
     // Use Windows native tar.exe on Windows due to npm tar library issues
     if (OS === 'win') {
       console.log('Using Windows native tar.exe for reliable extraction...');
-      execSync(`tar -xf "${tempFile}" -C "${platformDistPath}"`, { 
+      const relativeTempFile = relative(platformDistPath, tempFile);
+      execSync(`tar -xf "${relativeTempFile}"`, { 
         stdio: 'inherit',
         cwd: platformDistPath 
       });


### PR DESCRIPTION
- Use relative paths instead of absolute paths when calling tar on Windows
- Prevents MSYS from interpreting drive letters (C:) as network hostnames
- Fixes "Cannot connect to C: resolve failed" errors
- Updates tar execSync calls in CLI, Updater, and build modules
- Maintains compatibility across all Windows shell environments

Affects:
- src/cli/index.ts: Updated 2 tar extraction locations
- src/bun/core/Updater.ts: Updated 1 tar extraction location
- build.ts: Updated 1 Windows CEF extraction location

[Relevant Discord thread](https://discord.com/channels/1190061229914464397/1405359210304241667).