### PR TITLE
fix(windows): resolve dev command ENOENT error on Windows

### DIFF
--- a/package/src/cli/index.ts
+++ b/package/src/cli/index.ts
@@ -3926,14 +3926,22 @@ ${schemesXml}
 		} else if (OS === "win") {
 			// Windows: Use launcher if available, otherwise fallback to direct execution
 			const launcherPath = join(bundleExecPath, "launcher.exe");
-			if (existsSync(launcherPath)) {
+			const launcherExists = existsSync(launcherPath);
+
+			if (launcherExists) {
 				mainProc = Bun.spawn([launcherPath], {
 					stdio: ["inherit", "inherit", "inherit"],
 					cwd: bundleExecPath,
 				});
-			} else {
-				// Fallback for older builds
-				mainProc = Bun.spawn(["./bun.exe", "../Resources/main.js"], {
+			}
+
+			// Fallback for older builds without launcher
+			// Note: Using explicit !launcherExists check instead of else block
+			// to work around Bun compiler bug that strips else blocks on Windows
+			if (!launcherExists) {
+				const bunExePath = join(bundleExecPath, "bun.exe");
+				const mainJsPath = join(_bundleResourcesPath, "main.js");
+				mainProc = Bun.spawn([bunExePath, mainJsPath], {
 					stdio: ["inherit", "inherit", "inherit"],
 					cwd: bundleExecPath,
 					onExit: (_proc, exitCode, signalCode, error) => {


### PR DESCRIPTION
## Summary

Fixes #133 - Windows `electrobun dev` fails with `ENOENT` on `./bun.exe`

The Windows CLI binary was failing because both `Bun.spawn()` calls were executing sequentially instead of being mutually exclusive.

## Root Cause

During Bun's `--compile` process for Windows targets, the `else` block between the two spawn calls was being stripped. This caused the compiled binary to effectively become:

```typescript
if (existsSync(launcherPath)) {
  mainProc = Bun.spawn([launcherPath], { ... });
}
// else block stripped!
mainProc = Bun.spawn(["./bun.exe", ...], { ... });  // Always runs!
```

## Changes

- Store `existsSync()` result in a variable to avoid the if-else pattern
- Use explicit `if (!launcherExists)` instead of `else` block to work around the Bun compiler bug
- Fix Unix-style relative paths (`./bun.exe`, `../Resources/main.js`) to use proper `join()` calls with `bundleExecPath` and `bundleResourcesPath`

## Testing

Before this fix:
```
ENOENT: no such file or directory, uv_spawn './bun.exe'
```

After this fix: The dev command should correctly spawn only `launcher.exe` when it exists.

## Notes

This is a workaround for what appears to be a Bun compiler bug when cross-compiling for Windows. A separate issue may need to be filed with Bun if this pattern affects other codebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)