### PR TITLE
Add programmatic CDP message passing API for BrowserView

### DIFF
--- a/package/src/bun/core/BrowserView.ts
+++ b/package/src/bun/core/BrowserView.ts
@@ -279,6 +279,29 @@ export class BrowserView<T extends RPCWithTransport = RPCWithTransport> {
 		native.symbols.webviewToggleDevTools(this.ptr);
 	}
 
+	/** Resize and reposition this view within its parent window. */
+	setFrame(frame: { x: number; y: number; width: number; height: number }) {
+		this.frame = frame;
+		native.symbols.resizeWebview(
+			this.ptr,
+			frame.x,
+			frame.y,
+			frame.width,
+			frame.height,
+			toCString("[]"),
+		);
+	}
+
+	/** Remove this view from its parent window and clean up native resources. */
+	remove() {
+		native.symbols.webviewRemove(this.ptr);
+	}
+
+	/** Show or hide this view. */
+	setHidden(hidden: boolean) {
+		native.symbols.webviewSetHidden(this.ptr, hidden);
+	}
+
 	// ── CDP (Chrome DevTools Protocol) message passing ──
 	// Provides programmatic access to CDP without a remote debugging port.
 	// Uses CEF's internal SendDevToolsMessage / AddDevToolsMessageObserver APIs.

--- a/package/src/bun/proc/native.ts
+++ b/package/src/bun/proc/native.ts
@@ -192,7 +192,6 @@ export const native = (() => {
 					FFIType.cstring, // electrobunPreloadScript
 					FFIType.cstring, // customPreloadScript
 					FFIType.bool, // transparent
-					FFIType.bool, // sandbox - when true, bunBridge and internalBridge are not set up
 				],
 				returns: FFIType.ptr,
 			},
@@ -201,6 +200,7 @@ export const native = (() => {
 				args: [
 					FFIType.bool, // startTransparent
 					FFIType.bool, // startPassthrough
+					FFIType.bool, // sandbox
 				],
 				returns: FFIType.void,
 			},
@@ -1006,7 +1006,7 @@ window.__electrobunBunBridge = window.__electrobunBunBridge || window.webkit?.me
 			const customPreload = preload;
 
 			// Pre-set flags before initWebview (workaround for FFI param count limits)
-			native.symbols.setNextWebviewFlags(startTransparent, startPassthrough);
+			native.symbols.setNextWebviewFlags(startTransparent, startPassthrough, sandbox);
 			const webviewPtr = native.symbols.initWebview(
 				id,
 				windowPtr,
@@ -1026,7 +1026,6 @@ window.__electrobunBunBridge = window.__electrobunBunBridge || window.webkit?.me
 				toCString(electrobunPreload),
 				toCString(customPreload || ""),
 				transparent,
-				sandbox, // When true, bunBridge and internalBridge are not set up in native code
 			);
 
 			if (!webviewPtr) {

--- a/package/src/native/linux/nativeWrapper.cpp
+++ b/package/src/native/linux/nativeWrapper.cpp
@@ -5934,7 +5934,8 @@ AbstractView* initCEFWebview(uint32_t webviewId,
 static struct {
     bool startTransparent;
     bool startPassthrough;
-} g_nextWebviewFlags = {false, false};
+    bool sandbox;
+} g_nextWebviewFlags = {false, false, false};
 
 AbstractView* initGTKWebkitWebview(uint32_t webviewId,
                          void* window,
@@ -6001,9 +6002,10 @@ AbstractView* initGTKWebkitWebview(uint32_t webviewId,
     return result;
 }
 
-ELECTROBUN_EXPORT void setNextWebviewFlags(bool startTransparent, bool startPassthrough) {
+ELECTROBUN_EXPORT void setNextWebviewFlags(bool startTransparent, bool startPassthrough, bool sandbox) {
     g_nextWebviewFlags.startTransparent = startTransparent;
     g_nextWebviewFlags.startPassthrough = startPassthrough;
+    g_nextWebviewFlags.sandbox = sandbox;
 }
 
 ELECTROBUN_EXPORT AbstractView* initWebview(uint32_t webviewId,
@@ -6021,12 +6023,12 @@ ELECTROBUN_EXPORT AbstractView* initWebview(uint32_t webviewId,
                          HandlePostMessage internalBridgeHandler,
                          const char* electrobunPreloadScript,
                          const char* customPreloadScript,
-                         bool transparent,
-                         bool sandbox) {
+                         bool transparent) {
     // Read and clear pre-set flags
     bool startTransparent = g_nextWebviewFlags.startTransparent;
     bool startPassthrough = g_nextWebviewFlags.startPassthrough;
-    g_nextWebviewFlags = {false, false};
+    bool sandbox = g_nextWebviewFlags.sandbox;
+    g_nextWebviewFlags = {false, false, false};
 
     // TODO: Implement transparent handling for Linux
 

--- a/package/src/native/linux/nativeWrapper.cpp
+++ b/package/src/native/linux/nativeWrapper.cpp
@@ -6356,6 +6356,32 @@ ELECTROBUN_EXPORT void webviewToggleDevTools(AbstractView* abstractView) {
     }
 }
 
+// ── CDP (Chrome DevTools Protocol) FFI exports ──
+// TODO: Implement for Linux using CEF's SendDevToolsMessage / AddDevToolsMessageObserver APIs.
+// These stubs allow the shared FFI layer to load without link errors.
+
+ELECTROBUN_EXPORT void setDevToolsCDPCallbacks(void* methodResultCallback, void* eventCallback) {
+    // Stub — not yet implemented on Linux
+}
+
+ELECTROBUN_EXPORT bool webviewSendDevToolsMessage(AbstractView* abstractView, const char* jsonMessage, size_t messageLength) {
+    // Stub — not yet implemented on Linux
+    return false;
+}
+
+ELECTROBUN_EXPORT void* webviewAddDevToolsObserver(AbstractView* abstractView) {
+    // Stub — not yet implemented on Linux
+    return nullptr;
+}
+
+ELECTROBUN_EXPORT void webviewRemoveDevToolsObserver(AbstractView* abstractView, void* registration) {
+    // Stub — not yet implemented on Linux
+}
+
+ELECTROBUN_EXPORT void cdpFreeBuffer(void* buffer) {
+    if (buffer) free(buffer);
+}
+
 ELECTROBUN_EXPORT void updatePreloadScriptToWebView(AbstractView* abstractView, const char* scriptIdentifier, const char* scriptContent, bool forMainFrameOnly) {
     if (abstractView) {
         dispatch_sync_main_void([&]() {

--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -5433,11 +5433,13 @@ extern "C" void shutdownApplication() {
 static struct {
     bool startTransparent;
     bool startPassthrough;
-} g_nextWebviewFlags = {false, false};
+    bool sandbox;
+} g_nextWebviewFlags = {false, false, false};
 
-extern "C" void setNextWebviewFlags(bool startTransparent, bool startPassthrough) {
+extern "C" void setNextWebviewFlags(bool startTransparent, bool startPassthrough, bool sandbox) {
     g_nextWebviewFlags.startTransparent = startTransparent;
     g_nextWebviewFlags.startPassthrough = startPassthrough;
+    g_nextWebviewFlags.sandbox = sandbox;
 }
 
 extern "C" AbstractView* initWebview(uint32_t webviewId,
@@ -5455,13 +5457,13 @@ extern "C" AbstractView* initWebview(uint32_t webviewId,
                         HandlePostMessage internalBridgeHandler,
                         const char *electrobunPreloadScript,
                         const char *customPreloadScript,
-                        bool transparent,
-                        bool sandbox ) {
+                        bool transparent ) {
 
     // Read and clear pre-set flags
     bool startTransparent = g_nextWebviewFlags.startTransparent;
     bool startPassthrough = g_nextWebviewFlags.startPassthrough;
-    g_nextWebviewFlags = {false, false};
+    bool sandbox = g_nextWebviewFlags.sandbox;
+    g_nextWebviewFlags = {false, false, false};
 
     // Validate frame values - use defaults if NaN or invalid
     if (isnan(x) || isinf(x)) {

--- a/package/src/native/shared/devtools_cdp.h
+++ b/package/src/native/shared/devtools_cdp.h
@@ -1,0 +1,43 @@
+// devtools_cdp.h - Chrome DevTools Protocol (CDP) message passing
+// Enables programmatic CDP access to CEF webviews without a remote debugging port.
+// Uses CEF's CefBrowserHost::SendDevToolsMessage / AddDevToolsMessageObserver APIs.
+//
+// This is a header-only implementation to match the project convention.
+
+#ifndef ELECTROBUN_DEVTOOLS_CDP_H
+#define ELECTROBUN_DEVTOOLS_CDP_H
+
+#include <cstdint>
+#include <cstddef>
+
+namespace electrobun {
+
+// Callback invoked when a CDP method returns a result.
+// webviewId: the Electrobun webview that owns the browser
+// messageId: the "id" from the CDP request (for matching responses)
+// success: true if the method succeeded
+// result: raw UTF-8 JSON result string (only valid for the duration of the callback)
+// resultSize: byte length of result
+typedef void (*CDPMethodResultCallback)(
+    uint32_t webviewId,
+    int messageId,
+    uint32_t success,
+    const char* result,
+    size_t resultSize
+);
+
+// Callback invoked when a CDP event fires (e.g. "Page.loadEventFired").
+// webviewId: the Electrobun webview that owns the browser
+// method: the CDP event name (e.g. "Network.requestWillBeSent")
+// params: raw UTF-8 JSON params string (only valid for the duration of the callback)
+// paramsSize: byte length of params
+typedef void (*CDPEventCallback)(
+    uint32_t webviewId,
+    const char* method,
+    const char* params,
+    size_t paramsSize
+);
+
+} // namespace electrobun
+
+#endif // ELECTROBUN_DEVTOOLS_CDP_H

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -6983,6 +6983,32 @@ ELECTROBUN_EXPORT void webviewToggleDevTools(AbstractView *abstractView) {
     }
 }
 
+// ── CDP (Chrome DevTools Protocol) FFI exports ──
+// TODO: Implement for Windows using CEF's SendDevToolsMessage / AddDevToolsMessageObserver APIs.
+// These stubs allow the shared FFI layer to load without link errors.
+
+ELECTROBUN_EXPORT void setDevToolsCDPCallbacks(void* methodResultCallback, void* eventCallback) {
+    // Stub — not yet implemented on Windows
+}
+
+ELECTROBUN_EXPORT bool webviewSendDevToolsMessage(AbstractView *abstractView, const char *jsonMessage, size_t messageLength) {
+    // Stub — not yet implemented on Windows
+    return false;
+}
+
+ELECTROBUN_EXPORT void* webviewAddDevToolsObserver(AbstractView *abstractView) {
+    // Stub — not yet implemented on Windows
+    return nullptr;
+}
+
+ELECTROBUN_EXPORT void webviewRemoveDevToolsObserver(AbstractView *abstractView, void *registration) {
+    // Stub — not yet implemented on Windows
+}
+
+ELECTROBUN_EXPORT void cdpFreeBuffer(void *buffer) {
+    if (buffer) free(buffer);
+}
+
 ELECTROBUN_EXPORT NSRect createNSRectWrapper(double x, double y, double width, double height) {
     // Stub implementation
     NSRect rect = {x, y, width, height};

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -6671,11 +6671,13 @@ ELECTROBUN_EXPORT void shutdownApplication() {
 static struct {
     bool startTransparent;
     bool startPassthrough;
-} g_nextWebviewFlags = {false, false};
+    bool sandbox;
+} g_nextWebviewFlags = {false, false, false};
 
-ELECTROBUN_EXPORT void setNextWebviewFlags(bool startTransparent, bool startPassthrough) {
+ELECTROBUN_EXPORT void setNextWebviewFlags(bool startTransparent, bool startPassthrough, bool sandbox) {
     g_nextWebviewFlags.startTransparent = startTransparent;
     g_nextWebviewFlags.startPassthrough = startPassthrough;
+    g_nextWebviewFlags.sandbox = sandbox;
 }
 
 // Clean, elegant initWebview function - Windows version matching Mac pattern
@@ -6694,13 +6696,13 @@ ELECTROBUN_EXPORT AbstractView* initWebview(uint32_t webviewId,
                          HandlePostMessage internalBridgeHandler,
                          const char *electrobunPreloadScript,
                          const char *customPreloadScript,
-                         bool transparent,
-                         bool sandbox) {
+                         bool transparent) {
 
     // Read and clear pre-set flags
     bool startTransparent = g_nextWebviewFlags.startTransparent;
     bool startPassthrough = g_nextWebviewFlags.startPassthrough;
-    g_nextWebviewFlags = {false, false};
+    bool sandbox = g_nextWebviewFlags.sandbox;
+    g_nextWebviewFlags = {false, false, false};
 
     // Serialize webview creation to avoid CEF/WebView2 conflicts
     std::lock_guard<std::mutex> lock(g_webviewCreationMutex);


### PR DESCRIPTION
## Summary

Adds a TypeScript API on `BrowserView` for sending Chrome DevTools Protocol commands and receiving events, using CEF's built-in `SendDevToolsMessage` / `AddDevToolsMessageObserver` APIs. Includes follow-up fixes for ARM64 stability, sandbox safety, and BrowserView layout management.

This works entirely in-process — no remote debugging port required, no network exposure.

## Motivation

Apps embedding webviews often need programmatic access to CDP for tasks like capturing screenshots, evaluating JavaScript, inspecting the DOM, or monitoring network activity. The current approach requires enabling `remote-debugging-port` via chromium flags, which opens a network port that's unsuitable for production.

CEF has supported in-process CDP message passing since CEF 86+ via `CefBrowserHost::SendDevToolsMessage()` and `AddDevToolsMessageObserver()`. This PR exposes those APIs through ElectroBun's FFI layer.

## API

```typescript
const view = mainWindow.webview;

// Attach the CDP observer (auto-attaches on first cdpSend/cdpOn call)
view.cdpAttach();

// Send a CDP command — returns a Promise with the parsed result
const { result } = await view.cdpSend('Runtime.evaluate', {
  expression: 'document.title',
});

// Capture a screenshot
const { data } = await view.cdpSend('Page.captureScreenshot', {
  format: 'png',
});

// Subscribe to CDP events
const unsub = view.cdpOn('Page.loadEventFired', (params) => {
  console.log('Page loaded:', params);
});

// Subscribe to all CDP events
const unsubAll = view.cdpOnAll((method, params) => {
  console.log(method, params);
});

// Clean up
view.cdpDetach();
```

### BrowserView Layout APIs

```typescript
// Resize and reposition a view
view.setFrame({ x: 0, y: 32, width: 800, height: 568 });

// Show/hide without destroying DOM state
view.setHidden(true);

// Remove from parent window (auto-detaches CDP observer)
view.remove();
```

## Commits

### 1. `feat: add programmatic CDP message passing API`

**Native layer (macOS):**
- `ElectrobunDevToolsObserver` — `CefDevToolsMessageObserver` subclass that routes method results and events to Bun via threadsafe callbacks
- Heap-allocated buffer copies for cross-thread safety (CEF UI thread → Bun event loop)
- `cdpFreeBuffer()` for deterministic cleanup from JS after reading
- 5 new extern C exports: `setDevToolsCDPCallbacks`, `webviewSendDevToolsMessage`, `webviewAddDevToolsObserver`, `webviewRemoveDevToolsObserver`, `cdpFreeBuffer`

**FFI layer (`native.ts`):**
- Threadsafe JSCallbacks with `toArrayBuffer` for safe pointer-to-string conversion
- Lazy callback registration (deferred to first `cdpAttach()` call)

**TypeScript API (`BrowserView.ts`):**
- Promise-based request/response matching via message ID
- Event subscriptions (per-method and global)
- Multi-webview support — handlers dispatch by webviewId
- Auto-attach on first use

### 2. `fix: replace JSCallback with poll-based CDP queue to eliminate SIGTRAP crashes`

**Problem:** JSCallback with `threadsafe: true` uses TCC-generated trampolines that lack ARM64 PAC (Pointer Authentication Code) instructions. When CEF calls back from its UI thread on Apple Silicon, this causes intermittent SIGTRAP crashes.

**Solution:** Replace callback-based delivery with thread-safe `std::deque` queues (mutex-protected) polled from JavaScript at 1ms intervals.

- New C++ queue types: `CDPQueuedResult`, `CDPQueuedEvent`
- 5 new FFI exports: `cdpEnableQueue`, `cdpDequeueResult`, `cdpDequeueEvent`, `cdpResultQueueSize`, `cdpEventQueueSize`, `cdpFreeBuffer`
- JavaScript poll loop via `setInterval(cdpPollTick, 1)` drains both queues

### 3. `fix: detach CEF browser on view removal instead of CloseBrowser`

Calling `CloseBrowser()` on view removal caused cleanup order issues. Changed to `webviewRemove()` with proper observer detachment for safe lifecycle management.

### 4. `fix: pass sandbox flag via setNextWebviewFlags to avoid FFI param loss`

Bun FFI has parameter count limits that were silently dropping the `sandbox` boolean. Fixed by using `setNextWebviewFlags()` to pass the flag before `initWebview()`.

### 5. `feat: skip response filter + preload for sandboxed CEF views, add BrowserView layout APIs`

- Skip HTML response filter for sandboxed CEF views (prevents SIGTRAP conflicts with CDP)
- Skip preload script injection for sandboxed views (security: no RPC bridges for untrusted content)
- New BrowserView APIs: `setFrame()`, `setHidden()`, `remove()`

## Files Changed

| File | What |
|------|------|
| `src/native/shared/devtools_cdp.h` | Shared callback typedefs (new) |
| `src/native/macos/nativeWrapper.mm` | Observer class, queue implementation, extern C exports |
| `src/native/win/nativeWrapper.cpp` | Stub exports |
| `src/native/linux/nativeWrapper.cpp` | Stub exports |
| `src/bun/proc/native.ts` | FFI symbols, poll loop, queue drain, `cdpNative` export |
| `src/bun/core/BrowserView.ts` | Public API: `cdpAttach/Detach/Send/On/OnAll`, `setFrame`, `setHidden`, `remove` |

**Windows/Linux:** Stub implementations that allow the FFI layer to load without link errors. The same CEF APIs (`SendDevToolsMessage`, `AddDevToolsMessageObserver`) are available on all platforms — the macOS implementation serves as reference.

## Testing

Tested in a CEF-based ElectroBun app on macOS arm64 (Apple Silicon M-series). Verified:

- `Runtime.evaluate("document.title")` → correct string result
- `DOM.getDocument({depth: 1})` → full DOM tree with node IDs
- `Page.captureScreenshot({format: "png"})` → valid base64 PNG (576KB)
- `Runtime.evaluate("2 + 2")` → `{type: "number", value: 4}`
- Sustained CDP usage over 1000+ calls with no SIGTRAP crashes (poll queue fix verified)
- Sandboxed views: no preload injection, no response filter, CDP still functional
- `setFrame()` / `setHidden()` / `remove()` lifecycle with proper CDP observer cleanup