### PR TITLE
fix: #158 - Add missing linux dependency documentation and better DLOpen error messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,26 @@ Building apps with Electrobun is as easy as updating your package.json dependenc
 
 **This section is for building Electrobun from source locally in order to contribute fixes to it.**
 
+## Linux Runtime Dependencies
+
+Electrobun requires system GTK/WebKit libraries at runtime on Linux.
+
+### Arch Linux
+
+```bash
+sudo pacman -S webkit2gtk-4.1 gtk3 libayatana-appindicator
+```
+
+### Ubuntu/Debian
+
+```bash
+sudo apt install libwebkit2gtk-4.1-0 libgtk-3-0 libayatana-appindicator3-1
+```
+
+If you see errors like `libwebkit2gtk-4.1.so.0: cannot open shared object file` or
+`libayatana-appindicator3.so.1: cannot open shared object file`, install the
+packages above.
+
 ### Prerequisites
 
 **macOS:**


### PR DESCRIPTION
## Summary
Fixes first-run failures on Arch Linux caused by missing GTK/WebKit runtime libraries by:
- Documenting Linux runtime dependencies in `README.md`.
- Printing a clearer launcher error when common Linux libraries are missing.

On Arch Linux, launching the multi-tab browser template failed with missing shared library errors. The launcher error was opaque (`ERR_DLOPEN_FAILED`). These dependencies are hard runtime requirements for the Linux native wrapper and should be documented and surfaced clearly at runtime.

## Changes
- Added a `Linux Runtime Dependencies` section to `README.md` with Arch and Ubuntu/Debian package commands.
- Updated the launcher to detect common missing libraries (`libwebkit2gtk-4.1`, `libgtk-3`, `libayatana-appindicator`) and print install instructions.

## Reproduction 
See #158 

## Related Issue
- #158 