### PR TITLE
fix: replace deprecated rmdirSync with rmSync

### DIFF
--- a/package/src/bun/core/Updater.ts
+++ b/package/src/bun/core/Updater.ts
@@ -4,7 +4,7 @@ import {
 	renameSync,
 	unlinkSync,
 	mkdirSync,
-	rmdirSync,
+	rmSync,
 	statSync,
 	readdirSync,
 } from "fs";
@@ -145,7 +145,7 @@ function cleanupExtractionFolder(
 			try {
 				const s = statSync(fullPath);
 				if (s.isDirectory()) {
-					rmdirSync(fullPath, { recursive: true });
+					rmSync(fullPath, { recursive: true });
 				} else {
 					unlinkSync(fullPath);
 				}
@@ -895,7 +895,7 @@ const Updater = {
 					if (currentOS === "macos") {
 						// Remove existing app before installing the new one
 						if (statSync(runningAppBundlePath, { throwIfNoEntry: false })) {
-							rmdirSync(runningAppBundlePath, { recursive: true });
+							rmSync(runningAppBundlePath, { recursive: true });
 						}
 
 						emitStatus("replacing-app", "Installing new version...");
@@ -920,7 +920,7 @@ const Updater = {
 						
 						// Remove existing app directory if it exists
 						if (statSync(appBundleDir, { throwIfNoEntry: false })) {
-							rmdirSync(appBundleDir, { recursive: true });
+							rmSync(appBundleDir, { recursive: true });
 						}
 
 						// Move new app bundle directory to app location

--- a/package/src/cli/index.ts
+++ b/package/src/cli/index.ts
@@ -5,12 +5,11 @@ import {
 	readFileSync,
 	writeFileSync,
 	cpSync,
-	rmdirSync,
+	rmSync,
 	mkdirSync,
 	createWriteStream,
 	unlinkSync,
 	readdirSync,
-	rmSync,
 	symlinkSync,
 	statSync,
 	copyFileSync,
@@ -1684,7 +1683,7 @@ Categories=Utility;Application;
 
 		// refresh build folder
 		if (existsSync(buildFolder)) {
-			rmdirSync(buildFolder, { recursive: true });
+			rmSync(buildFolder, { recursive: true });
 		}
 		mkdirSync(buildFolder, { recursive: true });
 		// bundle bun to build/bun
@@ -2613,7 +2612,7 @@ Categories=Utility;Application;
 				console.log("✓ Created app.asar");
 
 				// Remove the entire app folder since it's now packed in ASAR
-				rmdirSync(appDirPath, { recursive: true });
+				rmSync(appDirPath, { recursive: true });
 				console.log("✓ Removed app/ folder (now in ASAR)");
 			}
 		}
@@ -2770,7 +2769,7 @@ Categories=Utility;Application;
 			
 			// Remove the app bundle folder after tarring (except on Linux where it might be needed for dev)
 			if (targetOS !== "linux" || buildEnvironment !== "dev") {
-				rmdirSync(appBundleFolderPath, { recursive: true });
+				rmSync(appBundleFolderPath, { recursive: true });
 			}
 
 			// generate bsdiff
@@ -3194,7 +3193,7 @@ Categories=Utility;Application;
 			console.log("creating artifacts folder...");
 			if (existsSync(artifactFolder)) {
 				console.info("deleting artifact folder: ", artifactFolder);
-				rmdirSync(artifactFolder, { recursive: true });
+				rmSync(artifactFolder, { recursive: true });
 			}
 
 			mkdirSync(artifactFolder, { recursive: true });


### PR DESCRIPTION
Hey! 👋
While building sveltekit+electrobun app I got hit by typescript from `svelte-check` with:
```
node_modules/electrobun/dist/api/bun/core/Updater.ts:148:26
Error: Expected 1 arguments, but got 2.
    rmdirSync(fullPath, { recursive: true });
```
    
Happens in 3 spots. So I decided to ship pr to update deprecated `rmdirSync` 
**Refs:** [DEP0147](https://nodejs.org/api/deprecations.html#DEP0147) | [rmSync docs](https://nodejs.org/api/fs.html#fsrmsyncpath-options)

### Fix
Replace `rmdirSync` with `rmSync` - same signature, modern API.
**Files:**
- `package/src/bun/core/Updater.ts` (4 changes)
- `package/src/cli/index.ts` (5 changes)
Your code already guards with `statSync` checks, so no `force: true` needed. Just a function name swap.
Tested in my SvelteKit project, went from 3 errors to 0.