### PR TITLE
fix monorepo-broken version detection and package resolution

### DIFF
--- a/package/src/shared/electrobun-version.ts
+++ b/package/src/shared/electrobun-version.ts
@@ -1,0 +1,2 @@
+import { version } from "../../package.json";
+export const ELECTROBUN_VERSION: string = version;

--- a/package/tsconfig.json
+++ b/package/tsconfig.json
@@ -7,6 +7,7 @@
       "moduleDetection": "force",
       "jsx": "react-jsx",
       "allowJs": true,
+      "resolveJsonModule": true,
 
       // Bundler mode
       "moduleResolution": "bundler",


### PR DESCRIPTION
`ELECTROBUN_DEP_PATH` was hardcoded to `projectRoot/node_modules/electrobun` which doesn't exist in monorepos with hoisted `node_modules`. This caused version detection to fall back to `"latest"` and all binary/cache paths & URLs to break.

- Walk up directory tree to find `electrobun` in `node_modules` (handles `yarn/pnpm/npm/bun` workspaces)
- Derive `.electrobun-cache` path from resolved location instead of hardcoding against `projectRoot`
- Replace runtime `package.json` reads with compile-time version constant