### PR TITLE
fix(build): Replace stuck tar with 7-Zip for Windows CEF extraction

### DIFF
--- a/package/build.ts
+++ b/package/build.ts
@@ -2,7 +2,7 @@
 
 import { $ } from "bun";
 import { platform, arch } from "os";
-import { join, dirname, relative } from "path";
+import { join, dirname, relative, basename } from "path";
 import {
 	existsSync,
 	readdirSync,
@@ -1281,15 +1281,39 @@ async function vendorCEF() {
 			await $`powershell -command "New-Item -ItemType Directory -Path 'vendors/cef_temp' -Force | Out-Null"`;
 			await $`powershell -command "New-Item -ItemType Directory -Path 'vendors/cef' -Force | Out-Null"`;
 
-			// Extract tar.bz2 using Windows built-in tar
-			console.log("Extracting with tar (this may take a few minutes)...");
-			console.log(
-				"Note: Windows tar extraction of bz2 files can be slow, please be patient...",
-			);
+			async function ensure7zip() {
+				try {
+					await $`where 7z`.quiet();
+					return true;
+				} catch {
+					console.log("7-Zip not found, installing for faster extraction...");
+					try {
+						await $`winget install 7zip.7zip --silent --accept-source-agreements --accept-package-agreements`;
+						console.log("7-Zip installed");
+						return true;
+					} catch {
+						console.warn("Could not install 7-Zip, will use tar (slow)");
+						return false;
+					}
+				}
+			}
 
-			// Windows tar doesn't support many options, just use basic extraction
-			const relativeTempPath = relative("vendors/cef_temp", tempPath);
-			await $`cd vendors/cef_temp && tar -xjf "${relativeTempPath}"`;
+			const has7zip = await ensure7zip();
+
+			if (has7zip) {
+				console.log("Extracting with 7-Zip (2-step process)...");
+				// Step 1: Decompress .bz2 to .tar
+				await $`7z x "${tempPath}" -o"vendors/cef_temp" -y`;
+				// Step 2: Extract .tar contents
+				const tarFile = join("vendors/cef_temp", basename(tempPath, ".bz2"));
+				await $`7z x "${tarFile}" -o"vendors/cef_temp" -y`;
+				// Clean up intermediate .tar file
+				await $`powershell -command "Remove-Item '${tarFile}' -Force"`;
+			} else {
+				console.log("Extracting with tar (this will take 10-30 minutes)...");
+				const relativeTempPath = relative("vendors/cef_temp", tempPath);
+				await $`cd vendors/cef_temp && tar -xjf "${relativeTempPath}"`;
+			}
 
 			// Check what was extracted
 			const tempDir = "vendors/cef_temp";


### PR DESCRIPTION

### Issue
Hey, so when building Electrobun on Windows 10 Pro CEF extraction just... froze. tar.exe sat at 0% CPU, 0 progress for 10+ minutes. Had to kill it. No disk activity, just hangs. Basically made Electrobun unbuildable on Windows without manual intervention.

### Solution 
Use 7zip. Check if its installed.
- auto-install via winget if not present, fall back to tar if that fails. 
- Two-step extraction: .bz2 -> .tar -> contents

### Impact
- Before: tar hangs indefinitely, build fails
- After: 7-Zip extracts in 1-2 minutes, reliable
- Fallback: Still tries tar if 7-Zip unavailable


Tested on Windows 10 Pro, happy to hear your thoughts