### PR TITLE
feat: add show option to BrowserWindow for deferred visibility

### DIFF
--- a/package/src/bun/core/BrowserWindow.ts
+++ b/package/src/bun/core/BrowserWindow.ts
@@ -36,6 +36,8 @@ export type WindowOptionsType<T = undefined> = {
 	// Use for untrusted content (remote URLs) to prevent malicious sites from
 	// accessing internal APIs, creating OOPIFs, or communicating with Bun
 	sandbox: boolean;
+	/** Whether to show the window immediately on creation. Default: true */
+	show?: boolean;
 };
 
 const defaultOptions: WindowOptionsType = {
@@ -54,6 +56,7 @@ const defaultOptions: WindowOptionsType = {
 	transparent: false,
 	navigationRules: null,
 	sandbox: false,
+	show: true,
 };
 
 export const BrowserWindowMap: {
@@ -112,7 +115,7 @@ export class BrowserWindow<T extends RPCWithTransport = RPCWithTransport> {
 		this.navigationRules = options.navigationRules || null;
 		this.sandbox = options.sandbox ?? false;
 
-		this.init(options);
+		this.init({ ...options, show: options.show ?? defaultOptions.show });
 	}
 
 	init({
@@ -120,6 +123,7 @@ export class BrowserWindow<T extends RPCWithTransport = RPCWithTransport> {
 		styleMask,
 		titleBarStyle,
 		transparent,
+		show,
 	}: Partial<WindowOptionsType<T>>) {
 		this.ptr = ffi.request.createWindow({
 			id: this.id,
@@ -162,6 +166,7 @@ export class BrowserWindow<T extends RPCWithTransport = RPCWithTransport> {
 			},
 			titleBarStyle: titleBarStyle || "default",
 			transparent: transparent ?? false,
+			show: show ?? true,
 		}) as Pointer;
 
 		BrowserWindowMap[this.id] = this;

--- a/package/src/bun/proc/native.ts
+++ b/package/src/bun/proc/native.ts
@@ -605,6 +605,7 @@ export const ffi = {
 			};
 			titleBarStyle: string;
 			transparent: boolean;
+			show?: boolean;
 		}): FFIType.ptr => {
 			const {
 				id,
@@ -667,7 +668,10 @@ export const ffi = {
 			}
 
 			native.symbols.setWindowTitle(windowPtr, toCString(title));
-			native.symbols.showWindow(windowPtr);
+
+			if (params.show !== false) {
+				native.symbols.showWindow(windowPtr);
+			}
 
 			return windowPtr;
 		},


### PR DESCRIPTION
## Summary

Adds a `show` option to `BrowserWindow` that controls whether the window is displayed immediately on creation. Defaults to `true` (current behavior).

When `show: false` is passed, the window is created but `showWindow()` is skipped. The window can be made visible later by calling `window.show()`.

## Motivation

Electron's `BrowserWindow` supports `show: false`, which is commonly used for:
- **E2E testing**: Playwright/test frameworks can spawn app instances that appear in the dock without stealing focus or flashing windows
- **Splash screens**: Create a window, load content, then show when ready
- **Background windows**: Create windows that start hidden until needed

This is a small, backwards-compatible change — existing code that doesn't pass `show` continues to work identically.

## Changes

- **`BrowserWindow.ts`**: Added `show?: boolean` to `WindowOptionsType`, added `show: true` to default options, passed through constructor → init → createWindow
- **`native.ts`**: Added `show?: boolean` to `createWindow` params, wrapped `showWindow()` in `if (params.show !== false)` guard

## Usage

```typescript
// Window appears immediately (default, unchanged behavior)
const win = new BrowserWindow({ title: "My App", url: "..." });

// Window created but not shown
const hidden = new BrowserWindow({ title: "Hidden", url: "...", show: false });

// Show it later
hidden.show();
```

## Testing

Tested locally on macOS ARM64:
- `new BrowserWindow()` with no `show` option → window appears immediately ✓
- `new BrowserWindow({ show: false })` → window created but not visible ✓
- `window.show()` on hidden window → window becomes visible ✓
- No crashes or errors ✓