### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           echo "Runner OS: $RUNNER_OS"
           df -h /
 
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.8
 
@@ -244,7 +244,7 @@ jobs:
           path: artifacts
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.inputs.tag || github.ref_name }}
           files: |
@@ -283,7 +283,7 @@ jobs:
           node-version: '18'
           registry-url: 'https://registry.npmjs.org'
 
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.8
 


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `oven-sh/setup-bun` | [`v1`](https://github.com/oven-sh/setup-bun/releases/tag/v1) | [`v2`](https://github.com/oven-sh/setup-bun/releases/tag/v2) | [Release](https://github.com/oven-sh/setup-bun/releases/tag/v2) | release.yml |
| `softprops/action-gh-release` | [`v1`](https://github.com/softprops/action-gh-release/releases/tag/v1) | [`v2`](https://github.com/softprops/action-gh-release/releases/tag/v2) | [Release](https://github.com/softprops/action-gh-release/releases/tag/v2) | release.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### ⚠️ Breaking Changes

- **oven-sh/setup-bun** (v1 → v2): Major version upgrade — review the [release notes](https://github.com/oven-sh/setup-bun/releases) for breaking changes
- **softprops/action-gh-release** (v1 → v2): Major version upgrade — review the [release notes](https://github.com/softprops/action-gh-release/releases) for breaking changes

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
