### PR TITLE
fix(windows): unique AppUserModelID for proper taskbar grouping

### DIFF
--- a/package/src/extractor/build.zig
+++ b/package/src/extractor/build.zig
@@ -18,5 +18,17 @@ pub fn build(b: *std.Build) void {
     // Use Console subsystem on all platforms so users can see extraction progress
     // The console window will automatically close when extraction completes
 
+    if (target.result.os.tag == .windows) {
+        exe.addCSourceFile(.{
+            .file = b.path("shortcut_helper.cpp"),
+            .flags = &.{"-std=c++17"},
+        });
+        exe.linkSystemLibrary("ole32");
+        exe.linkSystemLibrary("shell32");
+        exe.linkSystemLibrary("shlwapi");
+        exe.linkSystemLibrary("propsys");
+        exe.linkLibCpp();
+    }
+
     b.installArtifact(exe);
 }

--- a/package/src/extractor/main.zig
+++ b/package/src/extractor/main.zig
@@ -2,6 +2,15 @@ const std = @import("std");
 const builtin = @import("builtin");
 const zstd = std.compress.zstd;
 
+extern "c" fn CreateShortcutWithAppId(
+    shortcut_path: [*:0]const u16,
+    target_path: [*:0]const u16,
+    working_dir: [*:0]const u16,
+    icon_path: [*:0]const u16,
+    app_id: [*:0]const u16,
+    description: [*:0]const u16,
+) callconv(.C) i32;
+
 // const COMPRESSED_APP_BUNDLE_REL_PATH = "/Users/yoav/code/electrobun/example/build/canary/ElectrobunPlayground-0-0-1-canary.app/Contents/Resources/compressed.tar.zst";
 // const COMPRESSED_APP_BUNDLE_REL_PATH = "../Resources/compressed.tar.zst";
 const BUNLE_RESOURCES_REL_PATH = "../Resources/";
@@ -1070,53 +1079,46 @@ fn createDesktopShortcut(allocator: std.mem.Allocator, app_dir: []const u8, meta
     std.debug.print("Note: If the desktop icon opens as text, right-click it and select 'Allow Launching' or 'Trust and Launch'\n", .{});
 }
 
-fn createWindowsShortcutFile(allocator: std.mem.Allocator, shortcut_dir: []const u8, app_name: []const u8, target_path: []const u8, working_dir: []const u8, icon_path: []const u8) !void {
-    // Create a .lnk shortcut using PowerShell
+fn createWindowsShortcutFile(allocator: std.mem.Allocator, shortcut_dir: []const u8, app_name: []const u8, target_path: []const u8, working_dir: []const u8, icon_path: []const u8, app_identifier: []const u8) !void {
     const lnk_name = try std.fmt.allocPrint(allocator, "{s}.lnk", .{app_name});
     defer allocator.free(lnk_name);
 
     const lnk_path = try std.fs.path.join(allocator, &.{ shortcut_dir, lnk_name });
     defer allocator.free(lnk_path);
 
-    // Create PowerShell script to create the shortcut with icon
-    const ps_content = try std.fmt.allocPrint(allocator,
-        \\$WshShell = New-Object -ComObject WScript.Shell
-        \\$Shortcut = $WshShell.CreateShortcut("{s}")
-        \\$Shortcut.TargetPath = "{s}"
-        \\$Shortcut.WorkingDirectory = "{s}"
-        \\$Shortcut.IconLocation = "{s}"
-        \\$Shortcut.WindowStyle = 1
-        \\$Shortcut.Save()
-        \\
-    , .{ lnk_path, target_path, working_dir, icon_path });
-    defer allocator.free(ps_content);
+    const lnk_path_w = try std.unicode.utf8ToUtf16LeWithNull(allocator, lnk_path);
+    defer allocator.free(lnk_path_w);
 
-    // Execute PowerShell command
-    const ps_args = [_][]const u8{
-        "powershell",
-        "-NoProfile",
-        "-NonInteractive",
-        "-WindowStyle",
-        "Hidden",
-        "-Command",
-        ps_content,
-    };
+    const target_path_w = try std.unicode.utf8ToUtf16LeWithNull(allocator, target_path);
+    defer allocator.free(target_path_w);
 
-    var child = std.process.Child.init(&ps_args, allocator);
-    child.stdout_behavior = .Ignore;
-    child.stderr_behavior = .Ignore;
+    const working_dir_w = try std.unicode.utf8ToUtf16LeWithNull(allocator, working_dir);
+    defer allocator.free(working_dir_w);
 
-    _ = child.spawn() catch |err| {
-        std.debug.print("Warning: Could not spawn PowerShell to create shortcut: {}\n", .{err});
+    const icon_path_w = try std.unicode.utf8ToUtf16LeWithNull(allocator, icon_path);
+    defer allocator.free(icon_path_w);
+
+    const app_id_w = try std.unicode.utf8ToUtf16LeWithNull(allocator, app_identifier);
+    defer allocator.free(app_id_w);
+    
+    const description = std.unicode.utf8ToUtf16LeStringLiteral("");
+
+    const hr = CreateShortcutWithAppId(
+        lnk_path_w.ptr,
+        target_path_w.ptr,
+        working_dir_w.ptr,
+        icon_path_w.ptr,
+        app_id_w.ptr,
+        description,
+    );
+
+    if (hr != 0) {
+        std.debug.print("Warning: COM shortcut creation failed with HRESULT: 0x{x}\n", .{hr});
+        std.debug.print("Check %TEMP%\\electrobun-shortcut.log for details\n", .{});
         return;
-    };
+    }
 
-    _ = child.wait() catch |err| {
-        std.debug.print("Warning: PowerShell shortcut creation failed: {}\n", .{err});
-        return;
-    };
-
-    std.debug.print("Created Windows shortcut: {s}\n", .{lnk_path});
+    std.debug.print("Created Windows shortcut with AppUserModelID: {s}\n", .{lnk_path});
 }
 
 fn createWindowsShortcut(allocator: std.mem.Allocator, app_dir: []const u8, metadata: AppMetadata) !void {
@@ -1157,14 +1159,14 @@ fn createWindowsShortcut(allocator: std.mem.Allocator, app_dir: []const u8, meta
     const icon_to_use = target_path;
 
     // Create desktop shortcut
-    try createWindowsShortcutFile(allocator, desktop_dir, metadata.name, target_path, working_dir, icon_to_use);
+    try createWindowsShortcutFile(allocator, desktop_dir, metadata.name, target_path, working_dir, icon_to_use, metadata.identifier);
 
     // Create Start Menu shortcut
     // Make sure Start Menu directory exists
     std.fs.cwd().makePath(start_menu_dir) catch {
         std.debug.print("Warning: Could not create Start Menu directory\n", .{});
     };
-    try createWindowsShortcutFile(allocator, start_menu_dir, metadata.name, target_path, working_dir, icon_to_use);
+    try createWindowsShortcutFile(allocator, start_menu_dir, metadata.name, target_path, working_dir, icon_to_use, metadata.identifier);
 
     std.debug.print("Created Windows shortcuts for: {s}\n", .{metadata.name});
 

--- a/package/src/extractor/shortcut_helper.cpp
+++ b/package/src/extractor/shortcut_helper.cpp
@@ -1,0 +1,148 @@
+#include <windows.h>
+#include <shlobj.h>
+#include <propkey.h>
+#include <propvarutil.h>
+#include <iostream>
+#include <fstream>
+#include <string>
+
+static void log_to_file(const std::string& message) {
+    char temp_path[MAX_PATH];
+    GetTempPathA(MAX_PATH, temp_path);
+    std::string log_path = std::string(temp_path) + "electrobun-shortcut.log";
+    
+    std::ofstream log_file(log_path, std::ios::app);
+    if (log_file.is_open()) {
+        DWORD pid = GetCurrentProcessId();
+        DWORD tid = GetCurrentThreadId();
+        log_file << "[SHORTCUT] PID=" << pid << " TID=" << tid << " " << message << std::endl;
+        log_file.close();
+    }
+}
+
+extern "C" {
+
+__declspec(dllexport) HRESULT CreateShortcutWithAppId(
+    const wchar_t* shortcut_path,
+    const wchar_t* target_path,
+    const wchar_t* working_dir,
+    const wchar_t* icon_path,
+    const wchar_t* app_id,
+    const wchar_t* description
+) {
+    HRESULT hr;
+    
+    log_to_file("CreateShortcutWithAppId called");
+    
+    hr = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
+    if (FAILED(hr) && hr != RPC_E_CHANGED_MODE) {
+        log_to_file("CoInitializeEx failed: 0x" + std::to_string(hr));
+        return hr;
+    }
+    
+    IShellLinkW* pShellLink = NULL;
+    IPropertyStore* pPropertyStore = NULL;
+    IPersistFile* pPersistFile = NULL;
+    
+    hr = CoCreateInstance(
+        CLSID_ShellLink,
+        NULL,
+        CLSCTX_INPROC_SERVER,
+        IID_IShellLinkW,
+        (LPVOID*)&pShellLink
+    );
+    
+    if (FAILED(hr)) {
+        log_to_file("CoCreateInstance(IShellLink) failed: 0x" + std::to_string(hr));
+        CoUninitialize();
+        return hr;
+    }
+    
+    log_to_file("IShellLink created successfully");
+    
+    hr = pShellLink->SetPath(target_path);
+    if (FAILED(hr)) {
+        log_to_file("SetPath failed: 0x" + std::to_string(hr));
+        goto cleanup;
+    }
+    
+    hr = pShellLink->SetWorkingDirectory(working_dir);
+    if (FAILED(hr)) {
+        log_to_file("SetWorkingDirectory failed: 0x" + std::to_string(hr));
+        goto cleanup;
+    }
+    
+    hr = pShellLink->SetIconLocation(icon_path, 0);
+    if (FAILED(hr)) {
+        log_to_file("SetIconLocation failed: 0x" + std::to_string(hr));
+        goto cleanup;
+    }
+    
+    if (description && wcslen(description) > 0) {
+        hr = pShellLink->SetDescription(description);
+        if (FAILED(hr)) {
+            log_to_file("SetDescription failed: 0x" + std::to_string(hr));
+        }
+    }
+    
+    log_to_file("Basic shortcut properties set");
+    
+    hr = pShellLink->QueryInterface(IID_IPropertyStore, (LPVOID*)&pPropertyStore);
+    if (FAILED(hr)) {
+        log_to_file("QueryInterface(IPropertyStore) failed: 0x" + std::to_string(hr));
+        goto cleanup;
+    }
+    
+    log_to_file("IPropertyStore obtained");
+    
+    {
+        PROPVARIANT pv;
+        hr = InitPropVariantFromString(app_id, &pv);
+        if (SUCCEEDED(hr)) {
+            hr = pPropertyStore->SetValue(PKEY_AppUserModel_ID, pv);
+            PropVariantClear(&pv);
+            
+            if (FAILED(hr)) {
+                log_to_file("SetValue(PKEY_AppUserModel_ID) failed: 0x" + std::to_string(hr));
+                goto cleanup;
+            }
+            
+            log_to_file("PKEY_AppUserModel_ID set successfully");
+        } else {
+            log_to_file("InitPropVariantFromString failed: 0x" + std::to_string(hr));
+            goto cleanup;
+        }
+    }
+    
+    hr = pPropertyStore->Commit();
+    if (FAILED(hr)) {
+        log_to_file("IPropertyStore::Commit failed: 0x" + std::to_string(hr));
+        goto cleanup;
+    }
+    
+    log_to_file("Property changes committed");
+    
+    hr = pShellLink->QueryInterface(IID_IPersistFile, (LPVOID*)&pPersistFile);
+    if (FAILED(hr)) {
+        log_to_file("QueryInterface(IPersistFile) failed: 0x" + std::to_string(hr));
+        goto cleanup;
+    }
+    
+    hr = pPersistFile->Save(shortcut_path, TRUE);
+    if (FAILED(hr)) {
+        log_to_file("IPersistFile::Save failed: 0x" + std::to_string(hr));
+        goto cleanup;
+    }
+    
+    log_to_file("Shortcut saved successfully: 0x0");
+    
+cleanup:
+    if (pPersistFile) pPersistFile->Release();
+    if (pPropertyStore) pPropertyStore->Release();
+    if (pShellLink) pShellLink->Release();
+    CoUninitialize();
+    
+    return hr;
+}
+
+}

--- a/package/src/launcher/build.zig
+++ b/package/src/launcher/build.zig
@@ -15,13 +15,5 @@ pub fn build(b: *std.Build) void {
     // Link libc for signal handling on Linux
     exe.linkLibC();
 
-    // For production Windows builds, use GUI subsystem to hide console window
-    // For dev builds (Debug mode), use default console subsystem for CLI interaction
-    const is_windows = target.result.os.tag == .windows;
-    const is_production = optimize != .Debug;
-    if (is_windows and is_production) {
-        exe.subsystem = .Windows;
-    }
-
     b.installArtifact(exe);
 }

--- a/package/src/launcher/main.zig
+++ b/package/src/launcher/main.zig
@@ -16,6 +16,7 @@ const windows_imports = if (builtin.os.tag == .windows) struct {
     const BOOL = win.BOOL;
     const DWORD = win.DWORD;
     const HANDLE = win.HANDLE;
+    const HWND = win.HWND;
     const LPWSTR = win.LPWSTR;
     const LPVOID = win.LPVOID;
 
@@ -63,44 +64,103 @@ const windows_imports = if (builtin.os.tag == .windows) struct {
     extern "kernel32" fn WaitForSingleObject(hHandle: HANDLE, dwMilliseconds: DWORD) callconv(win.WINAPI) DWORD;
     extern "kernel32" fn GetExitCodeProcess(hProcess: HANDLE, lpExitCode: *DWORD) callconv(win.WINAPI) BOOL;
     extern "kernel32" fn CloseHandle(hObject: HANDLE) callconv(win.WINAPI) BOOL;
+    extern "kernel32" fn GetCurrentProcessId() callconv(win.WINAPI) DWORD;
+    extern "kernel32" fn GetCurrentThreadId() callconv(win.WINAPI) DWORD;
+    extern "kernel32" fn GetConsoleWindow() callconv(win.WINAPI) ?HWND;
+    extern "user32" fn ShowWindow(hWnd: HWND, nCmdShow: c_int) callconv(win.WINAPI) BOOL;
 
-    // Console attachment for dev mode
     extern "kernel32" fn AttachConsole(dwProcessId: DWORD) callconv(win.WINAPI) BOOL;
     extern "kernel32" fn FreeConsole() callconv(win.WINAPI) BOOL;
     extern "kernel32" fn GetStdHandle(nStdHandle: DWORD) callconv(win.WINAPI) ?HANDLE;
     extern "kernel32" fn SetStdHandle(nStdHandle: DWORD, hHandle: HANDLE) callconv(win.WINAPI) BOOL;
+    extern "shell32" fn SetCurrentProcessExplicitAppUserModelID(AppID: [*:0]const u16) callconv(win.WINAPI) win.HRESULT;
 
     const ATTACH_PARENT_PROCESS: DWORD = 0xFFFFFFFF;
     const STD_OUTPUT_HANDLE: DWORD = 0xFFFFFFF5; // -11
     const STD_ERROR_HANDLE: DWORD = 0xFFFFFFF4; // -12
     const CREATE_NO_WINDOW: DWORD = 0x08000000;
+    const CREATE_UNICODE_ENVIRONMENT: DWORD = 0x00000400;
     const INFINITE: DWORD = 0xFFFFFFFF;
+    const SW_HIDE: c_int = 0;
+    const SW_SHOW: c_int = 5;
 } else struct {};
 
-// Check if this is a dev build by reading version.json
-fn isDevBuild(allocator: std.mem.Allocator, exe_dir: []const u8) bool {
-    // Build path to version.json: exe_dir/../Resources/version.json
-    const version_path = std.fs.path.join(allocator, &.{ exe_dir, "..", "Resources", "version.json" }) catch return false;
+// Version info from version.json
+// Convert env_map to Windows environment block format (UTF-16LE, double-null-terminated)
+// Based on Zig's std/process.zig createWindowsEnvBlock implementation
+fn createWindowsEnvBlock(allocator: std.mem.Allocator, env_map: *const std.process.EnvMap) ![]u16 {
+    const max_chars_needed = blk: {
+        var max_chars: usize = if (env_map.count() == 0) 2 else 1;
+        var it = env_map.iterator();
+        while (it.next()) |pair| {
+            max_chars += pair.key_ptr.len + pair.value_ptr.len + 2;
+        }
+        break :blk max_chars;
+    };
+
+    const result = try allocator.alloc(u16, max_chars_needed);
+    errdefer allocator.free(result);
+
+    var it = env_map.iterator();
+    var i: usize = 0;
+    while (it.next()) |pair| {
+        i += try std.unicode.utf8ToUtf16Le(result[i..], pair.key_ptr.*);
+        result[i] = '=';
+        i += 1;
+        i += try std.unicode.utf8ToUtf16Le(result[i..], pair.value_ptr.*);
+        result[i] = 0;
+        i += 1;
+    }
+    result[i] = 0;
+    i += 1;
+
+    if (env_map.count() == 0) {
+        result[i] = 0;
+        i += 1;
+    }
+
+    return try allocator.realloc(result, i);
+}
+
+const VersionInfo = struct {
+    identifier: ?[]const u8,
+    channel: ?[]const u8,
+    
+    fn deinit(self: *VersionInfo, allocator: std.mem.Allocator) void {
+        if (self.identifier) |id| allocator.free(id);
+        if (self.channel) |ch| allocator.free(ch);
+    }
+};
+
+// Read version.json once and extract all needed fields (DRY)
+fn readVersionInfo(allocator: std.mem.Allocator, exe_dir: []const u8) ?VersionInfo {
+    const version_path = std.fs.path.join(allocator, &.{ exe_dir, "..", "Resources", "version.json" }) catch return null;
     defer allocator.free(version_path);
 
-    // Read the file
-    const file = std.fs.openFileAbsolute(version_path, .{}) catch return false;
+    const file = std.fs.openFileAbsolute(version_path, .{}) catch return null;
     defer file.close();
 
-    const content = file.readToEndAlloc(allocator, 1024 * 10) catch return false;
+    const content = file.readToEndAlloc(allocator, 1024 * 10) catch return null;
     defer allocator.free(content);
 
-    // Parse JSON and look for "channel":"dev"
-    const parsed = std.json.parseFromSlice(std.json.Value, allocator, content, .{}) catch return false;
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, content, .{}) catch return null;
     defer parsed.deinit();
 
-    if (parsed.value.object.get("channel")) |channel_value| {
-        if (channel_value == .string) {
-            return std.mem.eql(u8, channel_value.string, "dev");
+    var info = VersionInfo{ .identifier = null, .channel = null };
+
+    if (parsed.value.object.get("identifier")) |id_value| {
+        if (id_value == .string) {
+            info.identifier = allocator.dupe(u8, id_value.string) catch null;
         }
     }
 
-    return false;
+    if (parsed.value.object.get("channel")) |ch_value| {
+        if (ch_value == .string) {
+            info.channel = allocator.dupe(u8, ch_value.string) catch null;
+        }
+    }
+
+    return info;
 }
 
 // SIGALRM handler - safety net timeout for hung shutdowns
@@ -142,6 +202,58 @@ pub fn main() !void {
     var exePathBuffer: [1024]u8 = undefined;
     const exe_dir = try std.fs.selfExeDirPath(exePathBuffer[0..]);
 
+    // Read version.json once for all needed fields (DRY)
+    var version_info = readVersionInfo(alloc, exe_dir);
+    defer if (version_info) |*info| info.deinit(alloc);
+
+    // CRITICAL: Set AppUserModelID FIRST, before any console output or window creation.
+    // This ensures Windows taskbar groups launcher.exe and bun.exe correctly.
+    // If set too late, the console window gets its own taskbar identity.
+    if (builtin.os.tag == .windows) {
+        const win = windows_imports;
+        
+        // Use identifier from version.json, fallback to generic ID
+        const identifier = if (version_info) |info| info.identifier orelse "com.electrobun.app" else "com.electrobun.app";
+        
+        const app_id_utf16 = std.unicode.utf8ToUtf16LeWithNull(alloc, identifier) catch {
+            const fallback = std.unicode.utf8ToUtf16LeStringLiteral("com.electrobun.app");
+            _ = win.SetCurrentProcessExplicitAppUserModelID(fallback);
+            return;
+        };
+        defer alloc.free(app_id_utf16);
+        
+        const hr = win.SetCurrentProcessExplicitAppUserModelID(app_id_utf16.ptr);
+        
+        // Hide console window immediately (console windows prevent taskbar grouping)
+        const console_hwnd = win.GetConsoleWindow();
+        const console_hidden = if (console_hwnd) |hwnd| blk: {
+            _ = win.ShowWindow(hwnd, win.SW_HIDE);
+            break :blk true;
+        } else false;
+        
+        // Log to %temp%\electrobun-launcher.log (before any console output)
+        var arena = std.heap.ArenaAllocator.init(alloc);
+        defer arena.deinit();
+        const arena_alloc = arena.allocator();
+        
+        const temp_dir = std.process.getEnvVarOwned(arena_alloc, "TEMP") catch "C:\\Windows\\Temp";
+        defer arena_alloc.free(temp_dir);
+        const log_path = std.fs.path.join(arena_alloc, &.{ temp_dir, "electrobun-launcher.log" }) catch "";
+        if (log_path.len > 0) {
+            const log_file = std.fs.cwd().createFile(log_path, .{ .truncate = false }) catch null;
+            if (log_file) |file| {
+                defer file.close();
+                _ = file.seekFromEnd(0) catch {};
+                const pid = win.GetCurrentProcessId();
+                const tid = win.GetCurrentThreadId();
+                const log_msg = std.fmt.allocPrint(arena_alloc, 
+                    "[LAUNCHER EARLY] PID={d} TID={d} SetCurrentProcessExplicitAppUserModelID(\"{s}\") result: 0x{x} (0x0=success) | Console hidden: {}\n", 
+                    .{pid, tid, identifier, hr, console_hidden}) catch "";
+                _ = file.writeAll(log_msg) catch {};
+            }
+        }
+    }
+
     std.debug.print("Launcher starting on {s}...\n", .{@tagName(builtin.os.tag)});
     std.debug.print("Current directory: {s}\n", .{exe_dir});
 
@@ -180,12 +292,13 @@ pub fn main() !void {
     child_process.cwd = exe_dir;
 
     // Handle platform-specific environment setup
+    // Prepare environment for child process
+    var env_map = try std.process.getEnvMap(arena_alloc);
+    
     if (builtin.os.tag == .linux) {
-        // Check for CEF libraries that need LD_PRELOAD
+        // On Linux, check for CEF and SwiftShader libraries
         const cef_lib_path = try std.fs.path.join(arena_alloc, &.{ exe_dir, "libcef.so" });
         const swiftshader_lib_path = try std.fs.path.join(arena_alloc, &.{ exe_dir, "libvk_swiftshader.so" });
-
-        var env_map = try std.process.getEnvMap(arena_alloc);
 
         // Set LD_LIBRARY_PATH to include current directory
         if (env_map.get("LD_LIBRARY_PATH")) |existing_ld_path| {
@@ -195,7 +308,6 @@ pub fn main() !void {
             try env_map.put("LD_LIBRARY_PATH", exe_dir);
         }
 
-        // Check if CEF libraries exist and set LD_PRELOAD if needed
         const cef_exists = blk: {
             std.fs.accessAbsolute(cef_lib_path, .{}) catch {
                 break :blk false;
@@ -218,21 +330,21 @@ pub fn main() !void {
             try env_map.put("LD_PRELOAD", ld_preload);
             std.debug.print("Setting LD_PRELOAD: {s}\n", .{ld_preload});
         }
-
-        // Set ICU_DATA for external ICU data file (Linux)
-        try env_map.put("ICU_DATA", exe_dir);
-
-        child_process.env_map = &env_map;
-    } else if (builtin.os.tag == .windows) {
-        // On Windows, get environment and set ICU_DATA for external ICU data
-        var env_map = try std.process.getEnvMap(arena_alloc);
-        try env_map.put("ICU_DATA", exe_dir);
-        child_process.env_map = &env_map;
-    } else {
-        // On macOS, get environment and inherit it (uses system ICU)
-        var env_map = try std.process.getEnvMap(arena_alloc);
-        child_process.env_map = &env_map;
     }
+
+    // Set ICU_DATA for external ICU data file (platform-specific)
+    if (builtin.os.tag == .linux or builtin.os.tag == .windows) {
+        try env_map.put("ICU_DATA", exe_dir);
+    }
+
+    // Pass app identifier to bun for unique AppUserModelID
+    if (version_info) |info| {
+        if (info.identifier) |id| {
+            try env_map.put("ELECTROBUN_APP_IDENTIFIER", id);
+        }
+    }
+
+    child_process.env_map = &env_map;
 
     std.debug.print("Spawning: {s} {s}\n", .{ argv[0], if (argv.len > 1) argv[1] else "" });
 
@@ -242,8 +354,14 @@ pub fn main() !void {
         break :blk std.mem.eql(u8, val, "1");
     } else |_| false;
 
-    // Check if this is a dev build by reading version.json, or if console is forced
-    const is_dev_build = force_console or isDevBuild(arena_alloc, exe_dir);
+    // Check if this is a dev build using version_info.channel
+    const is_dev_build = force_console or (if (version_info) |info| blk: {
+        if (info.channel) |ch| {
+            break :blk std.mem.eql(u8, ch, "dev");
+        }
+        break :blk false;
+    } else false);
+    
     if (force_console) {
         std.debug.print("Console mode forced via ELECTROBUN_CONSOLE=1\n", .{});
     } else if (is_dev_build) {
@@ -258,12 +376,31 @@ pub fn main() !void {
         // Windows non-dev build - use CreateProcessW with CREATE_NO_WINDOW
         const win = windows_imports;
 
+        // Note: AppUserModelID already set at start of main() for proper taskbar grouping
+        
         // Build command line (needs to be mutable for CreateProcessW)
         const cmd_line = try std.fmt.allocPrintZ(arena_alloc, "\"{s}\" \"{s}\"", .{ argv[0], argv[1] });
         const cmd_line_w = try std.unicode.utf8ToUtf16LeWithNull(arena_alloc, cmd_line);
-
-        // Convert current directory to UTF-16
         const cwd_w = try std.unicode.utf8ToUtf16LeWithNull(arena_alloc, exe_dir);
+
+        const env_block_w = try createWindowsEnvBlock(arena_alloc, &env_map);
+        defer arena_alloc.free(env_block_w);
+
+        const temp_dir = std.process.getEnvVarOwned(arena_alloc, "TEMP") catch "C:\\Windows\\Temp";
+        defer arena_alloc.free(temp_dir);
+        const log_path = std.fs.path.join(arena_alloc, &.{ temp_dir, "electrobun-launcher.log" }) catch "";
+        if (log_path.len > 0) {
+            const log_file = std.fs.cwd().createFile(log_path, .{ .truncate = false }) catch null;
+            if (log_file) |file| {
+                defer file.close();
+                _ = file.seekFromEnd(0) catch {};
+                const identifier_for_log = if (version_info) |info| info.identifier orelse "com.electrobun.app" else "com.electrobun.app";
+                const log_msg = std.fmt.allocPrint(arena_alloc,
+                    "[LAUNCHER GUI] Passing env block to CreateProcessW with ELECTROBUN_APP_IDENTIFIER=\"{s}\"\n",
+                    .{identifier_for_log}) catch "";
+                _ = file.writeAll(log_msg) catch {};
+            }
+        }
 
         var si: win.STARTUPINFOW = std.mem.zeroes(win.STARTUPINFOW);
         si.cb = @sizeOf(win.STARTUPINFOW);
@@ -275,9 +412,9 @@ pub fn main() !void {
             @constCast(cmd_line_w.ptr),
             null,
             null,
-            0, // Don't inherit handles
-            win.CREATE_NO_WINDOW,
-            null,
+            0,
+            win.CREATE_NO_WINDOW | win.CREATE_UNICODE_ENVIRONMENT,
+            env_block_w.ptr,
             cwd_w.ptr,
             &si,
             &pi,

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -8515,6 +8515,37 @@ ELECTROBUN_EXPORT HWND createWindowWithFrameAndStyleFromWorker(
             classRegistered = true;
         }
 
+        // Set Windows taskbar identity (must be called before any UI is shown)
+        static bool appIdSet = false;
+        if (!appIdSet) {
+            char identifier_from_launcher[256] = {0};
+            DWORD env_result = GetEnvironmentVariableA("ELECTROBUN_APP_IDENTIFIER", identifier_from_launcher, sizeof(identifier_from_launcher));
+            
+            wchar_t app_id_wide[256];
+            if (env_result > 0 && env_result < sizeof(identifier_from_launcher)) {
+                MultiByteToWideChar(CP_UTF8, 0, identifier_from_launcher, -1, app_id_wide, 256);
+            } else {
+                wcscpy_s(app_id_wide, 256, L"com.electrobun.app");
+            }
+            
+            HRESULT hr = SetCurrentProcessExplicitAppUserModelID(app_id_wide);
+            appIdSet = true;
+            
+            char temp_path[MAX_PATH];
+            if (GetEnvironmentVariableA("TEMP", temp_path, MAX_PATH) > 0) {
+                std::string log_path = std::string(temp_path) + "\\electrobun-bun.log";
+                std::ofstream log_file(log_path, std::ios::app);
+                if (log_file.is_open()) {
+                    DWORD pid = GetCurrentProcessId();
+                    DWORD tid = GetCurrentThreadId();
+                    log_file << "[BUN EARLY] PID=" << pid << " TID=" << tid 
+                             << " SetCurrentProcessExplicitAppUserModelID(\"" << identifier_from_launcher << "\") result: 0x" 
+                             << std::hex << hr << std::dec << " (0x0=success)" << std::endl;
+                    log_file.close();
+                }
+            }
+        }
+
         // Create window data structure to store callbacks
         WindowData* data = (WindowData*)malloc(sizeof(WindowData));
         if (!data) return NULL;


### PR DESCRIPTION
### Issue 

Hey, so windows taskbar creates duplicate icons for Electrobun apps:
1. Pin app to taskbar
2. Launch -> 2 separate icons appear (launcher.exe + bun.exe)
3. Pinned icon doesn't group with running process
4. Pinning bun.exe directly fails to launch app
**Root cause:** launcher.exe and bun.exe use different `AppUserModelID` values (or none), so Windows treats them as separate applications.

### Solution
Set unique `AppUserModelID` per app using `app.identifier` from config:
launcher.exe -> reads identifier -> sets AppUserModelID
 ->
passes via env var (ELECTROBUN_APP_IDENTIFIER)
 ->
bun.exe -> reads env var -> sets same AppUserModelID
Shortcuts also include `AppUserModelID` via COM `IPropertyStore` API.

## Changes
### Core Fix
- `src/launcher/main.zig` - Read identifier, set AppUserModelID, pass to bun
- `src/native/win/nativeWrapper.cpp` - Read env var, set AppUserModelID
- `src/extractor/shortcut_helper.cpp` - NEW: COM helper for shortcuts
### Build
- `src/extractor/build.zig` - Link COM libraries
- `src/launcher/build.zig` - Console subsystem (fixes spinning cursor, no more deadlocks/threads during development))
### Bug Fixes
- `src/extractor/main.zig` - Remove spinner thread (Debug deadlock), add progress dots
- `src/launcher/main.zig` - Fix dev console visibility

## Testing
**Environment:** Windows 10 Pro
**Results:**
✅ **Pinning works correctly** - single unified taskbar icon, no duplicates, unique ID (from logs) = each Electrobun app has its own identity
✅ Debug mode no deadlock
✅ Dev console shows correctly in dev mode
✅ No breaking changes (Linux/macOS should be unaffected)


https://github.com/user-attachments/assets/333be9ec-566b-4143-9d3a-bdcaf62cae7c


https://github.com/user-attachments/assets/8a0561e9-81ca-4128-ad68-be1cac385f96

