### PR TITLE
fix(types): extract ContextMenuItemConfig to remove role support from context menus

### DIFF
--- a/package/src/bun/core/ContextMenu.ts
+++ b/package/src/bun/core/ContextMenu.ts
@@ -1,23 +1,20 @@
-// TODO: have a context specific menu that excludes role
-import { ffi, type ApplicationMenuItemConfig } from "../proc/native";
+import { ffi, type ContextMenuItemConfig } from "../proc/native";
 import electrobunEventEmitter from "../events/eventEmitter";
-import { roleLabelMap } from "./menuRoles";
 
 type NonDividerMenuItem = {
 	type?: "normal";
 	label?: string;
 	tooltip?: string;
 	action?: string;
-	role?: string;
 	data?: unknown;
-	submenu?: Array<ApplicationMenuItemConfig>;
+	submenu?: Array<ContextMenuItemConfig>;
 	enabled?: boolean;
 	checked?: boolean;
 	hidden?: boolean;
 	accelerator?: string;
 };
 
-export const showContextMenu = (menu: Array<ApplicationMenuItemConfig>) => {
+export const showContextMenu = (menu: Array<ContextMenuItemConfig>) => {
 	const menuWithDefaults = menuConfigWithDefaults(menu);
 	ffi.request.showContextMenu({
 		menuConfig: JSON.stringify(menuWithDefaults),
@@ -33,8 +30,8 @@ export const on = (
 };
 
 const menuConfigWithDefaults = (
-	menu: Array<ApplicationMenuItemConfig>,
-): Array<ApplicationMenuItemConfig> => {
+	menu: Array<ContextMenuItemConfig>,
+): Array<ContextMenuItemConfig> => {
 	return menu.map((item) => {
 		if (item.type === "divider" || item.type === "separator") {
 			return { type: "divider" } as const;
@@ -47,15 +44,9 @@ const menuConfigWithDefaults = (
 			);
 
 			return {
-				label:
-					menuItem.label ||
-					roleLabelMap[menuItem.role as keyof typeof roleLabelMap] ||
-					"",
+				label: menuItem.label || "",
 				type: menuItem.type || "normal",
-				// application menus can either have an action or a role. not both.
-				...(menuItem.role
-					? { role: menuItem.role }
-					: { action: actionWithDataId }),
+				action: actionWithDataId,
 				// default enabled to true unless explicitly set to false
 				enabled: menuItem.enabled === false ? false : true,
 				checked: Boolean(menuItem.checked),

--- a/package/src/bun/proc/native.ts
+++ b/package/src/bun/proc/native.ts
@@ -1820,8 +1820,8 @@ const webviewEventHandler = (id: number, eventName: string, detail: string) => {
 	const mappedName = eventMap[eventName];
 	const handler = mappedName
 		? (electrobunEventEmitter.events.webview as Record<string, unknown>)[
-				mappedName
-			]
+		mappedName
+		]
 		: undefined;
 
 	if (!handler) {
@@ -2419,40 +2419,34 @@ export const internalRpcHandlers = {
 export type MenuItemConfig =
 	| { type: "divider" | "separator" }
 	| {
-			type: "normal";
-			label: string;
-			tooltip?: string;
-			action?: string;
-			data?: any;
-			submenu?: Array<MenuItemConfig>;
-			enabled?: boolean;
-			checked?: boolean;
-			hidden?: boolean;
-	  };
+		type: "normal";
+		label: string;
+		tooltip?: string;
+		action?: string;
+		data?: any;
+		submenu?: Array<MenuItemConfig>;
+		enabled?: boolean;
+		checked?: boolean;
+		hidden?: boolean;
+	};
 
-export type ApplicationMenuItemConfig =
-	| { type: "divider" | "separator" }
-	| {
-			type?: "normal";
-			label: string;
-			tooltip?: string;
-			action?: string;
-			data?: any;
-			submenu?: Array<ApplicationMenuItemConfig>;
-			enabled?: boolean;
-			checked?: boolean;
-			hidden?: boolean;
-			accelerator?: string;
-	  }
-	| {
-			type?: "normal";
-			label?: string;
-			tooltip?: string;
-			role?: string;
-			data?: any;
-			submenu?: Array<ApplicationMenuItemConfig>;
-			enabled?: boolean;
-			checked?: boolean;
-			hidden?: boolean;
-			accelerator?: string;
-	  };
+export type BaseMenuItemConfig = {
+	type?: "separator" | "divider" | "normal";
+	label?: string;
+	tooltip?: string;
+	action?: string;
+	data?: any;
+	enabled?: boolean;
+	checked?: boolean;
+	hidden?: boolean;
+	accelerator?: string;
+};
+
+export type ApplicationMenuItemConfig = BaseMenuItemConfig & {
+	role?: string;
+	submenu?: Array<ApplicationMenuItemConfig>;
+};
+
+export type ContextMenuItemConfig = BaseMenuItemConfig & {
+	submenu?: Array<ContextMenuItemConfig>;
+};


### PR DESCRIPTION
Resolves a TODO inside `ContextMenu.ts`.

Context Menus should not share the exact same configuration type as Native Application Menus because application menus support the `role` property whereas context menus do not. This PR extracts a shared `BaseMenuItemConfig` and separates the `ApplicationMenuItemConfig` and `ContextMenuItemConfig` to restrict `role` usage to application menus only.

Tested locally via the `kitchen` sink application to ensure context menus still compile and render successfully.