### PR TITLE
fix: no-drag regions inside drag regions

### DIFF
--- a/kitchen/src/playgrounds/draggable/index.html
+++ b/kitchen/src/playgrounds/draggable/index.html
@@ -103,9 +103,16 @@
         <div class="electrobun-webkit-app-region-drag drag-zone">
             Drag the window from here!
         </div>
-        <div class="no-drag">
-            <p>This area is NOT draggable. You can interact with elements normally:</p>
-            <input type="text" placeholder="Try typing here - no dragging!">
+        <div class="electrobun-webkit-app-region-drag no-drag">
+            <p>
+              This area is draggable. The input is not draggable. You can interact
+              with elements normally:
+            </p>
+            <input
+              class="electrobun-webkit-app-region-no-drag"
+              type="text"
+              placeholder="Try typing here - no dragging!"
+            />
         </div>
     </div>
 </body>

--- a/package/src/bun/preload/dragRegions.ts
+++ b/package/src/bun/preload/dragRegions.ts
@@ -8,6 +8,14 @@ function isAppRegionDrag(e: MouseEvent): boolean {
 	const target = e.target as HTMLElement;
 	if (!target || !target.closest) return false;
 
+	// If the target is inside a no-drag region, it should not trigger window move
+  if (
+    target.closest(".electrobun-webkit-app-region-no-drag") ||
+    target.closest('[style*="app-region"][style*="no-drag"]')
+  ) {
+    return false;
+	}
+
 	// Check for inline style with app-region: drag
 	const draggableByStyle = target.closest(
 		'[style*="app-region"][style*="drag"]',


### PR DESCRIPTION
`isAppRegionDrag` now checks for no-drag before drag, so elements with `.electrobun-webkit-app-region-no-drag` or `app-region: no-drag` inline style correctly prevent window dragging.