### PR TITLE
feat: Enable Wayland draggable regions

### DIFF
--- a/package/src/native/linux/nativeWrapper.cpp
+++ b/package/src/native/linux/nativeWrapper.cpp
@@ -6364,16 +6364,6 @@ ELECTROBUN_EXPORT void updatePreloadScriptToWebView(AbstractView* abstractView, 
     }
 }
 
-// Helper: returns true when running under a native Wayland compositor
-static bool isWaylandDisplay() {
-    // GDK_BACKEND=x11 forces X11 even when WAYLAND_DISPLAY is set
-    const char* gdkBackend = getenv("GDK_BACKEND");
-    if (gdkBackend && strstr(gdkBackend, "x11")) {
-        return false;
-    }
-    return getenv("WAYLAND_DISPLAY") != nullptr;
-}
-
 // Forward declaration
 void stopWindowMove();
 


### PR DESCRIPTION
### **What I changed**
I ripped out the manual mouse event handling (gdk_seat_grab, motion listeners, etc.) and replaced it with gtk_window_begin_move_drag.
This is the "correct" way to do it in GTK—it just tells the Window Manager "hey, the user is dragging this window, you handle it."