### PR TITLE
Fix: Windows preload views:// URL not resolved to file content

### DIFF
--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -5813,7 +5813,7 @@ static std::shared_ptr<WebView2View> createWebView2View(uint32_t webviewId,
                                 nullptr);
                             
                             
-                            // Add preload scripts - TEST ADDITION
+                            // Add preload scripts
                             std::string combinedScript;
                             if (!view->electrobunScript.empty()) {
                                 combinedScript += view->electrobunScript;
@@ -5822,7 +5822,17 @@ static std::shared_ptr<WebView2View> createWebView2View(uint32_t webviewId,
                                 if (!combinedScript.empty()) {
                                     combinedScript += "\n";
                                 }
-                                combinedScript += view->customScript;
+                                // Resolve views:// URLs to file content (matching macOS behavior)
+                                if (view->customScript.substr(0, 8) == "views://") {
+                                    std::string fileContent = loadViewsFile(view->customScript.substr(8));
+                                    if (!fileContent.empty()) {
+                                        combinedScript += fileContent;
+                                    } else {
+                                        std::cout << "[WebView2] Could not read custom preload script from: " << view->customScript << std::endl;
+                                    }
+                                } else {
+                                    combinedScript += view->customScript;
+                                }
                             }
 
                             // Add Ctrl+Click detection and navigation rules handler


### PR DESCRIPTION
## Summary

- On Windows, custom preload scripts specified as `views://` URLs (e.g. `views://bridge/rpc-bridge.js`) are concatenated directly into the combined JavaScript preload **as a URL string** instead of being resolved to file content
- The JS parser interprets `views:` as a label and `//bridge/rpc-bridge.js` as a comment, causing `SyntaxError: Unexpected end of input` — this breaks the **entire** combined preload script including Electrobun's own setup code
- macOS correctly resolves `views://` URLs via `readViewsFile()` in `nativeWrapper.mm` — this fix applies the same pattern on Windows using the existing `loadViewsFile()` function

## Root Cause

In `nativeWrapper.cpp` (Windows), around line 5825:

```cpp
// Before (bug): URL string concatenated directly
combinedScript += view->customScript;
// view->customScript == "views://bridge/rpc-bridge.js"
```

The combined script ends with the literal text `views://bridge/rpc-bridge.js` which JS parses as:
- `views:` → label statement
- `//bridge/rpc-bridge.js` → line comment  
- End of input → **SyntaxError** (label requires a following statement)

Since this is a parse-time error, the entire combined preload script (dynamic preload + Electrobun IIFE + custom preload) fails to execute, leaving `window.__electrobun` and all user-defined globals (`window.firebase`, etc.) undefined.

## Fix

```cpp
// After (fix): resolve views:// URL to file content, matching macOS behavior
if (view->customScript.substr(0, 8) == "views://") {
    std::string fileContent = loadViewsFile(view->customScript.substr(8));
    if (!fileContent.empty()) {
        combinedScript += fileContent;
    }
} else {
    combinedScript += view->customScript;
}
```

## Test plan

- [ ] Build an Electrobun app with a custom preload using `views://` URL on Windows
- [ ] Verify the preload script executes correctly (e.g. `window.__electrobun` is defined)
- [ ] Verify macOS behavior is unchanged

Fixes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)