### PR TITLE
fix: copy jsonString before dispatch_async in setApplicationMenu and …

### DIFF
--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -6486,10 +6486,13 @@ extern "C" void removeTray(NSStatusItem *statusItem) {
 
 extern "C" void setApplicationMenu(const char *jsonString, ZigStatusItemHandler zigTrayItemHandler) {
     NSLog(@"Setting application menu from JSON in objc");
+    // Copy the string before dispatch_async since the JS-side buffer may be GC'd
+    char *jsonCopy = strdup(jsonString);
     dispatch_async(dispatch_get_main_queue(), ^{
-        NSData *jsonData = [NSData dataWithBytes:jsonString length:strlen(jsonString)];
+        NSData *jsonData = [NSData dataWithBytes:jsonCopy length:strlen(jsonCopy)];
         NSError *error;
         NSArray *menuArray = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error];
+        free(jsonCopy);
         if (error) {
             NSLog(@"Failed to parse JSON: %@", error);
             return;
@@ -6504,10 +6507,13 @@ extern "C" void setApplicationMenu(const char *jsonString, ZigStatusItemHandler 
 }
 
 extern "C" void showContextMenu(const char *jsonString, ZigStatusItemHandler contextMenuHandler) {
+    // Copy the string before dispatch_async since the JS-side buffer may be GC'd
+    char *jsonCopy = strdup(jsonString);
     dispatch_async(dispatch_get_main_queue(), ^{
-        NSData *jsonData = [NSData dataWithBytes:jsonString length:strlen(jsonString)];
+        NSData *jsonData = [NSData dataWithBytes:jsonCopy length:strlen(jsonCopy)];
         NSError *error;
         NSArray *menuArray = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error];
+        free(jsonCopy);
         if (error) {
             NSLog(@"Failed to parse JSON: %@", error);
             return;


### PR DESCRIPTION
…showContextMenu

The JS-side Buffer backing the jsonString pointer can be garbage collected before the dispatch_async block executes on the main thread, causing the menu JSON to be empty/corrupt and silently failing to create the menu.

This fixes keyboard shortcuts (Cmd+C/V/X/Z/A) not working because the Edit menu was never actually created.

Apply the same strdup() pattern already used in setTrayMenuFromJSON.

Fixes #160