### PR TITLE
fix: RPC memory leak in requestListeners and requestTimeouts

### DIFF
--- a/package/src/shared/rpc.ts
+++ b/package/src/shared/rpc.ts
@@ -272,6 +272,7 @@ export function createRPC<
 					requestId,
 					setTimeout(() => {
 						requestTimeouts.delete(requestId);
+						requestListeners.delete(requestId);
 						reject(new Error("RPC request timed out."));
 					}, maxRequestTime),
 				);
@@ -411,8 +412,10 @@ export function createRPC<
 		if (message.type === "response") {
 			const timeout = requestTimeouts.get(message.id);
 			if (timeout != null) clearTimeout(timeout);
+			requestTimeouts.delete(message.id);
 			const { resolve, reject } =
 				requestListeners.get(message.id) ?? {};
+			requestListeners.delete(message.id);
 			if (!message.success) reject?.(new Error(message.error));
 			else resolve?.(message.payload);
 			return;


### PR DESCRIPTION
## Summary
- **requestListeners** entries were never deleted when a response arrived or a request timed out
- **requestTimeouts** entries were never deleted when a response arrived
- Both maps grew unboundedly over the lifetime of the process, leaking memory on every RPC call

## Changes
- Delete `requestListeners` entry in the timeout handler (prevents leak when requests time out)
- Delete `requestTimeouts` and `requestListeners` entries in the response handler (prevents leak on every successful/failed response)