### PR TITLE
feat: add executeJavascript to webview tags

### DIFF
--- a/package/src/browser/webviewtag.ts
+++ b/package/src/browser/webviewtag.ts
@@ -73,6 +73,9 @@ interface WebviewTagElement extends HTMLElement {
 	openDevTools(): void;
 	closeDevTools(): void;
 	toggleDevTools(): void;
+
+	// JavaScript execution
+	executeJavascript(js: string): void;
 }
 
 // Augment global types so querySelector('electrobun-webview') returns WebviewTagElement

--- a/package/src/bun/preload/webviewTag.ts
+++ b/package/src/bun/preload/webviewTag.ts
@@ -324,6 +324,12 @@ export class ElectrobunWebviewTag extends HTMLElement {
 			send("webviewTagToggleDevTools", { id: this.webviewId });
 	}
 
+	// JavaScript execution
+	executeJavascript(js: string) {
+		if (this.webviewId === null) return;
+		send("webviewTagExecuteJavascript", { id: this.webviewId, js });
+	}
+
 	// Event handling
 	on(event: WebviewEventType, listener: (event: CustomEvent) => void) {
 		if (!this._eventListeners[event]) this._eventListeners[event] = [];

--- a/package/src/bun/proc/native.ts
+++ b/package/src/bun/proc/native.ts
@@ -2816,6 +2816,19 @@ export const internalRpcHandlers = {
 			}
 			native.symbols.webviewToggleDevTools(webview.ptr);
 		},
+		webviewTagExecuteJavascript: (params: { id: number; js: string }) => {
+			const webview = BrowserView.getById(params.id);
+			if (!webview || !webview.ptr) {
+				console.error(
+					`webviewTagExecuteJavascript: BrowserView not found or has no ptr for id ${params.id}`,
+				);
+				return;
+			}
+			native.symbols.evaluateJavaScriptWithNoCompletion(
+				webview.ptr,
+				toCString(params.js),
+			);
+		},
 		webviewEvent: (params: unknown) => {
 			console.log("-----------------+webviewEvent", params);
 		},


### PR DESCRIPTION
Add the ability to execute JavaScript in webview tags from the host page. This enables host applications to programmatically interact with embedded webviews without requiring the user to focus the webview first.

Changes:
- Add executeJavascript() method to ElectrobunWebviewTag custom element
- Add webviewTagExecuteJavascript handler in native.ts
- Add type definition to WebviewTagElement interface

Use case: A host application can now trigger scripts in embedded webviews, for example to capture page context (errors, selected text, etc.) when the user clicks a button in the host UI.