### PR TITLE
Fix/macos wkwebview evaluate js threading

### DIFF
--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -2569,24 +2569,16 @@ runOpenPanelWithParameters:(WKOpenPanelParameters *)parameters
     }
 
     - (void)evaluateJavaScriptWithNoCompletion:(const char*)jsString {
-        WKContentWorld *isolatedWorld = [WKContentWorld pageWorld];
+        // Copy the string before dispatch_async since the JS-side buffer may be GC'd
         NSString *code = (jsString ? [NSString stringWithUTF8String:jsString] : @"");
-        [self.webView evaluateJavaScript:code
-                                inFrame:nil
-                        inContentWorld:isolatedWorld
-                    completionHandler:nil];
-
-        // DEBUG
-        // [self.webView evaluateJavaScript:code
-        //                   inFrame:nil
-        //           inContentWorld:isolatedWorld
-        //       completionHandler:^(id result, NSError *error) {
-        //     if (error) {
-        //         NSLog(@"JavaScript evaluation error: %@", error);
-        //     } else {
-        //         NSLog(@"JavaScript evaluation result: %@", result);
-        //     }
-        // }];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (!self.webView) return;
+            WKContentWorld *isolatedWorld = [WKContentWorld pageWorld];
+            [self.webView evaluateJavaScript:code
+                                    inFrame:nil
+                            inContentWorld:isolatedWorld
+                        completionHandler:nil];
+        });
     }
 
     - (void)callAsyncJavascript:(const char*)messageId jsString:(const char*)jsString webviewId:(uint32_t)webviewId hostWebviewId:(uint32_t)hostWebviewId completionHandler:(callAsyncJavascriptCompletionHandler)completionHandler {


### PR DESCRIPTION
`evaluateJavaScriptWithNoCompletion` was calling `[WKWebView evaluateJavaScript:]` directly from the Bun Worker thread instead of dispatching to the main queue. WKWebView's `evaluateJavaScript` triggers WebKit internal process management (`WebProcessPool`, `WebsiteDataStore`) that is not thread-safe. When the Worker thread races with the main thread's WebKit initialization, this causes a PAC (Pointer Authentication Code) trap in `WebProcessPool::pageEndUsingWebsiteDataStore`, crashing the app with SIGTRAP (signal 5). Non-deterministic but reliably reproducible on second app launch when macOS caches are warm.

Fix: copy the JS string into an `NSString` before `dispatch_async` (same GC-safety pattern as `setApplicationMenu` from #160), then dispatch the `evaluateJavaScript` call to the main queue. Also guard against nil `webView` during teardown.