### PR TITLE
Feat/webview page zoom

### DIFF
--- a/package/src/bun/core/BrowserView.ts
+++ b/package/src/bun/core/BrowserView.ts
@@ -279,6 +279,22 @@ export class BrowserView<T extends RPCWithTransport = RPCWithTransport> {
 		native.symbols.webviewToggleDevTools(this.ptr);
 	}
 
+	/**
+	 * Set the page zoom level (WebKit only, similar to browser zoom).
+	 * @param zoomLevel - The zoom level (1.0 = 100%, 1.5 = 150%, etc.)
+	 */
+	setPageZoom(zoomLevel: number) {
+		native.symbols.webviewSetPageZoom(this.ptr, zoomLevel);
+	}
+
+	/**
+	 * Get the current page zoom level.
+	 * @returns The current zoom level (1.0 = 100%)
+	 */
+	getPageZoom(): number {
+		return native.symbols.webviewGetPageZoom(this.ptr) as number;
+	}
+
 	// todo (yoav): move this to a class that also has off, append, prepend, etc.
 	// name should only allow browserView events
 	// Note: normalize event names to willNavigate instead of ['will-navigate'] to save

--- a/package/src/bun/core/BrowserWindow.ts
+++ b/package/src/bun/core/BrowserWindow.ts
@@ -330,6 +330,22 @@ export class BrowserWindow<T extends RPCWithTransport = RPCWithTransport> {
 		return { width: frame.width, height: frame.height };
 	}
 
+	/**
+	 * Set the page zoom level for the window's webview (WebKit only).
+	 * @param zoomLevel - The zoom level (1.0 = 100%, 1.5 = 150%, etc.)
+	 */
+	setPageZoom(zoomLevel: number) {
+		this.webview?.setPageZoom(zoomLevel);
+	}
+
+	/**
+	 * Get the current page zoom level for the window's webview.
+	 * @returns The current zoom level (1.0 = 100%)
+	 */
+	getPageZoom(): number {
+		return this.webview?.getPageZoom() ?? 1.0;
+	}
+
 	// todo (yoav): move this to a class that also has off, append, prepend, etc.
 	// name should only allow browserWindow events
 	on(name: string, handler: (event: unknown) => void) {

--- a/package/src/bun/proc/native.ts
+++ b/package/src/bun/proc/native.ts
@@ -338,6 +338,14 @@ export const native = (() => {
 				args: [FFIType.ptr],
 				returns: FFIType.void,
 			},
+			webviewSetPageZoom: {
+				args: [FFIType.ptr, FFIType.f64],
+				returns: FFIType.void,
+			},
+			webviewGetPageZoom: {
+				args: [FFIType.ptr],
+				returns: FFIType.f64,
+			},
 			wgpuViewSetFrame: {
 				args: [
 					FFIType.ptr,

--- a/package/src/native/linux/nativeWrapper.cpp
+++ b/package/src/native/linux/nativeWrapper.cpp
@@ -7893,6 +7893,16 @@ ELECTROBUN_EXPORT void webviewToggleDevTools(AbstractView* abstractView) {
     }
 }
 
+ELECTROBUN_EXPORT void webviewSetPageZoom(AbstractView* abstractView, double zoomLevel) {
+    // pageZoom is WebKit-specific, not available on Linux CEF
+    // TODO: implement CEF zoom if needed
+}
+
+ELECTROBUN_EXPORT double webviewGetPageZoom(AbstractView* abstractView) {
+    // pageZoom is WebKit-specific, not available on Linux CEF
+    return 1.0;
+}
+
 ELECTROBUN_EXPORT void updatePreloadScriptToWebView(AbstractView* abstractView, const char* scriptIdentifier, const char* scriptContent, bool forMainFrameOnly) {
     if (abstractView) {
         dispatch_sync_main_void([&]() {

--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -6941,6 +6941,37 @@ extern "C" void webviewToggleDevTools(AbstractView *abstractView) {
     });
 }
 
+extern "C" void webviewSetPageZoom(AbstractView *abstractView, double zoomLevel) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if ([abstractView isKindOfClass:[WKWebViewImpl class]]) {
+            WKWebViewImpl *wkImpl = (WKWebViewImpl *)abstractView;
+            if (wkImpl.webView) {
+                wkImpl.webView.pageZoom = zoomLevel;
+                [wkImpl.webView setNeedsDisplay:YES];
+                [wkImpl.webView setNeedsLayout:YES];
+            }
+        }
+    });
+}
+
+extern "C" double webviewGetPageZoom(AbstractView *abstractView) {
+    __block double zoomLevel = 1.0;
+    if ([abstractView isKindOfClass:[WKWebViewImpl class]]) {
+        WKWebViewImpl *wkImpl = (WKWebViewImpl *)abstractView;
+        if (wkImpl.webView) {
+            if ([NSThread isMainThread]) {
+                zoomLevel = wkImpl.webView.pageZoom;
+            } else {
+                dispatch_sync(dispatch_get_main_queue(), ^{
+                    zoomLevel = wkImpl.webView.pageZoom;
+                });
+            }
+        }
+    }
+    return zoomLevel;
+}
+
+
 extern "C" NSRect createNSRectWrapper(double x, double y, double width, double height) {
     return NSMakeRect(x, y, width, height);
 }
@@ -7795,7 +7826,6 @@ extern "C" void removeTray(NSStatusItem *statusItem) {
 }
 
 extern "C" void setApplicationMenu(const char *jsonString, ZigStatusItemHandler zigTrayItemHandler) {
-    NSLog(@"Setting application menu from JSON in objc");
     // Copy the string before dispatch_async since the JS-side buffer may be GC'd
     char *jsonCopy = strdup(jsonString);
     dispatch_async(dispatch_get_main_queue(), ^{

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -8436,6 +8436,16 @@ ELECTROBUN_EXPORT void webviewToggleDevTools(AbstractView *abstractView) {
     }
 }
 
+ELECTROBUN_EXPORT void webviewSetPageZoom(AbstractView *abstractView, double zoomLevel) {
+    // pageZoom is WebKit-specific, not available on Windows
+    // TODO: implement WebView2 zoom if needed
+}
+
+ELECTROBUN_EXPORT double webviewGetPageZoom(AbstractView *abstractView) {
+    // pageZoom is WebKit-specific, not available on Windows
+    return 1.0;
+}
+
 ELECTROBUN_EXPORT NSRect createNSRectWrapper(double x, double y, double width, double height) {
     // Stub implementation
     NSRect rect = {x, y, width, height};


### PR DESCRIPTION
Adds programmatic page zoom for WKWebView webviews, equivalent to browser Cmd+/Cmd-/Cmd+0 zoom.

## API

```
// Set zoom level (1.0 = 100%, 1.5 = 150%, etc.)
browserWindow.setPageZoom(1.5);
browserView.setPageZoom(1.5);

// Read current zoom level
const level = browserWindow.getPageZoom();
```

## Implementation notes

Uses WKWebView.pageZoom which provides true browser-style zoom — content re-layouts to honor window constraints and mouse coordinates remain accurate (unlike CSS zoom or magnification which either break hit-testing or
don't trigger re-layout).

Key finding: WKWebView accepts pageZoom values but doesn't automatically invalidate its display. The fix is to call setNeedsDisplay:YES and setNeedsLayout:YES after setting the property.

Changes

- BrowserView / BrowserWindow: new setPageZoom(level) / getPageZoom() methods
- native.ts: FFI bindings
- nativeWrapper.mm: macOS implementation with display refresh fix
- nativeWrapper.cpp (linux/win): stubs for cross-platform compat