### PR TITLE
fix: include .gitignore in init templates

### DIFF
--- a/package/build.ts
+++ b/package/build.ts
@@ -2197,7 +2197,7 @@ async function generateTemplateEmbeddings() {
 					entry.name === "dist" ||
 					entry.name === ".next" ||
 					entry.name === ".DS_Store" ||
-					entry.name.startsWith(".") ||
+					(entry.name.startsWith(".") && entry.name !== ".gitignore") ||
 					entry.name === "package-lock.json" ||
 					entry.name === "bun.lock" ||
 					entry.name === "bun.lockb" ||

--- a/templates/angular/.gitignore
+++ b/templates/angular/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+build/
+dist/
+artifacts/
+*.tsbuildinfo

--- a/templates/bunny/.gitignore
+++ b/templates/bunny/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+build/
+dist/
+artifacts/
+*.tsbuildinfo

--- a/templates/hello-world/.gitignore
+++ b/templates/hello-world/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+build/
+dist/
+artifacts/
+*.tsbuildinfo

--- a/templates/multi-window/.gitignore
+++ b/templates/multi-window/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+build/
+dist/
+artifacts/
+*.tsbuildinfo

--- a/templates/multitab-browser/.gitignore
+++ b/templates/multitab-browser/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+build/
+dist/
+artifacts/
+*.tsbuildinfo

--- a/templates/notes-app/.gitignore
+++ b/templates/notes-app/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+build/
+dist/
+artifacts/
+*.tsbuildinfo

--- a/templates/photo-booth/.gitignore
+++ b/templates/photo-booth/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+build/
+dist/
+artifacts/
+*.tsbuildinfo

--- a/templates/react-tailwind-vite/.gitignore
+++ b/templates/react-tailwind-vite/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+build/
+dist/
+artifacts/
+*.tsbuildinfo

--- a/templates/solid/.gitignore
+++ b/templates/solid/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+build/
+dist/
+artifacts/
+*.tsbuildinfo

--- a/templates/sqlite-crud/.gitignore
+++ b/templates/sqlite-crud/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+build/
+dist/
+artifacts/
+*.tsbuildinfo

--- a/templates/svelte/.gitignore
+++ b/templates/svelte/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+build/
+dist/
+artifacts/
+*.tsbuildinfo

--- a/templates/tailwind-vanilla/.gitignore
+++ b/templates/tailwind-vanilla/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+build/
+dist/
+artifacts/
+*.tsbuildinfo

--- a/templates/tray-app/.gitignore
+++ b/templates/tray-app/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+build/
+dist/
+artifacts/
+*.tsbuildinfo

--- a/templates/vanilla-vite/.gitignore
+++ b/templates/vanilla-vite/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+build/
+dist/
+artifacts/
+*.tsbuildinfo

--- a/templates/vue/.gitignore
+++ b/templates/vue/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+build/
+dist/
+artifacts/
+*.tsbuildinfo

--- a/templates/wgpu-babylon/.gitignore
+++ b/templates/wgpu-babylon/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+build/
+dist/
+artifacts/
+*.tsbuildinfo

--- a/templates/wgpu-mlp/.gitignore
+++ b/templates/wgpu-mlp/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+build/
+dist/
+artifacts/
+*.tsbuildinfo

--- a/templates/wgpu-threejs/.gitignore
+++ b/templates/wgpu-threejs/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+build/
+dist/
+artifacts/
+*.tsbuildinfo

--- a/templates/wgpu/.gitignore
+++ b/templates/wgpu/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+build/
+dist/
+artifacts/
+*.tsbuildinfo


### PR DESCRIPTION
## Summary
- allow `.gitignore` through the template embedding step instead of dropping all dotfiles
- add a basic `.gitignore` to each shipped init template

## Testing
- verified all 19 templates now include `.gitignore`
- `git diff --check`
- did not run a full CLI rebuild in this branch

Closes #162