### PR TITLE
fix: use direct child paths for CEF partitions

### DIFF
--- a/package/src/native/linux/nativeWrapper.cpp
+++ b/package/src/native/linux/nativeWrapper.cpp
@@ -3587,7 +3587,7 @@ CefRefPtr<CefRequestContext> CreateRequestContextForPartition(const char* partit
             // Build cache path with identifier/channel structure (consistent with CLI and updater)
             char* home = getenv("HOME");
             std::string basePath = home ? std::string(home) + "/.cache" : "/tmp";
-            std::string cachePath = buildPartitionPath(basePath, g_electrobunIdentifier, g_electrobunChannel, "CEF", partitionName);
+            std::string cachePath = buildCEFPartitionPath(basePath, g_electrobunIdentifier, g_electrobunChannel, "CEF", partitionName);
 
             // Create directory
             g_mkdir_with_parents(cachePath.c_str(), 0755);

--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -5777,7 +5777,7 @@ CefRefPtr<CefRequestContext> CreateRequestContextForPartition(const char* partit
       NSString* appSupportPath = [NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES) firstObject];
 
       // Build path with identifier/channel structure to match root_cache_path logic
-      std::string cachePathStr = buildPartitionPath(
+      std::string cachePathStr = buildCEFPartitionPath(
           [appSupportPath UTF8String],
           g_electrobunIdentifier,
           g_electrobunChannel,

--- a/package/src/native/shared/app_paths.h
+++ b/package/src/native/shared/app_paths.h
@@ -68,6 +68,34 @@ inline std::string buildPartitionPath(
     return base;
 }
 
+/**
+ * Build a CEF partition-specific path as a direct child of the renderer root.
+ *
+ * CEF requires persistent profile directories to live directly under
+ * root_cache_path rather than under a nested Partitions/ directory.
+ *
+ * @param basePath The base application support/data path
+ * @param identifier The app identifier
+ * @param channel The release channel
+ * @param renderer The renderer type (typically "CEF")
+ * @param partitionName The partition name
+ * @param pathSeparator The path separator to use
+ * @return The full path: basePath/identifier/channel/renderer/partitionName
+ */
+inline std::string buildCEFPartitionPath(
+    const std::string& basePath,
+    const std::string& identifier,
+    const std::string& channel,
+    const std::string& renderer,
+    const std::string& partitionName,
+    char pathSeparator = '/'
+) {
+    std::string base = buildAppDataPath(basePath, identifier, channel, renderer, pathSeparator);
+    base += pathSeparator;
+    base += partitionName;
+    return base;
+}
+
 } // namespace electrobun
 
 #endif // ELECTROBUN_APP_PATHS_H

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -6607,8 +6607,8 @@ CefRefPtr<CefRequestContext> CreateRequestContextForPartition(const char* partit
                 settings.persist_session_cookies = false;
             } else {
                 // Build path with identifier/channel structure (consistent with CLI and updater)
-                // Structure: %LOCALAPPDATA%\{identifier}\{channel}\CEF\Partitions\{partitionName}
-                std::string cachePath = buildPartitionPath(localAppData, g_electrobunIdentifier, g_electrobunChannel, "CEF", partitionName, '\\');
+                // Structure: %LOCALAPPDATA%\{identifier}\{channel}\CEF\{partitionName}
+                std::string cachePath = buildCEFPartitionPath(localAppData, g_electrobunIdentifier, g_electrobunChannel, "CEF", partitionName, '\\');
 
                 // Create directory if it doesn't exist
                 std::wstring wideCachePath(cachePath.begin(), cachePath.end());


### PR DESCRIPTION
## Summary
- add a CEF-specific partition path helper that places persistent profile directories directly under the renderer root cache path
- switch the macOS, Linux, and Windows CEF request-context callsites to use that helper

## Testing
- `git diff --check`
- did not run native platform repros in this environment

Closes #278