### PR TITLE
fix(macos): use performWindowDragWithEvent: for native window dragging

### DIFF
--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -96,12 +96,9 @@ BOOL useCEF = false;
 std::string g_electrobunChannel = "";
 std::string g_electrobunIdentifier = "";
 
-static BOOL isMovingWindow = NO;
+// Window drag state
 static NSWindow *targetWindow = nil;
-static CGFloat offsetX = 0.0;
-static CGFloat offsetY = 0.0;
-static id mouseDraggedMonitor = nil;
-static id mouseUpMonitor = nil;
+static id mouseDownDragMonitor = nil;
 
 static int g_remoteDebugPort = 9222;
 
@@ -7318,50 +7315,81 @@ extern "C" void resizeWebview(AbstractView *abstractView, double x, double y, do
 }
 
 extern "C" void stopWindowMove() {
-    isMovingWindow = NO;
+    if (mouseDownDragMonitor) {
+        [NSEvent removeMonitor:mouseDownDragMonitor];
+        mouseDownDragMonitor = nil;
+    }
     targetWindow = nil;
-    offsetX = 0.0;
-    offsetY = 0.0;
-    if (mouseDraggedMonitor) {
-        [NSEvent removeMonitor:mouseDraggedMonitor];
-        mouseDraggedMonitor = nil;
-    }
-    if (mouseUpMonitor) {
-        [NSEvent removeMonitor:mouseUpMonitor];
-        mouseUpMonitor = nil;
-    }
 }
 
 extern "C" void startWindowMove(NSWindow *window) {
+    // Clean up any previous monitor
+    stopWindowMove();
+
     targetWindow = window;
     if (!targetWindow) {
         NSLog(@"No window found for the given WebView.");
         return;
     }
-    isMovingWindow = YES;
-    NSPoint initialLocation = [NSEvent mouseLocation];
 
-    mouseDraggedMonitor = [NSEvent addLocalMonitorForEventsMatchingMask:(NSEventMaskLeftMouseDragged | NSEventMaskMouseMoved)
+    // The preload script calls startWindowMove asynchronously on mousedown in a
+    // drag region. By the time we get here the original LeftMouseDown NSEvent has
+    // already been dispatched, so we can't use it directly. Instead we install a
+    // monitor for the next LeftMouseDragged event (which fires as soon as the user
+    // starts moving the mouse while holding the button). From that event we
+    // synthesize a LeftMouseDown and pass it to performWindowDragWithEvent:, which
+    // delegates the drag to the macOS Window Server.
+    //
+    // Why performWindowDragWithEvent: matters: the Window Server handles tiling,
+    // snapping, Spaces transitions, and the proportional-restore-on-untile
+    // behavior that users expect. The previous manual setFrameOrigin approach
+    // bypassed all of that.
+    mouseDownDragMonitor = [NSEvent addLocalMonitorForEventsMatchingMask:(NSEventMaskLeftMouseDragged | NSEventMaskLeftMouseUp)
                                                                 handler:^NSEvent *(NSEvent *event) {
-        if (isMovingWindow) {
-            NSPoint currentLocation = [NSEvent mouseLocation];
-            if (offsetX == 0.0 && offsetY == 0.0) {
-                NSPoint windowOrigin = targetWindow.frame.origin;
-                offsetX = initialLocation.x - windowOrigin.x;
-                offsetY = initialLocation.y - windowOrigin.y;
-            }
-            CGFloat newX = currentLocation.x - offsetX;
-            CGFloat newY = currentLocation.y - offsetY;
-            [targetWindow setFrameOrigin:NSMakePoint(newX, newY)];
-        }
-        return event;
-    }];
-    mouseUpMonitor = [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskLeftMouseUp
-                                                           handler:^NSEvent *(NSEvent *event) {
-        if (isMovingWindow) {
+        if (!targetWindow) {
             stopWindowMove();
+            return event;
         }
-        return event;
+        if ([event window] != targetWindow) return event;
+
+        // Mouse released before any drag — not a drag, clean up
+        if ([event type] == NSEventTypeLeftMouseUp) {
+            stopWindowMove();
+            return event;
+        }
+
+        // Synthesize a LeftMouseDown event at the current cursor position.
+        // performWindowDragWithEvent: requires a LeftMouseDown but will work with
+        // a synthesized one as long as the mouse button is physically held down
+        // (same technique used by Tauri/tao for edge-case event types).
+        NSPoint mouseLocation = [NSEvent mouseLocation];
+        NSRect windowFrame = [targetWindow frame];
+        NSPoint locationInWindow = NSMakePoint(
+            mouseLocation.x - windowFrame.origin.x,
+            mouseLocation.y - windowFrame.origin.y
+        );
+
+        NSEvent *syntheticDown = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown
+                                                    location:locationInWindow
+                                               modifierFlags:[event modifierFlags]
+                                                   timestamp:[event timestamp]
+                                                windowNumber:[targetWindow windowNumber]
+                                                     context:nil
+                                                 eventNumber:0
+                                                  clickCount:1
+                                                    pressure:1.0];
+
+        NSWindow *dragTarget = targetWindow;
+
+        // Clean up monitor before calling performWindowDragWithEvent: since it
+        // runs a nested event loop and will block until the drag finishes.
+        [NSEvent removeMonitor:mouseDownDragMonitor];
+        mouseDownDragMonitor = nil;
+        targetWindow = nil;
+
+        [dragTarget performWindowDragWithEvent:syntheticDown];
+
+        return nil;
     }];
 }
 


### PR DESCRIPTION
## Summary

Replaces the manual `setFrameOrigin` + `NSEvent` monitor approach in `startWindowMove` with `performWindowDragWithEvent:`, which delegates window dragging to the macOS Window Server.

- Fixes window jitter/shaking during fast drags
- Enables macOS tiling and snapping (Sequoia tile zones, Split View)
- Enables proportional restore when untiling a maximized/tiled window
- Enables Spaces/Mission Control drag interactions

Fixes #145

## Problem

The previous implementation tracked `LeftMouseDragged` events via `addLocalMonitorForEventsMatchingMask:` and manually called `[NSWindow setFrameOrigin:]` on each frame. This bypassed the Window Server entirely — the system had no idea a "drag" was happening, it just saw programmatic frame changes. This is why tiling, snapping, and untile-restore didn't work.

This is the same root cause identified in #145 (window jitter from the feedback loop between event processing and frame updates).

## Solution

Since `startWindowMove` is called asynchronously via RPC (preload JS → Bun → FFI), the original `LeftMouseDown` NSEvent is already gone by the time the native function runs. We can't call `performWindowDragWithEvent:` directly with the original event.

Instead, we install a `LeftMouseDragged | LeftMouseUp` monitor that fires on the **first drag movement** after `startWindowMove` is called. On that first drag event, we:

1. Synthesize a `LeftMouseDown` event at the current cursor position (same technique [Tauri/tao uses](https://github.com/tauri-apps/tao/blob/dev/src/platform_impl/macos/window.rs#L940-L958) for edge-case event types)
2. Call `[NSWindow performWindowDragWithEvent:]` with the synthesized event
3. The Window Server takes over from there — tracks all mouse movement, handles tiling/snapping, and releases when the mouse button goes up

If the user releases the mouse without dragging (a click), the `LeftMouseUp` branch cleans up the monitor without starting a drag.

## How it works

```
Before (broken):
  mousedown → JS preload → RPC → startWindowMove()
    → installs LeftMouseDragged monitor
    → each drag frame: [window setFrameOrigin:] (bypasses Window Server)

After (fixed):
  mousedown → JS preload → RPC → startWindowMove()
    → installs LeftMouseDragged monitor
    → first drag event: synthesize LeftMouseDown → [window performWindowDragWithEvent:]
    → Window Server handles everything from here
```

## Test plan

- [ ] Drag a window by its custom titlebar — should move smoothly without jitter
- [ ] Tile a window using Sequoia tile zones (drag to screen edge) — should snap
- [ ] Drag a tiled/maximized window to untile — should proportionally restore under cursor
- [ ] Double-click titlebar — should still maximize/restore (not affected, handled by preload)
- [ ] Click without dragging on titlebar — should not move window
- [ ] Drag in non-drag regions — should not trigger window move