### PR TITLE
feat: add setWindowButtonPosition() API for macOS traffic light buttons

### DIFF
--- a/kitchen/src/tests/interactive/window-events.test.ts
+++ b/kitchen/src/tests/interactive/window-events.test.ts
@@ -246,4 +246,52 @@ defineTest({
     log("Test completed successfully");
   },
 }),
+defineTest({
+  name: "Window button position (macOS)",
+  category: "Window Events (Interactive)",
+  description: "Test repositioning macOS traffic light buttons",
+  interactive: true,
+  timeout: 120000,
+  async run({ createWindow, log, showInstructions, waitForUserVerification }) {
+    if (process.platform !== "darwin") {
+      log("Skipping test - only available on macOS");
+      return;
+    }
+
+    await showInstructions([
+      "A window with hiddenInset titlebar will open",
+      "The traffic light buttons (close/minimize/zoom) will be repositioned",
+      "Verify the buttons are moved down and to the right from their default position",
+    ]);
+
+    log("Creating test window with hiddenInset titleBarStyle");
+    const win = await createWindow({
+      url: "views://test-harness/index.html",
+      title: "Window Button Position Test",
+      renderer: "cef",
+      width: 600,
+      height: 400,
+      titleBarStyle: "hiddenInset",
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    log("Setting window button position to (80, 80)");
+    win.window.setWindowButtonPosition(80, 80);
+
+    log("Window buttons repositioned - verify visually");
+    const result = await waitForUserVerification();
+
+    if (result.action === "pass") {
+      log("Test passed - window buttons successfully repositioned");
+    } else if (result.action === "fail") {
+      throw new Error("User reported window buttons not repositioned correctly");
+    } else if (result.action === "retest") {
+      log("Re-test requested");
+      return;
+    }
+
+    log("Test completed successfully");
+  },
+})
 ];

--- a/package/src/bun/core/BrowserWindow.ts
+++ b/package/src/bun/core/BrowserWindow.ts
@@ -316,6 +316,10 @@ export class BrowserWindow<T extends RPCWithTransport = RPCWithTransport> {
 		return ffi.request.setWindowPosition({ winId: this.id, x, y });
 	}
 
+	setWindowButtonPosition(x: number, y: number) {
+		return ffi.request.setWindowButtonPosition({ winId: this.id, x, y });
+	}
+
 	setSize(width: number, height: number) {
 		this.frame.width = width;
 		this.frame.height = height;

--- a/package/src/bun/core/GpuWindow.ts
+++ b/package/src/bun/core/GpuWindow.ts
@@ -214,6 +214,10 @@ export class GpuWindow {
 		return ffi.request.setWindowPosition({ winId: this.id, x, y });
 	}
 
+	setWindowButtonPosition(x: number, y: number) {
+		return ffi.request.setWindowButtonPosition({ winId: this.id, x, y });
+	}
+
 	setSize(width: number, height: number) {
 		this.frame.width = width;
 		this.frame.height = height;

--- a/package/src/bun/proc/native.ts
+++ b/package/src/bun/proc/native.ts
@@ -177,6 +177,10 @@ export const native = (() => {
 				args: [FFIType.ptr, FFIType.f64, FFIType.f64],
 				returns: FFIType.void,
 			},
+			setWindowButtonPosition: {
+				args: [FFIType.ptr, FFIType.f64, FFIType.f64],
+				returns: FFIType.void,
+			},
 			setWindowSize: {
 				args: [FFIType.ptr, FFIType.f64, FFIType.f64],
 				returns: FFIType.void,
@@ -1008,6 +1012,15 @@ export const ffi = {
 			}
 
 			native.symbols.setWindowPosition(windowPtr, x, y);
+		},
+
+		setWindowButtonPosition: (params: { winId: number; x: number; y: number }) => {
+			const { winId, x, y } = params;
+			const windowPtr = getWindowPtr(winId);
+			if (!windowPtr) {
+				throw `Can't set window button position. Window no longer exists`;
+			}
+			native.symbols.setWindowButtonPosition(windowPtr, x, y);
 		},
 
 		setWindowSize: (params: {

--- a/package/src/native/linux/nativeWrapper.cpp
+++ b/package/src/native/linux/nativeWrapper.cpp
@@ -9657,6 +9657,10 @@ ELECTROBUN_EXPORT void setWindowPosition(void* window, double x, double y) {
     });
 }
 
+ELECTROBUN_EXPORT void setWindowButtonPosition(void* window, double x, double y) {
+    // Not applicable on Linux - no-op
+}
+
 ELECTROBUN_EXPORT void setWindowSize(void* window, double width, double height) {
     if (!window) return;
 

--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -6354,6 +6354,26 @@ static void applyWindowButtonPosition(NSWindow *window, double x, double y) {
             }
         }
     }
+
+    - (void)windowWillExitFullScreen:(NSNotification *)notification {
+        if (self.hasCustomButtonPosition) {
+            NSWindow *window = [notification object];
+            [[window standardWindowButton:NSWindowCloseButton] setHidden:YES];
+            [[window standardWindowButton:NSWindowMiniaturizeButton] setHidden:YES];
+            [[window standardWindowButton:NSWindowZoomButton] setHidden:YES];
+        }
+    }
+
+    - (void)windowDidExitFullScreen:(NSNotification *)notification {
+        if (self.hasCustomButtonPosition) {
+            NSWindow *window = [notification object];
+            applyWindowButtonPosition(window, self.buttonPositionX, self.buttonPositionY);
+            [[window standardWindowButton:NSWindowCloseButton] setHidden:NO];
+            [[window standardWindowButton:NSWindowMiniaturizeButton] setHidden:NO];
+            [[window standardWindowButton:NSWindowZoomButton] setHidden:NO];
+        }
+    }
+
     - (void)windowDidMove:(NSNotification *)notification {
         if (self.moveHandler) {
             NSWindow *window = [notification object];

--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -865,6 +865,9 @@ static NSMutableDictionary<NSNumber *, AbstractView *> *globalAbstractViews = ni
     @property (nonatomic, assign) WindowFocusHandler focusHandler;
     @property (nonatomic, assign) WindowBlurHandler blurHandler;
     @property (nonatomic, assign) WindowKeyHandler keyHandler;
+    @property (nonatomic, assign) BOOL hasCustomButtonPosition;
+    @property (nonatomic, assign) double buttonPositionX;
+    @property (nonatomic, assign) double buttonPositionY;
     @property (nonatomic, assign) uint32_t windowId;
     @property (nonatomic, strong) NSWindow *window;
 @end
@@ -6282,6 +6285,39 @@ CefRefPtr<CefRequestContext> CreateRequestContextForPartition(const char* partit
     }
 @end
 
+static void applyWindowButtonPosition(NSWindow *window, double x, double y) {
+    NSButton *closeBtn = [window standardWindowButton:NSWindowCloseButton];
+    NSButton *minimizeBtn = [window standardWindowButton:NSWindowMiniaturizeButton];
+    NSButton *zoomBtn = [window standardWindowButton:NSWindowZoomButton];
+
+    if (!closeBtn || !minimizeBtn || !zoomBtn) return;
+
+    NSView *titlebarView = [closeBtn superview];
+    if (!titlebarView) return;
+
+    NSView *titlebarContainerView = [titlebarView superview];
+    if (!titlebarContainerView) return;
+
+    CGFloat buttonSpacing = 20.0;
+    CGFloat buttonHeight = closeBtn.frame.size.height;
+    CGFloat requiredHeight = y + buttonHeight;
+
+    NSRect containerFrame = titlebarContainerView.frame;
+    containerFrame.size.height = requiredHeight;
+    containerFrame.origin.y = NSHeight(window.frame) - requiredHeight;
+    [titlebarContainerView setFrame:containerFrame];
+
+    NSRect titlebarFrame = titlebarView.frame;
+    titlebarFrame.size.height = requiredHeight;
+    titlebarFrame.origin.y = 0;
+    [titlebarView setFrame:titlebarFrame];
+
+    CGFloat adjustedY = requiredHeight - y - buttonHeight;
+    [closeBtn setFrameOrigin:NSMakePoint(x, adjustedY)];
+    [minimizeBtn setFrameOrigin:NSMakePoint(x + buttonSpacing, adjustedY)];
+    [zoomBtn setFrameOrigin:NSMakePoint(x + 2 * buttonSpacing, adjustedY)];
+}
+
 @implementation WindowDelegate
     - (BOOL)windowShouldClose:(NSWindow *)sender {
     return YES;
@@ -6313,6 +6349,9 @@ CefRefPtr<CefRequestContext> CreateRequestContextForPartition(const char* partit
             NSRect contentRect = [window contentRectForFrameRect:windowFrame];
             self.resizeHandler(self.windowId, windowFrame.origin.x, windowFrame.origin.y,
                                contentRect.size.width, contentRect.size.height);
+            if (self.hasCustomButtonPosition) {
+                applyWindowButtonPosition(window, self.buttonPositionX, self.buttonPositionY);
+            }
         }
     }
     - (void)windowDidMove:(NSNotification *)notification {
@@ -7251,44 +7290,14 @@ extern "C" void setWindowButtonPosition(NSWindow *window, double x, double y) {
     dispatch_async(dispatch_get_main_queue(), ^{
         if (!window) return;
 
-        NSButton *closeBtn = [window standardWindowButton:NSWindowCloseButton];
-        NSButton *minimizeBtn = [window standardWindowButton:NSWindowMiniaturizeButton];
-        NSButton *zoomBtn = [window standardWindowButton:NSWindowZoomButton];
+        WindowDelegate *delegate = (WindowDelegate *)[window delegate];
+        if (delegate) {
+            delegate.hasCustomButtonPosition = YES;
+            delegate.buttonPositionX = x;
+            delegate.buttonPositionY = y;
+        }
 
-        if (!closeBtn || !minimizeBtn || !zoomBtn) return;
-
-        // View hierarchy: NSTitlebarContainerView > NSTitlebarView > buttons
-        NSView *titlebarView = [closeBtn superview];
-        if (!titlebarView) return;
-
-        NSView *titlebarContainerView = [titlebarView superview];
-        if (!titlebarContainerView) return;
-
-        CGFloat buttonSpacing = 20.0;
-        CGFloat buttonHeight = closeBtn.frame.size.height;
-
-        // Calculate required container height to fit buttons at the requested y position
-        CGFloat requiredHeight = y + buttonHeight;
-
-        // Resize the titlebar container to encompass the new button positions
-        // Position it at the top of the window (macOS y-axis is bottom-up)
-        NSRect containerFrame = titlebarContainerView.frame;
-        containerFrame.size.height = requiredHeight;
-        containerFrame.origin.y = NSHeight(window.frame) - requiredHeight;
-        [titlebarContainerView setFrame:containerFrame];
-
-        // Resize the titlebar view to match
-        NSRect titlebarFrame = titlebarView.frame;
-        titlebarFrame.size.height = requiredHeight;
-        titlebarFrame.origin.y = 0;
-        [titlebarView setFrame:titlebarFrame];
-
-        // Position buttons (convert from top-down y to macOS bottom-up within the resized view)
-        CGFloat adjustedY = requiredHeight - y - buttonHeight;
-
-        [closeBtn setFrameOrigin:NSMakePoint(x, adjustedY)];
-        [minimizeBtn setFrameOrigin:NSMakePoint(x + buttonSpacing, adjustedY)];
-        [zoomBtn setFrameOrigin:NSMakePoint(x + 2 * buttonSpacing, adjustedY)];
+        applyWindowButtonPosition(window, x, y);
     });
 }
 

--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -7247,6 +7247,34 @@ extern "C" void setWindowPosition(NSWindow *window, double x, double y) {
     });
 }
 
+extern "C" void setWindowButtonPosition(NSWindow *window, double x, double y) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (!window) return;
+
+        NSButton *closeBtn = [window standardWindowButton:NSWindowCloseButton];
+        NSButton *minimizeBtn = [window standardWindowButton:NSWindowMiniaturizeButton];
+        NSButton *zoomBtn = [window standardWindowButton:NSWindowZoomButton];
+
+        if (!closeBtn || !minimizeBtn || !zoomBtn) return;
+
+        NSView *titlebarView = [closeBtn superview];
+        if (!titlebarView) return;
+
+        CGFloat titlebarHeight = titlebarView.frame.size.height;
+
+        CGFloat buttonSpacing = 20.0;
+
+        // Button height for vertical centering
+        CGFloat buttonHeight = closeBtn.frame.size.height;
+
+        CGFloat adjustedY = titlebarHeight - y - buttonHeight;
+
+        [closeBtn setFrameOrigin:NSMakePoint(x, adjustedY)];
+        [minimizeBtn setFrameOrigin:NSMakePoint(x + buttonSpacing, adjustedY)];
+        [zoomBtn setFrameOrigin:NSMakePoint(x + 2 * buttonSpacing, adjustedY)];
+    });
+}
+
 extern "C" void setWindowSize(NSWindow *window, double width, double height) {
     dispatch_async(dispatch_get_main_queue(), ^{
         if (!window) return;

--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -7257,17 +7257,34 @@ extern "C" void setWindowButtonPosition(NSWindow *window, double x, double y) {
 
         if (!closeBtn || !minimizeBtn || !zoomBtn) return;
 
+        // View hierarchy: NSTitlebarContainerView > NSTitlebarView > buttons
         NSView *titlebarView = [closeBtn superview];
         if (!titlebarView) return;
 
-        CGFloat titlebarHeight = titlebarView.frame.size.height;
+        NSView *titlebarContainerView = [titlebarView superview];
+        if (!titlebarContainerView) return;
 
         CGFloat buttonSpacing = 20.0;
-
-        // Button height for vertical centering
         CGFloat buttonHeight = closeBtn.frame.size.height;
 
-        CGFloat adjustedY = titlebarHeight - y - buttonHeight;
+        // Calculate required container height to fit buttons at the requested y position
+        CGFloat requiredHeight = y + buttonHeight;
+
+        // Resize the titlebar container to encompass the new button positions
+        // Position it at the top of the window (macOS y-axis is bottom-up)
+        NSRect containerFrame = titlebarContainerView.frame;
+        containerFrame.size.height = requiredHeight;
+        containerFrame.origin.y = NSHeight(window.frame) - requiredHeight;
+        [titlebarContainerView setFrame:containerFrame];
+
+        // Resize the titlebar view to match
+        NSRect titlebarFrame = titlebarView.frame;
+        titlebarFrame.size.height = requiredHeight;
+        titlebarFrame.origin.y = 0;
+        [titlebarView setFrame:titlebarFrame];
+
+        // Position buttons (convert from top-down y to macOS bottom-up within the resized view)
+        CGFloat adjustedY = requiredHeight - y - buttonHeight;
 
         [closeBtn setFrameOrigin:NSMakePoint(x, adjustedY)];
         [minimizeBtn setFrameOrigin:NSMakePoint(x + buttonSpacing, adjustedY)];

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -8925,6 +8925,10 @@ ELECTROBUN_EXPORT void setWindowPosition(NSWindow *window, double x, double y) {
     SetWindowPos(hwnd, NULL, (int)x, (int)y, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
 }
 
+ELECTROBUN_EXPORT void setWindowButtonPosition(NSWindow *window, double x, double y) {
+    // Not applicable on Windows - no-op
+}
+
 ELECTROBUN_EXPORT void setWindowSize(NSWindow *window, double width, double height) {
     HWND hwnd = reinterpret_cast<HWND>(window);
     if (!IsWindow(hwnd)) return;


### PR DESCRIPTION
## Summary
Add `setWindowButtonPosition(x, y)` API to `BrowserWindow` and `GpuWindow` to allow custom positioning of the macOS traffic light buttons (close, minimize, zoom). The buttons remain fully interactive and retain their position across window resizes and fullscreen transitions.

## Changes
  - **Native wrapper (`nativeWrapper.mm`)**: Added `setWindowButtonPosition()`
    which resizes `NSTitlebarContainerView` and `NSTitlebarView` to encompass
    the new position, ensuring hit-testing works correctly. Added
    `applyWindowButtonPosition()` helper shared by `setWindowButtonPosition`, resize and fullscreen
    handlers. Edited `windowDidResize:`, Added `windowWillExitFullScreen:`, and
    `windowDidExitFullScreen:` delegate methods to persist the custom
    position across layout resets.
  - **WindowDelegate (`nativeWrapper.mm`)**: Added `hasCustomButtonPosition`,
    `buttonPositionX`, and `buttonPositionY` properties to store the last
    requested position.
  - **FFI bindings (`native.ts`)**: Registered `setWindowButtonPosition` and
    added the request handler.
  - **BrowserWindow API (`BrowserWindow.ts`)**: Exposed `setWindowButtonPosition()` method.
  - **GpuWindow API (`GpuWindow.ts`)**: Exposed `setWindowButtonPosition()` method.
  - **Tests (`window-events.test.ts`)**: Added test case verifying button
    repositioning behavior.
    
## Demo:
   
https://github.com/user-attachments/assets/8a5a76c9-dba5-4397-9759-2984cf8cb750

