### PR TITLE
Fix Windows rcedit resolution for icon embedding

### DIFF
--- a/package/src/cli/index.ts
+++ b/package/src/cli/index.ts
@@ -15,7 +15,7 @@ import {
 	copyFileSync,
 	renameSync,
 } from "fs";
-import { execSync } from "child_process";
+import { execFileSync, execSync } from "child_process";
 import * as readline from "readline";
 import { OS, ARCH } from "../shared/platform";
 import { DEFAULT_CEF_VERSION_STRING } from "../shared/cef-version";
@@ -88,6 +88,37 @@ function resolveElectrobunDir(): string {
 }
 
 const ELECTROBUN_DEP_PATH = resolveElectrobunDir();
+
+function resolveLocalRceditBinaryPath() {
+	const rceditPackageJsonPath = require.resolve("rcedit/package.json", {
+		paths: [projectRoot],
+	});
+	const rceditPackageDir = dirname(rceditPackageJsonPath);
+	const candidatePaths = [
+		join(rceditPackageDir, "bin", "rcedit-x64.exe"),
+		join(rceditPackageDir, "bin", "rcedit.exe"),
+	];
+	const rceditBinaryPath = candidatePaths.find((candidatePath) =>
+		existsSync(candidatePath),
+	);
+
+	if (!rceditBinaryPath) {
+		throw new Error(
+			`Could not find a local rcedit executable in ${join(rceditPackageDir, "bin")}`,
+		);
+	}
+
+	return rceditBinaryPath;
+}
+
+function embedWindowsIconWithLocalRcedit(
+	executablePath: string,
+	iconPath: string,
+) {
+	execFileSync(resolveLocalRceditBinaryPath(), [executablePath, "--set-icon", iconPath], {
+		stdio: "pipe",
+	});
+}
 const ELECTROBUN_CACHE_PATH = join(dirname(ELECTROBUN_DEP_PATH), ".electrobun-cache");
 
 // When debugging electrobun with the example app use the builds (dev or release) right from the source folder
@@ -2161,11 +2192,8 @@ Categories=Utility;Application;
 						);
 					}
 
-					// Use rcedit to embed the icon into launcher.exe
-					const rcedit = (await import("rcedit")).default;
-					await rcedit(bunCliLauncherDestination, {
-						icon: iconPath,
-					});
+					// Resolve rcedit from the local project install instead of a baked snapshot path.
+					embedWindowsIconWithLocalRcedit(bunCliLauncherDestination, iconPath);
 					console.log(`Successfully embedded icon into launcher.exe`);
 
 					// Clean up temp ICO file
@@ -2257,11 +2285,8 @@ Categories=Utility;Application;
 						);
 					}
 
-					// Use rcedit to embed the icon into bun.exe
-					const rcedit = (await import("rcedit")).default;
-					await rcedit(bunBinaryDestInBundlePath, {
-						icon: iconPath,
-					});
+					// Resolve rcedit from the local project install instead of a baked snapshot path.
+					embedWindowsIconWithLocalRcedit(bunBinaryDestInBundlePath, iconPath);
 					console.log(`Successfully embedded icon into bun.exe`);
 
 					// Clean up temp ICO file
@@ -4300,11 +4325,8 @@ Categories=Utility;Application;
 						console.log(`Converted PNG to ICO format: ${tempIcoPath}`);
 					}
 
-					// Use rcedit to embed the icon
-					const rcedit = (await import("rcedit")).default;
-					await rcedit(outputExePath, {
-						icon: iconPath,
-					});
+					// Resolve rcedit from the local project install instead of a baked snapshot path.
+					embedWindowsIconWithLocalRcedit(outputExePath, iconPath);
 					console.log(`Successfully embedded icon into ${setupFileName}`);
 
 					// Clean up temp ICO file


### PR DESCRIPTION
# ElectroBun PR draft

## Title

Fix Windows `rcedit` resolution for icon embedding

## Summary

This changes the Windows icon embedding paths to resolve `rcedit` from the local installed dependency tree instead of relying on a baked CI/snapshot path.

## Problem

On Windows, `electrobun@1.15.1` can attempt to execute `rcedit` from a path like:

`D:\a\electrobun\electrobun\package\node_modules\rcedit\bin\rcedit-x64.exe`

That path does not exist in normal local app installs, which causes icon embedding to fail even though packaging otherwise continues.

## Change

This PR updates the Windows icon embedding code in `src/cli/index.ts` to:

1. Resolve `rcedit/package.json` from the local project dependency tree.
2. Derive the installed `rcedit` package directory.
3. Use `bin/rcedit-x64.exe` when available, with fallback to `bin/rcedit.exe`.
4. Execute the resolved binary directly for `--set-icon`.

The existing behavior is preserved for:

- PNG-to-ICO conversion
- temp ICO cleanup
- warning-only error handling

## Validation

Validated in a downstream Windows app repo by:

1. running a clean install
2. packaging with `build.win.icon` configured
3. confirming icon embedding succeeds for:
   - `launcher.exe`
   - `bun.exe`
   - the Windows installer EXE

## Notes

The downstream repo currently carries a wrapper-only compatibility workaround until ElectroBun publishes a release containing this fix.
