### PR TITLE
Add `dev.reloadWithoutActivating` option for focus-free live reload

### DIFF
--- a/package/src/bun/ElectrobunConfig.ts
+++ b/package/src/bun/ElectrobunConfig.ts
@@ -328,11 +328,12 @@ export interface ElectrobunConfig {
 	 */
 	dev?: {
 		/**
-		 * Show windows without stealing focus from the currently active app.
-		 * Useful during development so live-reload doesn't yank you out of your editor.
+		 * When live-reloading (`electrobun dev --watch`), show windows without
+		 * stealing focus from the currently active app. The initial launch still
+		 * activates normally.
 		 * @default false
 		 */
-		launchWithoutActivating?: boolean;
+		reloadWithoutActivating?: boolean;
 	};
 
 	/**

--- a/package/src/bun/ElectrobunConfig.ts
+++ b/package/src/bun/ElectrobunConfig.ts
@@ -323,6 +323,19 @@ export interface ElectrobunConfig {
 	};
 
 	/**
+	 * Dev mode configuration.
+	 * Controls behaviour when running with `electrobun dev`.
+	 */
+	dev?: {
+		/**
+		 * Show windows without stealing focus from the currently active app.
+		 * Useful during development so live-reload doesn't yank you out of your editor.
+		 * @default false
+		 */
+		launchWithoutActivating?: boolean;
+	};
+
+	/**
 	 * Runtime behaviour configuration.
 	 * These values are copied into build.json and available to the Bun process at runtime.
 	 * You can add arbitrary keys here and access them via BuildConfig.

--- a/package/src/bun/core/BrowserWindow.ts
+++ b/package/src/bun/core/BrowserWindow.ts
@@ -199,6 +199,7 @@ export class BrowserWindow<T extends RPCWithTransport = RPCWithTransport> {
 			titleBarStyle: titleBarStyle || "default",
 			transparent: transparent ?? false,
 			hidden: hidden ?? false,
+			showWithoutActivating: buildConfig?.dev?.launchWithoutActivating ?? false,
 		}) as Pointer;
 
 		BrowserWindowMap[this.id] = this;
@@ -260,6 +261,10 @@ export class BrowserWindow<T extends RPCWithTransport = RPCWithTransport> {
 
 	show() {
 		return ffi.request.focusWindow({ winId: this.id });
+	}
+
+	showWithoutActivating() {
+		return ffi.request.showWindowWithoutActivating({ winId: this.id });
 	}
 
 	minimize() {

--- a/package/src/bun/core/BrowserWindow.ts
+++ b/package/src/bun/core/BrowserWindow.ts
@@ -199,7 +199,7 @@ export class BrowserWindow<T extends RPCWithTransport = RPCWithTransport> {
 			titleBarStyle: titleBarStyle || "default",
 			transparent: transparent ?? false,
 			hidden: hidden ?? false,
-			showWithoutActivating: buildConfig?.dev?.launchWithoutActivating ?? false,
+			showWithoutActivating: buildConfig?.dev?.reloadWithoutActivating ?? false,
 		}) as Pointer;
 
 		BrowserWindowMap[this.id] = this;

--- a/package/src/bun/core/BuildConfig.ts
+++ b/package/src/bun/core/BuildConfig.ts
@@ -7,6 +7,9 @@ export type BuildConfigType = {
 		exitOnLastWindowClosed?: boolean;
 		[key: string]: unknown;
 	};
+	dev?: {
+		launchWithoutActivating?: boolean;
+	};
 };
 
 let buildConfig: BuildConfigType | null = null;

--- a/package/src/bun/core/BuildConfig.ts
+++ b/package/src/bun/core/BuildConfig.ts
@@ -8,7 +8,7 @@ export type BuildConfigType = {
 		[key: string]: unknown;
 	};
 	dev?: {
-		launchWithoutActivating?: boolean;
+		reloadWithoutActivating?: boolean;
 	};
 };
 

--- a/package/src/bun/core/GpuWindow.ts
+++ b/package/src/bun/core/GpuWindow.ts
@@ -1,9 +1,11 @@
 import { ffi } from "../proc/native";
 import electrobunEventEmitter from "../events/eventEmitter";
 import { type Pointer } from "bun:ffi";
+import { BuildConfig } from "./BuildConfig";
 import { WGPUView } from "./WGPUView";
 import { getNextWindowId } from "./windowIds";
 
+const buildConfig = await BuildConfig.get();
 
 export type GpuWindowOptionsType = {
 	title: string;
@@ -123,6 +125,7 @@ export class GpuWindow {
 			},
 			titleBarStyle: titleBarStyle || "default",
 			transparent: transparent ?? false,
+			showWithoutActivating: buildConfig?.dev?.launchWithoutActivating ?? false,
 		}) as Pointer;
 
 		GpuWindowMap[this.id] = this;
@@ -166,6 +169,10 @@ export class GpuWindow {
 
 	show() {
 		return ffi.request.focusWindow({ winId: this.id });
+	}
+
+	showWithoutActivating() {
+		return ffi.request.showWindowWithoutActivating({ winId: this.id });
 	}
 
 	minimize() {

--- a/package/src/bun/core/GpuWindow.ts
+++ b/package/src/bun/core/GpuWindow.ts
@@ -125,7 +125,7 @@ export class GpuWindow {
 			},
 			titleBarStyle: titleBarStyle || "default",
 			transparent: transparent ?? false,
-			showWithoutActivating: buildConfig?.dev?.launchWithoutActivating ?? false,
+			showWithoutActivating: buildConfig?.dev?.reloadWithoutActivating ?? false,
 		}) as Pointer;
 
 		GpuWindowMap[this.id] = this;

--- a/package/src/bun/proc/native.ts
+++ b/package/src/bun/proc/native.ts
@@ -118,6 +118,12 @@ export const native = (() => {
 				],
 				returns: FFIType.void,
 			},
+			showWindowWithoutActivating: {
+				args: [
+					FFIType.ptr, // window ptr
+				],
+				returns: FFIType.void,
+			},
 			closeWindow: {
 				args: [
 					FFIType.ptr, // window ptr
@@ -739,6 +745,7 @@ export const ffi = {
 			titleBarStyle: string;
 			transparent: boolean;
 			hidden?: boolean;
+			showWithoutActivating?: boolean;
 		}): FFIType.ptr => {
 			const {
 				id,
@@ -762,6 +769,7 @@ export const ffi = {
 				titleBarStyle,
 				transparent,
 				hidden = false,
+				showWithoutActivating = false,
 			} = params;
 
 			const styleMask = native.symbols.getWindowStyle(
@@ -804,7 +812,11 @@ export const ffi = {
 
 			native.symbols.setWindowTitle(windowPtr, toCString(title));
 			if (!hidden) {
-				native.symbols.showWindow(windowPtr);
+				if (showWithoutActivating) {
+					native.symbols.showWindowWithoutActivating(windowPtr);
+				} else {
+					native.symbols.showWindow(windowPtr);
+				}
 			}
 
 			return windowPtr;
@@ -841,6 +853,16 @@ export const ffi = {
 			}
 
 			native.symbols.showWindow(windowPtr);
+		},
+
+		showWindowWithoutActivating: (params: { winId: number }) => {
+			const windowPtr = getWindowPtr(params.winId);
+
+			if (!windowPtr) {
+				throw `Can't show window. Window no longer exists`;
+			}
+
+			native.symbols.showWindowWithoutActivating(windowPtr);
 		},
 
 		minimizeWindow: (params: { winId: number }) => {

--- a/package/src/cli/index.ts
+++ b/package/src/cli/index.ts
@@ -4131,14 +4131,19 @@ Categories=Utility;Application;
 		});
 
 		// Initial build + launch (watchers start after build completes)
+		// First launch should activate normally; reloads respect launchWithoutActivating
+		const savedLaunchWithoutActivating = config.dev.launchWithoutActivating;
+		config.dev.launchWithoutActivating = false;
 		try {
 			await runBuild(config, "dev");
+			config.dev.launchWithoutActivating = savedLaunchWithoutActivating;
 			appHandle = await runApp(config, {
 				onExit: () => {
 					appHandle = null;
 				},
 			});
 		} catch (error) {
+			config.dev.launchWithoutActivating = savedLaunchWithoutActivating;
 			console.error("[electrobun dev --watch] Initial build failed:", error);
 			console.log("[electrobun dev --watch] Waiting for file changes...");
 		}

--- a/package/src/cli/index.ts
+++ b/package/src/cli/index.ts
@@ -1424,6 +1424,9 @@ const defaultConfig = {
 		watch: undefined as string[] | undefined,
 		watchIgnore: undefined as string[] | undefined,
 	},
+	dev: {
+		launchWithoutActivating: false,
+	},
 	runtime: {} as Record<string, unknown>,
 	scripts: {
 		preBuild: "",
@@ -3130,6 +3133,7 @@ Categories=Utility;Application;
 			defaultRenderer: platformConfig?.defaultRenderer ?? "native",
 			availableRenderers: bundlesCEF ? ["native", "cef"] : ["native"],
 			runtime: config.runtime ?? {},
+			...(buildEnvironment === "dev" ? { dev: config.dev ?? {} } : {}),
 			...(bundlesCEF
 				? { cefVersion: config.build?.cefVersion ?? DEFAULT_CEF_VERSION_STRING }
 				: {}),
@@ -4234,6 +4238,10 @@ Categories=Utility;Application;
 					...defaultConfig.build.bun,
 					...(loadedConfig?.build?.bun || {}),
 				},
+			},
+			dev: {
+				...defaultConfig.dev,
+				...(loadedConfig?.dev || {}),
 			},
 			runtime: {
 				...defaultConfig.runtime,

--- a/package/src/cli/index.ts
+++ b/package/src/cli/index.ts
@@ -1425,7 +1425,7 @@ const defaultConfig = {
 		watchIgnore: undefined as string[] | undefined,
 	},
 	dev: {
-		launchWithoutActivating: false,
+		reloadWithoutActivating: false,
 	},
 	runtime: {} as Record<string, unknown>,
 	scripts: {
@@ -4131,19 +4131,19 @@ Categories=Utility;Application;
 		});
 
 		// Initial build + launch (watchers start after build completes)
-		// First launch should activate normally; reloads respect launchWithoutActivating
-		const savedLaunchWithoutActivating = config.dev.launchWithoutActivating;
-		config.dev.launchWithoutActivating = false;
+		// First launch should activate normally; reloads respect reloadWithoutActivating
+		const savedLaunchWithoutActivating = config.dev.reloadWithoutActivating;
+		config.dev.reloadWithoutActivating = false;
 		try {
 			await runBuild(config, "dev");
-			config.dev.launchWithoutActivating = savedLaunchWithoutActivating;
+			config.dev.reloadWithoutActivating = savedLaunchWithoutActivating;
 			appHandle = await runApp(config, {
 				onExit: () => {
 					appHandle = null;
 				},
 			});
 		} catch (error) {
-			config.dev.launchWithoutActivating = savedLaunchWithoutActivating;
+			config.dev.reloadWithoutActivating = savedLaunchWithoutActivating;
 			console.error("[electrobun dev --watch] Initial build failed:", error);
 			console.log("[electrobun dev --watch] Waiting for file changes...");
 		}

--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -7087,12 +7087,19 @@ extern "C" void showWindow(NSWindow *window) {
     dispatch_sync(dispatch_get_main_queue(), ^{
         // First ensure the window is visible
         [window orderFront:nil];
-        
+
         // Make the window key and bring to front
         [window makeKeyAndOrderFront:nil];
-        
+
         // Activate the application to ensure it can receive focus
-        [[NSApplication sharedApplication] activateIgnoringOtherApps:YES];    
+        [[NSApplication sharedApplication] activateIgnoringOtherApps:YES];
+    });
+}
+
+extern "C" void showWindowWithoutActivating(NSWindow *window) {
+    dispatch_sync(dispatch_get_main_queue(), ^{
+        // Make window visible and frontmost without stealing keyboard focus
+        [window orderFrontRegardless];
     });
 }
 


### PR DESCRIPTION
Closes #288

The problem is that while working on my app, its constantly reloading and stealing focus.
This new option lets us launch normally in dev mode, and then re-launch without stealing focus on reloads.

## Summary
- Adds a native `showWindowWithoutActivating` function (macOS) that uses `orderFrontRegardless` to show windows without stealing keyboard focus
- Exposes it through FFI, the request layer, and as `BrowserWindow.showWithoutActivating()` / `GpuWindow.showWithoutActivating()`
- Adds a `dev.reloadWithoutActivating` config option that automatically uses the non-activating path during live-reload rebuilds (`electrobun dev --watch`), while the initial launch still activates normally

## Usage
```ts
// electrobun.config.ts
export default {
  dev: {
    reloadWithoutActivating: true,
  },
} satisfies ElectrobunConfig;
```

## Test plan
- [ ] Run `electrobun dev --watch` with `reloadWithoutActivating: true` — verify initial launch steals focus
- [ ] Make a file change to trigger live-reload — verify the app window reappears without stealing focus from the editor
- [ ] Run `electrobun dev --watch` with `reloadWithoutActivating: false` (or omitted) — verify reload still steals focus as before
- [ ] Call `win.showWithoutActivating()` manually from app code — verify it works independently of the config option

🤖 Generated with [Claude Code](https://claude.com/claude-code)