### PR TITLE
Fix CEF render buffer mismatch on tiling window managers

### DIFF
--- a/package/src/native/linux/nativeWrapper.cpp
+++ b/package/src/native/linux/nativeWrapper.cpp
@@ -1256,11 +1256,17 @@ public:
             CefRefPtr<CefBrowser> browser;
             gint64 start_time;
             int trigger_count;
+            Window parent_window;
+            int last_parent_width;
+            int last_parent_height;
         };
-        
+
         auto* interval_data = new LayoutIntervalData{
-            browser, 
+            browser,
             g_get_monotonic_time(), // microseconds since arbitrary point
+            0,
+            parent_window_handle_,
+            0,
             0
         };
         
@@ -1280,8 +1286,27 @@ public:
                 if (cefWindow && cefWindow != 0x1) {
                     
                     
-                    // Get window dimensions for mouse event coordinates
                     Display* display = gdk_x11_get_default_xdisplay();
+
+                    // Check if parent window was resized by WM (e.g. tiling WM)
+                    // and sync CEF browser window to match
+                    if (lid->parent_window) {
+                        XWindowAttributes parent_attrs;
+                        if (XGetWindowAttributes(display, lid->parent_window, &parent_attrs) != 0) {
+                            if (parent_attrs.width != lid->last_parent_width ||
+                                parent_attrs.height != lid->last_parent_height) {
+                                lid->last_parent_width = parent_attrs.width;
+                                lid->last_parent_height = parent_attrs.height;
+                                // Resize CEF window to match parent
+                                XMoveResizeWindow(display, (Window)cefWindow,
+                                    0, 0, parent_attrs.width, parent_attrs.height);
+                                XFlush(display);
+                                lid->browser->GetHost()->WasResized();
+                            }
+                        }
+                    }
+
+                    // Get window dimensions for mouse event coordinates
                     XWindowAttributes attrs;
                     if (XGetWindowAttributes(display, (Window)cefWindow, &attrs) != 0) {
                         // Send mouse move event to trigger layout recalculation
@@ -1289,7 +1314,7 @@ public:
                         moveEvent.x = attrs.width / 2;
                         moveEvent.y = attrs.height / 2;
                         lid->browser->GetHost()->SendMouseMoveEvent(moveEvent, false);
-                        
+
                         // Send minimal scroll event
                         CefMouseEvent scrollEvent;
                         scrollEvent.x = attrs.width / 2;


### PR DESCRIPTION
## Summary

- Fixes CEF content rendering at the wrong size when a tiling window manager (e.g. Hyprland) resizes the window immediately after creation
- The `OnAfterCreated` interval timer now polls the parent X11 window's actual size and syncs the CEF child window when a mismatch is detected

## Problem

On tiling window managers like Hyprland (Wayland + XWayland), the window creation sequence is:

1. `XCreateWindow()` at requested size (e.g. 1200x800)
2. CEF browser created with `CefRect(0, 0, 1200, 800)`
3. WM immediately tiles the XWayland window to a different size (e.g. 960x1040)
4. CEF has already allocated its render buffer at 1200x800
5. The `ConfigureNotify` event arrives but CEF's internal compositor doesn't fully re-layout

The result: CEF content renders at the initial requested size, not the actual tiled size. Manually resizing the window fixes it because that triggers a fresh `WasResized()` cycle.

## Fix

The existing `OnAfterCreated` interval timer (which already runs every 5ms for 1 second to handle OOPIF positioning) now also:

1. Reads the parent X11 window's actual dimensions via `XGetWindowAttributes`
2. Compares with the last known size
3. If the parent was resized (by the WM), calls `XMoveResizeWindow` on the CEF child window to match, then `browser->GetHost()->WasResized()`

This catches the tiling resize that happens in the first few milliseconds after window mapping.

## Environment

- **OS**: Arch Linux (rolling), kernel 6.18.13-arch1-1
- **Window Manager**: Hyprland 0.54.0 (Wayland compositor, XWayland for CEF)
- **GPU**: AMD Radeon Strix Halo (Radeon 8060S)
- **Display Protocol**: Wayland (Hyprland) → XWayland (CEF)

## Electrobun Config

We're building a desktop editor using CEF with GPU + WebGPU enabled. The default Linux flags disable GPU for VM compatibility, so we override them via `chromiumFlags`:

```typescript
import type { ElectrobunConfig } from "electrobun";

export default {
  app: {
    name: "gemworks",
    identifier: "ai.gemworks.editor",
    version: "0.0.1",
  },
  build: {
    copy: {
      "dist/index.html": "views/mainview/index.html",
      "dist/assets": "views/mainview/assets",
    },
    watchIgnore: ["dist/**"],
    mac: { bundleCEF: false },
    linux: {
      bundleCEF: true,
      chromiumFlags: {
        // Suppress default GPU-disable flags
        "disable-gpu": false,
        "disable-gpu-compositing": false,
        "disable-gpu-sandbox": false,
        "enable-software-rasterizer": false,
        "force-software-rasterizer": false,
        "disable-accelerated-2d-canvas": false,
        "disable-accelerated-video-decode": false,
        "disable-accelerated-video-encode": false,
        "disable-gpu-memory-buffer-video-frames": false,
        // Enable GPU + WebGPU
        "ignore-gpu-blocklist": true,
        "enable-gpu-rasterization": true,
        "enable-unsafe-webgpu": true,
        "enable-features": "Vulkan,UseSkiaRenderer,WebGPU",
        "use-vulkan": "native",
      },
    },
    win: { bundleCEF: false },
  },
} satisfies ElectrobunConfig;
```

## Scenario

Our app creates a `BrowserWindow` at 1200x800. Hyprland tiles it to ~960x1040. Before this fix, the WebGPU canvas rendered at 1200x800 inside the 960x1040 window, creating a visible mismatch (content clipped/offset). After this fix, the CEF child window syncs to the tiled size within the first 5ms poll cycle, and `WasResized()` triggers a proper re-layout.

## Test plan

- [x] Tested on Arch Linux + Hyprland 0.54.0 (tiling WM) — window renders correctly on first open
- [x] Manual resize still works as before
- [x] No regressions on non-tiling setups (the size check is a no-op when parent size hasn't changed)