### PR TITLE
Add notification click callbacks with userInfo support

### DIFF
--- a/package/src/bun/core/Utils.ts
+++ b/package/src/bun/core/Utils.ts
@@ -78,6 +78,11 @@ export type NotificationOptions = {
 	 * If true, the notification will not play a sound
 	 */
 	silent?: boolean;
+	/**
+	 * Arbitrary serializable data attached to the notification.
+	 * Returned in the `notification-clicked` event when the user clicks the notification.
+	 */
+	userInfo?: Record<string, unknown>;
 };
 
 /**
@@ -88,35 +93,27 @@ export type NotificationOptions = {
  * @param options.body - The main body text
  * @param options.subtitle - A subtitle (macOS shows this between title and body)
  * @param options.silent - If true, no sound will be played
+ * @param options.userInfo - Arbitrary data returned in the `notification-clicked` event
  *
  * @example
  * // Simple notification
  * showNotification({ title: "Download Complete" });
  *
- * // Notification with body
+ * // Notification with userInfo for click handling
  * showNotification({
- *   title: "New Message",
- *   body: "You have a new message from John"
+ *   title: "Permission Required",
+ *   body: "Agent needs access to: /etc/hosts",
+ *   userInfo: { sessionId: "abc123", reason: "permission" },
  * });
  *
- * // Full notification
- * showNotification({
- *   title: "Reminder",
- *   subtitle: "Calendar Event",
- *   body: "Team meeting in 15 minutes",
- *   silent: false
- * });
- *
- * // Silent notification
- * showNotification({
- *   title: "Sync Complete",
- *   body: "All files have been synchronized",
- *   silent: true
+ * // Listen for notification clicks
+ * Electrobun.events.on("notification-clicked", (e) => {
+ *   console.log(e.data.userInfo); // { sessionId: "abc123", reason: "permission" }
  * });
  */
 export const showNotification = (options: NotificationOptions): void => {
-	const { title, body, subtitle, silent } = options;
-	ffi.request.showNotification({ title, body, subtitle, silent });
+	const { title, body, subtitle, silent, userInfo } = options;
+	ffi.request.showNotification({ title, body, subtitle, silent, userInfo });
 };
 
 let isQuitting = false;

--- a/package/src/bun/events/ApplicationEvents.ts
+++ b/package/src/bun/events/ApplicationEvents.ts
@@ -2,6 +2,7 @@ import ElectrobunEvent from "./event";
 
 type MenuClickedData = { id?: number; action: string; data?: unknown };
 type OpenUrlData = { url: string };
+type NotificationClickedData = { userInfo: Record<string, unknown> };
 
 export default {
 	applicationMenuClicked: (data: MenuClickedData) =>
@@ -16,6 +17,11 @@ export default {
 		),
 	openUrl: (data: OpenUrlData) =>
 		new ElectrobunEvent<OpenUrlData, void>("open-url", data),
+	notificationClicked: (data: NotificationClickedData) =>
+		new ElectrobunEvent<NotificationClickedData, void>(
+			"notification-clicked",
+			data,
+		),
 	reopen: (data: {}) => new ElectrobunEvent<{}, void>("reopen", data),
 	beforeQuit: (data: {}) =>
 		new ElectrobunEvent<{}, { allow: boolean }>("before-quit", data),

--- a/package/src/bun/proc/native.ts
+++ b/package/src/bun/proc/native.ts
@@ -508,7 +508,12 @@ export const native = (() => {
 					FFIType.cstring, // body
 					FFIType.cstring, // subtitle
 					FFIType.bool, // silent
+					FFIType.cstring, // userInfoJson
 				],
+				returns: FFIType.void,
+			},
+			setNotificationClickedHandler: {
+				args: [FFIType.function],
 				returns: FFIType.void,
 			},
 
@@ -1467,13 +1472,16 @@ window.__electrobunBunBridge = window.__electrobunBunBridge || window.webkit?.me
 			body?: string;
 			subtitle?: string;
 			silent?: boolean;
+			userInfo?: Record<string, unknown>;
 		}): void => {
-			const { title, body = "", subtitle = "", silent = false } = params;
+			const { title, body = "", subtitle = "", silent = false, userInfo } = params;
+			const userInfoJson = userInfo ? JSON.stringify(userInfo) : "";
 			native.symbols.showNotification(
 				toCString(title),
 				toCString(body),
 				toCString(subtitle),
 				silent,
+				toCString(userInfoJson),
 			);
 		},
 		setDockIconVisible: (params: { visible: boolean }): void => {
@@ -1935,6 +1943,32 @@ const urlOpenCallback = new JSCallback(
 // Register the URL open handler with native code (macOS only)
 if (process.platform === "darwin") {
 	native.symbols.setURLOpenHandler(urlOpenCallback);
+}
+
+// Notification click handler
+const notificationClickedCallback = new JSCallback(
+	(userInfoJsonPtr) => {
+		const userInfoJson = new CString(userInfoJsonPtr).toString();
+		let userInfo: Record<string, unknown> = {};
+		try {
+			userInfo = JSON.parse(userInfoJson);
+		} catch {
+			// ignore parse errors
+		}
+		const event = electrobunEventEmitter.events.app.notificationClicked({
+			userInfo,
+		});
+		electrobunEventEmitter.emitEvent(event);
+	},
+	{
+		args: [FFIType.cstring],
+		returns: "void",
+		threadsafe: true,
+	},
+);
+
+if (process.platform === "darwin") {
+	native.symbols.setNotificationClickedHandler(notificationClickedCallback);
 }
 
 const appReopenCallback = new JSCallback(

--- a/package/src/native/linux/nativeWrapper.cpp
+++ b/package/src/native/linux/nativeWrapper.cpp
@@ -8327,7 +8327,8 @@ ELECTROBUN_EXPORT bool openPath(const char* pathString) {
 }
 
 // Show a native desktop notification using notify-send
-void showNotification(const char* title, const char* body, const char* subtitle, bool silent) {
+void showNotification(const char* title, const char* body, const char* subtitle, bool silent, const char* userInfoJson) {
+    (void)userInfoJson; // Not yet used on Linux
     if (!title) {
         fprintf(stderr, "ERROR: NULL title passed to showNotification\n");
         return;
@@ -10877,6 +10878,11 @@ ELECTROBUN_EXPORT void setURLOpenHandler(void (*callback)(const char*)) {
 ELECTROBUN_EXPORT void setAppReopenHandler(void (*callback)()) {
     (void)callback;
     // Not supported on Linux - stub to prevent dlopen failure
+}
+
+ELECTROBUN_EXPORT void setNotificationClickedHandler(void (*callback)(const char*)) {
+    (void)callback;
+    // Not yet supported on Linux - stub to prevent dlopen failure
 }
 
 ELECTROBUN_EXPORT void setDockIconVisible(bool visible) {

--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -508,6 +508,7 @@ typedef StatusItemHandler ZigStatusItemHandler;
 static URLOpenHandler g_urlOpenHandler = nullptr;
 static AppReopenHandler g_appReopenHandler = nullptr;
 static QuitRequestedHandler g_quitRequestedHandler = nullptr;
+static NotificationClickedHandler g_notificationClickedHandler = nullptr;
 static std::atomic<bool> g_shutdownComplete{false};
 static std::atomic<bool> g_eventLoopStopping{false};
 
@@ -855,7 +856,7 @@ static NSMutableDictionary<NSNumber *, AbstractView *> *globalAbstractViews = ni
     }
 @end
 
-@interface AppDelegate : NSObject <NSApplicationDelegate>
+@interface AppDelegate : NSObject <NSApplicationDelegate, UNUserNotificationCenterDelegate>
 @end
 
 @interface WindowDelegate : NSObject <NSWindowDelegate>
@@ -6280,6 +6281,26 @@ CefRefPtr<CefRequestContext> CreateRequestContextForPartition(const char* partit
 
         return YES;
     }
+
+    // UNUserNotificationCenterDelegate - handle notification clicks
+    - (void)userNotificationCenter:(UNUserNotificationCenter *)center
+    didReceiveNotificationResponse:(UNNotificationResponse *)response
+             withCompletionHandler:(void (^)(void))completionHandler {
+        if (g_notificationClickedHandler) {
+            NSDictionary *userInfo = response.notification.request.content.userInfo;
+            NSData *jsonData = [NSJSONSerialization dataWithJSONObject:userInfo options:0 error:nil];
+            NSString *jsonString = jsonData ? [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding] : @"{}";
+            g_notificationClickedHandler([jsonString UTF8String]);
+        }
+        completionHandler();
+    }
+
+    // Show notifications while app is in foreground
+    - (void)userNotificationCenter:(UNUserNotificationCenter *)center
+           willPresentNotification:(UNNotification *)notification
+             withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
+        completionHandler(UNNotificationPresentationOptionBanner | UNNotificationPresentationOptionSound);
+    }
 @end
 
 @implementation WindowDelegate
@@ -7442,10 +7463,19 @@ static void showNotificationLegacy(NSString *titleStr, NSString *bodyStr, NSStri
     });
 }
 
-extern "C" void showNotification(const char *title, const char *body, const char *subtitle, BOOL silent) {
+extern "C" void showNotification(const char *title, const char *body, const char *subtitle, BOOL silent, const char *userInfoJson) {
     NSString *titleStr = [NSString stringWithUTF8String:title ?: ""];
     NSString *bodyStr = [NSString stringWithUTF8String:body ?: ""];
     NSString *subtitleStr = subtitle ? [NSString stringWithUTF8String:subtitle] : nil;
+
+    // Parse userInfo JSON if provided
+    NSDictionary *userInfo = nil;
+    if (userInfoJson && strlen(userInfoJson) > 0) {
+        NSData *jsonData = [[NSString stringWithUTF8String:userInfoJson] dataUsingEncoding:NSUTF8StringEncoding];
+        if (jsonData) {
+            userInfo = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:nil];
+        }
+    }
 
     // If we've already determined modern API doesn't work, use legacy
     if (!useModernNotifications) {
@@ -7458,6 +7488,12 @@ extern "C" void showNotification(const char *title, const char *body, const char
     // Request authorization if we haven't already
     if (!notificationAuthRequested) {
         notificationAuthRequested = YES;
+
+        // Set the delegate so we receive click callbacks
+        dispatch_async(dispatch_get_main_queue(), ^{
+            AppDelegate *appDelegate = (AppDelegate *)[NSApp delegate];
+            center.delegate = appDelegate;
+        });
 
         // Use a semaphore to wait for authorization result on first call
         dispatch_semaphore_t sem = dispatch_semaphore_create(0);
@@ -7496,6 +7532,9 @@ extern "C" void showNotification(const char *title, const char *body, const char
     }
     if (!silent) {
         content.sound = [UNNotificationSound defaultSound];
+    }
+    if (userInfo) {
+        content.userInfo = userInfo;
     }
 
     // Create a unique identifier for this notification
@@ -7771,6 +7810,10 @@ extern "C" void setURLOpenHandler(URLOpenHandler handler) {
 
 extern "C" void setAppReopenHandler(AppReopenHandler handler) {
     g_appReopenHandler = handler;
+}
+
+extern "C" void setNotificationClickedHandler(NotificationClickedHandler handler) {
+    g_notificationClickedHandler = handler;
 }
 
 extern "C" void setDockIconVisible(bool visible) {

--- a/package/src/native/shared/callbacks.h
+++ b/package/src/native/shared/callbacks.h
@@ -45,6 +45,10 @@ typedef void (*AppReopenHandler)();
 // (e.g., dock icon quit, system shutdown, console close)
 typedef void (*QuitRequestedHandler)();
 
+// Notification clicked handler - called when user clicks a notification
+// userInfoJson is a JSON string of the userInfo dict attached to the notification
+typedef void (*NotificationClickedHandler)(const char* userInfoJson);
+
 // JS Utils callbacks (DEPRECATED: Now using map-based approach instead)
 typedef const char* (*GetMimeType)(const char* filePath);
 typedef const char* (*GetHTMLForWebviewSync)(uint32_t webviewId);

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -9189,7 +9189,8 @@ ELECTROBUN_EXPORT BOOL openPath(const char *pathString) {
 }
 
 // Show a native desktop notification using Shell_NotifyIcon balloon
-ELECTROBUN_EXPORT void showNotification(const char *title, const char *body, const char *subtitle, BOOL silent) {
+ELECTROBUN_EXPORT void showNotification(const char *title, const char *body, const char *subtitle, BOOL silent, const char *userInfoJson) {
+    (void)userInfoJson; // Not yet used on Windows
     if (!title) {
         ::log("ERROR: NULL title passed to showNotification");
         return;
@@ -11523,6 +11524,12 @@ extern "C" ELECTROBUN_EXPORT void setURLOpenHandler(void (*callback)(const char*
 extern "C" ELECTROBUN_EXPORT void setAppReopenHandler(void (*callback)()) {
     (void)callback;
     // Not supported on Windows - stub to prevent dlopen failure
+}
+
+// Notification click handler - stub for Windows
+extern "C" ELECTROBUN_EXPORT void setNotificationClickedHandler(void (*callback)(const char*)) {
+    (void)callback;
+    // Not yet supported on Windows - stub to prevent dlopen failure
 }
 
 // Dock icon visibility - macOS only, stubs for Windows


### PR DESCRIPTION
## Summary
- Accept `userInfo` dict in `showNotification` options, passed through to `UNMutableNotificationContent.userInfo` on macOS
- Implement `UNUserNotificationCenterDelegate` on `AppDelegate` to capture notification clicks and route them back to Bun via FFI callback
- Emit `notification-clicked` event with `userInfo` from clicked notification
- Add `willPresentNotification` delegate to show notifications while app is in foreground
- Add stubs on Linux and Windows for the new native function signatures

## Usage

```typescript
// Send notification with userInfo
Utils.showNotification({
  title: "Permission Required",
  body: "Agent needs access to: /etc/hosts",
  userInfo: { sessionId: "abc123", reason: "permission" },
});

// Listen for clicks
Electrobun.events.on("notification-clicked", (e) => {
  console.log(e.data.userInfo); // { sessionId: "abc123", reason: "permission" }
});
```

Closes #306

## Test plan
- [ ] Verify `showNotification` still works without `userInfo` (backward compatible)
- [ ] Verify `showNotification` with `userInfo` delivers notification correctly
- [ ] Click notification and verify `notification-clicked` event fires with correct `userInfo`
- [ ] Verify notifications display while app is in foreground
- [ ] Verify Linux/Windows builds still compile with new function signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)