### PR TITLE
Add BrowserWindow.hide() with native hideWindow bindings

### DIFF
--- a/package/src/bun/core/BrowserWindow.ts
+++ b/package/src/bun/core/BrowserWindow.ts
@@ -271,6 +271,10 @@ export class BrowserWindow<T extends RPCWithTransport = RPCWithTransport> {
 		return ffi.request.focusWindow({ winId: this.id });
 	}
 
+	hide() {
+		return ffi.request.hideWindow({ winId: this.id });
+	}
+
 	minimize() {
 		return ffi.request.minimizeWindow({ winId: this.id });
 	}

--- a/package/src/bun/proc/native.ts
+++ b/package/src/bun/proc/native.ts
@@ -119,6 +119,10 @@ export const native = (() => {
 				],
 				returns: FFIType.void,
 			},
+			hideWindow: {
+				args: [FFIType.ptr],
+				returns: FFIType.void,
+			},
 			closeWindow: {
 				args: [
 					FFIType.ptr, // window ptr
@@ -860,6 +864,17 @@ export const ffi = {
 			}
 
 			native.symbols.showWindow(windowPtr);
+		},
+
+		hideWindow: (params: { winId: number }) => {
+			const { winId } = params;
+			const windowPtr = getWindowPtr(winId);
+
+			if (!windowPtr) {
+				throw `Can't hide window. Window no longer exists`;
+			}
+
+			native.symbols.hideWindow(windowPtr);
 		},
 
 		minimizeWindow: (params: { winId: number }) => {

--- a/package/src/native/linux/nativeWrapper.cpp
+++ b/package/src/native/linux/nativeWrapper.cpp
@@ -6340,6 +6340,30 @@ ELECTROBUN_EXPORT void showWindow(void* window) {
     }
 }
 
+void hideX11Window(void* window) {
+    dispatch_sync_main_void([&]() {
+        X11Window* x11win = static_cast<X11Window*>(window);
+        if (x11win && x11win->display && x11win->window) {
+            XUnmapWindow(x11win->display, x11win->window);
+            XFlush(x11win->display);
+        }
+    });
+}
+
+void hideGTKWindow(void* window) {
+    dispatch_sync_main_void([&]() {
+        gtk_widget_hide(GTK_WIDGET(window));
+    });
+}
+
+ELECTROBUN_EXPORT void hideWindow(void* window) {
+    if (isCEFAvailable()) {
+        hideX11Window(window);
+    } else {
+        hideGTKWindow(window);
+    }
+}
+
 // Cross-platform compatible function for Linux - return dummy style mask
 ELECTROBUN_EXPORT uint32_t getWindowStyle(bool borderless, bool titled, bool closable, bool miniaturizable,
                         bool resizable, bool unifiedTitleAndToolbar, bool fullScreen,

--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -7145,6 +7145,12 @@ extern "C" void showWindow(NSWindow *window) {
     });
 }
 
+extern "C" void hideWindow(NSWindow *window) {
+    dispatch_sync(dispatch_get_main_queue(), ^{
+        [window orderOut:nil];
+    });
+}
+
 extern "C" void setWindowTitle(NSWindow *window, const char *title) {
     NSString *titleString = [NSString stringWithUTF8String:title ?: ""];
 

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -8662,6 +8662,19 @@ ELECTROBUN_EXPORT void showWindow(void *window) {
     });
 }
 
+ELECTROBUN_EXPORT void hideWindow(void *window) {
+    HWND hwnd = reinterpret_cast<HWND>(window);
+
+    if (!IsWindow(hwnd)) {
+        ::log("ERROR: Invalid window handle in hideWindow");
+        return;
+    }
+
+    MainThreadDispatcher::dispatch_sync([=]() {
+        ShowWindow(hwnd, SW_HIDE);
+    });
+}
+
 ELECTROBUN_EXPORT void setWindowTitle(NSWindow *window, const char *title) {
     // On Windows, NSWindow* is actually HWND
     HWND hwnd = reinterpret_cast<HWND>(window);


### PR DESCRIPTION
## Summary
- add `BrowserWindow.hide()` as a first-class API alongside existing window controls
- wire a new `hideWindow` FFI symbol + request handler in Bun runtime
- implement native `hideWindow` on macOS (`orderOut:`), Windows (`SW_HIDE`), and Linux (`XUnmapWindow` / `gtk_widget_hide`)

## Test plan
- [x] verify `BrowserWindow.hide()` calls the new request path
- [x] confirm each native wrapper exports `hideWindow`
- [ ] run kitchen/manual smoke checks for show/hide behavior on each supported OS