### PR TITLE
fix: explicitly resolve rcedit from dependency tree for Windows packaging

### DIFF
--- a/package/src/cli/index.ts
+++ b/package/src/cli/index.ts
@@ -2163,10 +2163,12 @@ Categories=Utility;Application;
 					}
 
 					// Use rcedit to embed the icon into launcher.exe
-					const rcedit = (await import("rcedit")).default;
-					await rcedit(bunCliLauncherDestination, {
-						icon: iconPath,
-					});
+										const { execFileSync } = await import("child_process");
+					const rceditPkgPath = require.resolve("rcedit/package.json");
+					const rceditDir = dirname(rceditPkgPath);
+					const rceditX64 = join(rceditDir, "bin", "rcedit-x64.exe");
+					const rceditExe = existsSync(rceditX64) ? rceditX64 : join(rceditDir, "bin", "rcedit.exe");
+					execFileSync(rceditExe, [bunCliLauncherDestination, "--set-icon", iconPath]);
 					console.log(`Successfully embedded icon into launcher.exe`);
 
 					// Clean up temp ICO file
@@ -2259,10 +2261,12 @@ Categories=Utility;Application;
 					}
 
 					// Use rcedit to embed the icon into bun.exe
-					const rcedit = (await import("rcedit")).default;
-					await rcedit(bunBinaryDestInBundlePath, {
-						icon: iconPath,
-					});
+										const { execFileSync } = await import("child_process");
+					const rceditPkgPath = require.resolve("rcedit/package.json");
+					const rceditDir = dirname(rceditPkgPath);
+					const rceditX64 = join(rceditDir, "bin", "rcedit-x64.exe");
+					const rceditExe = existsSync(rceditX64) ? rceditX64 : join(rceditDir, "bin", "rcedit.exe");
+					execFileSync(rceditExe, [bunBinaryDestInBundlePath, "--set-icon", iconPath]);
 					console.log(`Successfully embedded icon into bun.exe`);
 
 					// Clean up temp ICO file
@@ -4305,10 +4309,12 @@ Categories=Utility;Application;
 					}
 
 					// Use rcedit to embed the icon
-					const rcedit = (await import("rcedit")).default;
-					await rcedit(outputExePath, {
-						icon: iconPath,
-					});
+										const { execFileSync } = await import("child_process");
+					const rceditPkgPath = require.resolve("rcedit/package.json");
+					const rceditDir = dirname(rceditPkgPath);
+					const rceditX64 = join(rceditDir, "bin", "rcedit-x64.exe");
+					const rceditExe = existsSync(rceditX64) ? rceditX64 : join(rceditDir, "bin", "rcedit.exe");
+					execFileSync(rceditExe, [outputExePath, "--set-icon", iconPath]);
 					console.log(`Successfully embedded icon into ${setupFileName}`);
 
 					// Clean up temp ICO file


### PR DESCRIPTION
## Summary
Resolves `rcedit` explicitly to avoid falling back to the baked CI path during Windows packaging.

## Problem
Closes #298
When running `electrobun build` for Windows, it tries to execute `rcedit` from a baked CI path like `D:\a\electrobun\electrobun\package\node_modules\rcedit\bin\rcedit-x64.exe`, which fails on local environments.

## Solution
Replaced `await import("rcedit")` in `src/cli/index.ts` with explicit local dependency resolution:
- Resolves `rcedit/package.json` using `require.resolve`.
- Selects `rcedit-x64.exe` if available, falling back to `rcedit.exe`.
- Executes it via `execFileSync`.

## Testing
- Code modifications mirror the proposed fix in the issue closely.