### PR TITLE
fix: export the RESOURCES_FOLDER

### DIFF
--- a/package/src/bun/core/Paths.ts
+++ b/package/src/bun/core/Paths.ts
@@ -1,5 +1,5 @@
 import { resolve } from "path";
 
-const RESOURCES_FOLDER = resolve("../Resources/");
+export const RESOURCES_FOLDER = resolve("../Resources/");
 
 export const VIEWS_FOLDER = resolve(RESOURCES_FOLDER, "app/views");


### PR DESCRIPTION
When I look at the official website, found that there is this field, but the code is not, so increase the export
<img width="759" height="506" alt="image" src="https://github.com/user-attachments/assets/cfad3e74-3d07-42f2-a825-717a5ef7eba5" />
