### PR TITLE
fix: resolve electrobun package dir via require.resolve for Yarn PnP support

### DIFF
--- a/package/src/cli/index.ts
+++ b/package/src/cli/index.ts
@@ -74,17 +74,27 @@ const indexOfElectrobun = process.argv.findIndex((arg) =>
 );
 const commandArg = process.argv[indexOfElectrobun + 1] || "build";
 
-// Walk up from projectRoot to find electrobun in node_modules (supports hoisted monorepo layouts)
+// Resolve the electrobun package directory using Node's module resolution first
+// (works with any package manager: npm, pnpm, Yarn PnP, Bun, etc.),
+// then fall back to walking node_modules for hoisted monorepo layouts.
 function resolveElectrobunDir(): string {
-	let dir = projectRoot;
-	while (dir !== dirname(dir)) {
-		const candidate = join(dir, "node_modules", "electrobun");
-		if (existsSync(join(candidate, "package.json"))) {
-			return candidate;
+	try {
+		const entryPoint = require.resolve("electrobun/package.json", {
+			paths: [projectRoot],
+		});
+		return dirname(entryPoint);
+	} catch {
+		// Fallback: walk up from projectRoot to find electrobun in node_modules
+		let dir = projectRoot;
+		while (dir !== dirname(dir)) {
+			const candidate = join(dir, "node_modules", "electrobun");
+			if (existsSync(join(candidate, "package.json"))) {
+				return candidate;
+			}
+			dir = dirname(dir);
 		}
-		dir = dirname(dir);
+		return join(projectRoot, "node_modules", "electrobun");
 	}
-	return join(projectRoot, "node_modules", "electrobun");
 }
 
 const ELECTROBUN_DEP_PATH = resolveElectrobunDir();


### PR DESCRIPTION
## Summary

- `resolveElectrobunDir()` now uses `require.resolve("electrobun/package.json")` as the primary resolution strategy, which works with any package manager (npm, pnpm, Yarn PnP, Bun)
- The original `node_modules` directory-walking logic is preserved as a fallback for backwards compatibility

## Problem

The CLI assumes a `node_modules` directory layout to locate the electrobun package directory. This breaks under Yarn Plug'n'Play (PnP) where there is no `node_modules` directory:

- **Without `yarn unplug`:** `ELECTROBUN_DEP_PATH` resolves to a non-existent path
- **With `yarn unplug`:** the unplugged copy lives in `.yarn/unplugged/`, not in any ancestor's `node_modules/`

## Solution

Use Node's `require.resolve` with the `paths` option to find the package, which delegates to whatever resolution strategy the package manager provides. This is a single-function change with no new dependencies.

> **Note:** The `ELECTROBUN_CACHE_PATH` (currently placed as a sibling of the package directory) may still be in a read-only location under full Yarn PnP mode. That's a separate concern I'd be happy to address in a follow-up PR if desired.

## Test plan

- [ ] Verify `bun dev` still works from the `package/` folder (npm/bun layout)
- [ ] Verify `electrobun build` works in a Yarn PnP project with `yarn unplug electrobun`

🤖 Generated with [Claude Code](https://claude.com/claude-code)