### PR TITLE
fix(webgpu): remove makeSurfaceTexture duplicate definition

### DIFF
--- a/package/src/bun/webgpuAdapter.ts
+++ b/package/src/bun/webgpuAdapter.ts
@@ -811,11 +811,6 @@ function makeCommandBufferArray(cmdPtr: number) {
 	return { buffer, ptr: ptr(buffer) };
 }
 
-function makeSurfaceTexture() {
-	const buffer = new ArrayBuffer(24);
-	return { buffer, view: new DataView(buffer), ptr: ptr(buffer) };
-}
-
 function makeSurfaceCapabilities() {
 	const buffer = new ArrayBuffer(64);
 	const view = new DataView(buffer);


### PR DESCRIPTION
# Issue 
- Bundling error due to duplicate definitions of makeSurfaceTexture. 

# Solution
- Removed the duplicate `makeSurfaceTexture`  function 