### PR TITLE
fix: resolve rcedit path at runtime to fix ENOENT on Windows

### DIFF
--- a/package/src/cli/index.ts
+++ b/package/src/cli/index.ts
@@ -40,6 +40,41 @@ const _MAX_CHUNK_SIZE = 1024 * 2;
 
 // const binExt = OS === 'win' ? '.exe' : '';
 
+
+/**
+ * Embeds a Windows icon into an EXE using rcedit.
+ *
+ * When the CLI is compiled with `bun build --compile`, dynamic `import("rcedit")`
+ * freezes __dirname to the *build-machine* path (e.g. D:\... on GitHub Actions)
+ * rather than the runtime machine's path, causing ENOENT on any developer machine.
+ * We instead locate rcedit-x64.exe at runtime relative to process.execPath (the
+ * running electrobun binary), which is always a sibling package in node_modules.
+ *
+ * Layout:
+ *   <project>/node_modules/electrobun/bin/electrobun.exe  <- process.execPath
+ *   <project>/node_modules/rcedit/bin/rcedit-x64.exe      <- resolved here
+ */
+function spawnRcedit(exePath: string, iconPath: string): void {
+	const rceditExe = process.arch === "x64" ? "rcedit-x64.exe" : "rcedit.exe";
+	const rceditPath = join(
+		dirname(process.execPath),
+		"..",
+		"..",
+		"rcedit",
+		"bin",
+		rceditExe,
+	);
+	if (!existsSync(rceditPath)) {
+		throw new Error(
+			`rcedit binary not found at ${rceditPath}. ` +
+				`Make sure 'rcedit' is installed in your project's node_modules.`,
+		);
+	}
+	execSync(`"${rceditPath}" "${exePath}" --set-icon "${iconPath}"`, {
+		stdio: "pipe",
+	});
+}
+
 // Create a tar file using system tar command (preserves file permissions unlike Bun.Archive)
 function createTar(tarPath: string, cwd: string, entries: string[]) {
 	// Use a relative path for the tar output on Windows to avoid bsdtar
@@ -2163,10 +2198,7 @@ Categories=Utility;Application;
 					}
 
 					// Use rcedit to embed the icon into launcher.exe
-					const rcedit = (await import("rcedit")).default;
-					await rcedit(bunCliLauncherDestination, {
-						icon: iconPath,
-					});
+					spawnRcedit(bunCliLauncherDestination, iconPath);
 					console.log(`Successfully embedded icon into launcher.exe`);
 
 					// Clean up temp ICO file
@@ -2259,10 +2291,7 @@ Categories=Utility;Application;
 					}
 
 					// Use rcedit to embed the icon into bun.exe
-					const rcedit = (await import("rcedit")).default;
-					await rcedit(bunBinaryDestInBundlePath, {
-						icon: iconPath,
-					});
+					spawnRcedit(bunBinaryDestInBundlePath, iconPath);
 					console.log(`Successfully embedded icon into bun.exe`);
 
 					// Clean up temp ICO file
@@ -4305,10 +4334,7 @@ Categories=Utility;Application;
 					}
 
 					// Use rcedit to embed the icon
-					const rcedit = (await import("rcedit")).default;
-					await rcedit(outputExePath, {
-						icon: iconPath,
-					});
+					spawnRcedit(outputExePath, iconPath);
 					console.log(`Successfully embedded icon into ${setupFileName}`);
 
 					// Clean up temp ICO file


### PR DESCRIPTION
## Problem

When `electrobun dev` or `electrobun build` runs on Windows and the project has a Windows icon configured, icon embedding into `launcher.exe`, `bun.exe`, and the installer EXE silently fails with:

```
Warning: Failed to embed icon into launcher.exe: Error: Error executing command (D:\a\electrobun\electrobun\package\node_modules\rcedit\bin\rcedit-x64.exe ...):
spawn D:\a\electrobun\electrobun\package\node_modules\rcedit\bin\rcedit-x64.exe ENOENT
The system cannot find the drive specified.
```

**Root cause:** The CLI binary is compiled with `bun build --compile` on the GitHub Actions runner whose workspace is `D:\a\electrobun\`. Bun's compiler freezes `__dirname` (inside the bundled `rcedit` CJS module) to that build-machine path. On any developer machine without a `D:\` drive, `path.resolve(__dirname, '..', 'bin', 'rcedit-x64.exe')` resolves to a non-existent path.

## Fix

Replace all three `await import("rcedit")` call sites with a new `spawnRcedit()` helper that resolves the `rcedit-x64.exe` path at **runtime** using `process.execPath`:

```
dirname(process.execPath)/../../rcedit/bin/rcedit-x64.exe
```

Since `electrobun.exe` and `rcedit` are always sibling packages in the consuming project's `node_modules/`, this path is correct at runtime on any machine, regardless of where the binary was compiled.

## Affected call sites

- Icon embedding into `launcher.exe` (~line 2166)
- Icon embedding into `bun.exe` (~line 2263)  
- Icon embedding into the Windows installer EXE (~line 4310)

## Testing

Verified by reproducing the `ENOENT` locally (no `D:\` drive) and confirming all three call sites now correctly resolve to the local `node_modules/rcedit/bin/rcedit-x64.exe`.