### PR TITLE
fix: export RESOURCES_FOLDER from Paths module

### DIFF
--- a/package/src/bun/core/Paths.ts
+++ b/package/src/bun/core/Paths.ts
@@ -1,5 +1,5 @@
 import { resolve } from "path";
 
-const RESOURCES_FOLDER = resolve("../Resources/");
+export const RESOURCES_FOLDER = resolve("../Resources/");
 
 export const VIEWS_FOLDER = resolve(RESOURCES_FOLDER, "app/views");


### PR DESCRIPTION
[38;5;238m─────┬──────────────────────────────────────────────────────────────────────────[0m
[38;5;238m   1[0m [38;5;238m│[0m [38;2;255;255;255m## Summary[0m
[38;5;238m   2[0m [38;5;238m│[0m 
[38;5;238m   3[0m [38;5;238m│[0m [38;2;255;255;255m- Adds `export` to `RESOURCES_FOLDER` in `package/src/bun/core/Paths.ts` so it's accessible via `Electrobun.PATHS.RESOURCES_FOLDER`[0m
[38;5;238m   4[0m [38;5;238m│[0m [38;2;255;255;255m- The constant was defined but not exported, making it `undefined` when accessed through the existing `import *` re-export in `index.ts`[0m
[38;5;238m   5[0m [38;5;238m│[0m [38;2;255;255;255m- One-word change: `const` → `export const`[0m
[38;5;238m   6[0m [38;5;238m│[0m 
[38;5;238m   7[0m [38;5;238m│[0m [38;2;255;255;255mFixes #321[0m
[38;5;238m─────┴──────────────────────────────────────────────────────────────────────────[0m