### PR TITLE
fix: rename getLocallocalInfo to getLocalInfo (typo)

### DIFF
--- a/kitchen/src/bun/index.ts
+++ b/kitchen/src/bun/index.ts
@@ -78,7 +78,7 @@ const saveTestRunnerPreferences = async (
 };
 
 // Update state
-const localInfo = await Updater.getLocallocalInfo();
+const localInfo = await Updater.getLocalInfo();
 let updateState: UpdateInfo = {
 	status: "checking",
 	currentVersion: localInfo.version,

--- a/package/src/bun/core/Updater.ts
+++ b/package/src/bun/core/Updater.ts
@@ -179,7 +179,7 @@ const Updater = {
 	// todo: allow switching channels, by default will check the current channel
 	checkForUpdate: async () => {
 		emitStatus("checking", "Checking for updates...");
-		const localInfo = await Updater.getLocallocalInfo();
+		const localInfo = await Updater.getLocalInfo();
 
 		if (localInfo.channel === "dev") {
 			emitStatus("no-update", "Dev channel - updates disabled", {
@@ -283,7 +283,7 @@ const Updater = {
 		await Updater.channelBucketUrl(); // Ensure localInfo is loaded
 		const appFileName = localInfo.name;
 
-		let currentHash = (await Updater.getLocallocalInfo()).hash;
+		let currentHash = (await Updater.getLocalInfo()).hash;
 		let latestHash = (await Updater.checkForUpdate()).hash;
 
 		const extractionFolder = join(appDataFolder, "self-extraction");
@@ -1074,14 +1074,14 @@ del "%~f0"
 	},
 
 	channelBucketUrl: async () => {
-		await Updater.getLocallocalInfo();
+		await Updater.getLocalInfo();
 		// With flat prefix-based naming, channelBucketUrl is just the baseUrl
 		// Users can also use Updater.localInfo.baseUrl() directly
 		return localInfo.baseUrl;
 	},
 
 	appDataFolder: async () => {
-		await Updater.getLocallocalInfo();
+		await Updater.getLocalInfo();
 		// Use identifier + channel for the app data folder
 		// e.g., ~/Library/Application Support/sh.blackboard.myapp/canary/
 		const appDataFolder = join(
@@ -1096,20 +1096,20 @@ del "%~f0"
 	// TODO: consider moving this from "Updater.localInfo" to "BuildVars"
 	localInfo: {
 		version: async () => {
-			return (await Updater.getLocallocalInfo()).version;
+			return (await Updater.getLocalInfo()).version;
 		},
 		hash: async () => {
-			return (await Updater.getLocallocalInfo()).hash;
+			return (await Updater.getLocalInfo()).hash;
 		},
 		channel: async () => {
-			return (await Updater.getLocallocalInfo()).channel;
+			return (await Updater.getLocalInfo()).channel;
 		},
 		baseUrl: async () => {
-			return (await Updater.getLocallocalInfo()).baseUrl;
+			return (await Updater.getLocalInfo()).baseUrl;
 		},
 	},
 
-	getLocallocalInfo: async () => {
+	getLocalInfo: async () => {
 		if (localInfo) {
 			return localInfo;
 		}


### PR DESCRIPTION
[38;5;238m─────┬──────────────────────────────────────────────────────────────────────────[0m
[38;5;238m   1[0m [38;5;238m│[0m [38;2;255;255;255m## Summary[0m
[38;5;238m   2[0m [38;5;238m│[0m 
[38;5;238m   3[0m [38;5;238m│[0m [38;2;255;255;255m- Renames `getLocallocalInfo` (double "local" typo) to `getLocalInfo` to match the documented API name[0m
[38;5;238m   4[0m [38;5;238m│[0m [38;2;255;255;255m- Updates all 10 call sites: 9 in `package/src/bun/core/Updater.ts` + 1 in `kitchen/src/bun/index.ts`[0m
[38;5;238m   5[0m [38;5;238m│[0m [38;2;255;255;255m- This is a **breaking change** for anyone using the typo'd name directly, but aligns with what the docs already say[0m
[38;5;238m   6[0m [38;5;238m│[0m 
[38;5;238m   7[0m [38;5;238m│[0m [38;2;255;255;255mFixes #254[0m
[38;5;238m─────┴──────────────────────────────────────────────────────────────────────────[0m