### PR TITLE
feat: add NSIS and MSI installer support for Windows

### DIFF
--- a/kitchen/bun.lock
+++ b/kitchen/bun.lock
@@ -1,6 +1,6 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
+  "configVersion": 1,
   "workspaces": {
     "": {
       "dependencies": {
@@ -12,8 +12,100 @@
     },
   },
   "packages": {
-    "electrobun": ["electrobun@file:../package", { "devDependencies": { "typescript": "^5.9.3" }, "bin": "bin/electrobun.cjs" }],
+    "@babylonjs/core": ["@babylonjs/core@7.54.3", "", {}, "sha512-P5ncXVd8GEUJLhwloP9V0oVwQYIrvZztguVeLlvd5Rx+9aQnenKjpV8auJ6SRsUlAmNZU4pFTKzwF6o2EUfhAw=="],
+
+    "@malept/cross-spawn-promise": ["@malept/cross-spawn-promise@1.1.1", "", { "dependencies": { "cross-spawn": "^7.0.1" } }, "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ=="],
+
+    "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
+
+    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
+    "@types/node": ["@types/node@17.0.45", "", {}, "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
+
+    "basic-ftp": ["basic-ftp@5.2.0", "", {}, "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw=="],
+
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "cross-spawn-windows-exe": ["cross-spawn-windows-exe@1.2.0", "", { "dependencies": { "@malept/cross-spawn-promise": "^1.1.0", "is-wsl": "^2.2.0", "which": "^2.0.2" } }, "sha512-mkLtJJcYbDCxEG7Js6eUnUNndWjyUZwJ3H7bErmmtOYU/Zb99DyUkpamuIZE0b3bhmJyZ7D90uS6f+CGxRRjOw=="],
+
+    "data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
+
+    "electrobun": ["electrobun@file:../package", { "dependencies": { "@babylonjs/core": "^7.45.0", "@types/bun": "^1.3.8", "png-to-ico": "^2.1.8", "proxy-agent": "^6.5.0", "rcedit": "^4.0.1", "three": "^0.165.0" }, "devDependencies": { "typescript": "^5.9.3" }, "bin": { "electrobun": "./bin/electrobun.cjs" } }],
+
+    "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
+
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
+    "is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
+
+    "is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "netmask": ["netmask@2.0.2", "", {}, "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="],
+
+    "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
+
+    "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "png-to-ico": ["png-to-ico@2.1.8", "", { "dependencies": { "@types/node": "^17.0.36", "minimist": "^1.2.6", "pngjs": "^6.0.0" }, "bin": { "png-to-ico": "bin/cli.js" } }, "sha512-Nf+IIn/cZ/DIZVdGveJp86NG5uNib1ZXMiDd/8x32HCTeKSvgpyg6D/6tUBn1QO/zybzoMK0/mc3QRgAyXdv9w=="],
+
+    "pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
+
+    "proxy-agent": ["proxy-agent@6.5.0", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.6", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.1.0", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.5" } }, "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
+    "rcedit": ["rcedit@4.0.1", "", { "dependencies": { "cross-spawn-windows-exe": "^1.1.0" } }, "sha512-bZdaQi34krFWhrDn+O53ccBDw0MkAT2Vhu75SqhtvhQu4OPyFM4RoVheyYiVQYdjhUi6EJMVWQ0tR6bCIYVkUg=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
+    "socks": ["socks@2.8.7", "", { "dependencies": { "ip-address": "^10.0.1", "smart-buffer": "^4.2.0" } }, "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A=="],
+
+    "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "three": ["three@0.165.0", "", {}, "sha512-cc96IlVYGydeceu0e5xq70H8/yoVT/tXBxV/W8A/U6uOq7DXc4/s1Mkmnu6SqoYGhSRWWYFOhVwvq6V0VtbplA=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
   }
 }

--- a/kitchen/electrobun.config.ts
+++ b/kitchen/electrobun.config.ts
@@ -184,6 +184,28 @@ export default {
 				// "show-composited-layer-borders": true,
 				"user-agent": "BarkusAurelius/1.0 (Macintosh; powered by bunnies)",
 			},
+			nsis: {
+				enabled: true,
+				// enabled: true,               // default: true
+				// installMode: "currentUser",  // "currentUser" | "perMachine"
+				// allowDowngrades: false,
+				// publisher: "Blackboard Inc.",
+				// homepage: "https://electrobun.dev",
+				// desktopShortcut: true,
+				// startMenuFolder: "Electrobun Kitchen Sink",
+				// appDataPaths: ["sh.blackboard.electrobun-kitchen"],
+			},
+			msi: {
+				// enabled: true,                          // default: true
+				// publisher: "Blackboard Inc.",
+				// upgradeCode: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", // stable GUID; auto-derived if omitted
+				// installMode: "currentUser",             // "currentUser" | "perMachine"
+				// allowDowngrades: false,
+				// desktopShortcut: true,
+				// startMenuFolder: "Electrobun Kitchen Sink",
+				// additionalCandleArgs: [],
+				// additionalLightArgs: [],
+			},
 		},
 	},
 	scripts: {

--- a/kitchen/package-lock.json
+++ b/kitchen/package-lock.json
@@ -13,13 +13,13 @@
 		},
 		"../package": {
 			"name": "electrobun",
-			"version": "1.14.5-beta.0",
+			"version": "1.16.0",
 			"license": "MIT",
 			"dependencies": {
 				"@babylonjs/core": "^7.45.0",
 				"@types/bun": "^1.3.8",
-				"archiver": "^7.0.1",
 				"png-to-ico": "^2.1.8",
+				"proxy-agent": "^6.5.0",
 				"rcedit": "^4.0.1",
 				"three": "^0.165.0"
 			},
@@ -27,7 +27,6 @@
 				"electrobun": "bin/electrobun.cjs"
 			},
 			"devDependencies": {
-				"@types/archiver": "^6.0.3",
 				"typescript": "^5.9.3"
 			}
 		},

--- a/package/bin/electrobun.cjs
+++ b/package/bin/electrobun.cjs
@@ -97,8 +97,11 @@ async function ensureCliBinary() {
     // Download tarball
     await downloadFile(tarballUrl, tarballPath);
 
-    // Extract using system tar (available on macOS, Linux, and Windows 10+)
-    execSync(`tar -xzf "${tarballPath}"`, { cwd: cacheDir, stdio: 'pipe' });
+    // Extract using system tar (available on macOS, Linux, and Windows 10+).
+    // Use basename only: cwd is set to cacheDir, and tar on Windows (Git Bash)
+    // interprets absolute Windows paths like "C:\..." as remote URLs.
+    const tarballFilename = require('path').basename(tarballPath);
+    execSync(`tar -xzf "${tarballFilename}"`, { cwd: cacheDir, stdio: 'pipe' });
 
     // Clean up tarball
     unlinkSync(tarballPath);

--- a/package/build.ts
+++ b/package/build.ts
@@ -127,6 +127,7 @@ try {
 
 // Global variables to store build tool paths
 var CMAKE_BIN = "cmake";
+var VS_CMAKE_GENERATOR = "Visual Studio 17 2022";
 
 async function vendorCmake() {
 	if (OS !== "macos") return;
@@ -237,6 +238,27 @@ async function findMsvcTools() {
 			console.log("vcvarsall.bat not found at expected location");
 			VCVARSALL_PATH = "";
 			return;
+		}
+
+		// Detect VS version to pick the correct CMake generator
+		try {
+			const vsVersionResult =
+				await $`powershell -command "& '${vswherePath}' -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationVersion"`.quiet();
+			const versionStr = vsVersionResult.stdout.toString().trim();
+			const majorVersion = parseInt(versionStr.split(".")[0], 10);
+			const generatorMap: Record<number, string> = {
+				14: "Visual Studio 14 2015",
+				15: "Visual Studio 15 2017",
+				16: "Visual Studio 16 2019",
+				17: "Visual Studio 17 2022",
+				18: "Visual Studio 18 2026",
+			};
+			if (generatorMap[majorVersion]) {
+				VS_CMAKE_GENERATOR = generatorMap[majorVersion];
+				console.log(`✓ Detected VS generator: ${VS_CMAKE_GENERATOR}`);
+			}
+		} catch {
+			console.log("Could not detect VS version, using default CMake generator");
 		}
 
 		console.log("✓ Found MSVC tools with vcvarsall.bat");
@@ -534,7 +556,10 @@ async function copyToDist() {
 	await $`cp ${PATH.bun.RUNTIME} ${PATH.bun.DIST}`;
 	// Zig launcher for all platforms
 	await $`cp src/launcher/zig-out/bin/launcher${binExt} dist/launcher${binExt}`;
-	await $`cp src/extractor/zig-out/bin/extractor${binExt} dist/extractor${binExt}`;
+	// Extractor is only built for macOS/Linux release builds.
+	if (OS !== "win" && CHANNEL !== "debug") {
+		await $`cp src/extractor/zig-out/bin/extractor${binExt} dist/extractor${binExt}`;
+	}
 	// Copy bsdiff/bspatch from vendored zig-bsdiff
 	await $`cp vendors/zig-bsdiff/bsdiff${binExt} dist/bsdiff${binExt}`;
 	await $`cp vendors/zig-bsdiff/bspatch${binExt} dist/bspatch${binExt}`;
@@ -1209,8 +1234,14 @@ async function vendorAsar() {
 			// Validate download
 			validateDownload(tempTarball, "zig-asar");
 
-			// Extract to architecture-specific directory
-			await $`tar -xzf "${tempTarball}" -C "${asarDir}"`;
+			// Extract to architecture-specific directory.
+			// On Windows, Git Bash's tar cannot handle absolute Windows paths in -C
+			// (it interprets "C:" as a remote hostname).  Convert to Unix-style path.
+			const tarExtractDir =
+				OS === "win"
+					? asarDir.replace(/\\/g, "/").replace(/^([A-Za-z]):/, "/$1")
+					: asarDir;
+			await $`tar -xzf "${tempTarball}" -C "${tarExtractDir}"`;
 
 			// Clean up temp file
 			await $`rm "${tempTarball}"`;
@@ -1520,7 +1551,7 @@ async function vendorCEF() {
 			await $`cd vendors/cef && powershell -command "if (Test-Path build) { Remove-Item -Recurse -Force build }"`;
 			await $`cd vendors/cef && mkdir build`;
 			// Generate Visual Studio project with sandbox disabled
-			await $`cd vendors/cef/build && "${CMAKE_BIN}" -G "Visual Studio 17 2022" -A x64 -DCEF_USE_SANDBOX=OFF -DCMAKE_BUILD_TYPE=Release ..`;
+			await $`cd vendors/cef/build && "${CMAKE_BIN}" -G "${VS_CMAKE_GENERATOR}" -A x64 -DCEF_USE_SANDBOX=OFF -DCMAKE_BUILD_TYPE=Release ..`;
 			// Build the wrapper library only
 			// await $`cd vendors/cef/build && msbuild cef.sln /p:Configuration=Release /p:Platform=x64 /target:libcef_dll_wrapper`;
 			// const msbuildPath = await $`"C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vswhere.exe" -latest -requires Microsoft.Component.MSBuild -find MSBuild\\**\\Bin\\MSBuild.exe | head -n 1`.text();
@@ -2058,18 +2089,14 @@ async function buildMainJs() {
 }
 
 async function buildSelfExtractor() {
-	const zigArgs =
-		OS === "win"
-			? ["-Dtarget=x86_64-windows", "-Dcpu=baseline"]
-			: ARCH === "x64"
-				? ["-Dcpu=baseline"]
-				: [];
+	// Extractor is only used during release builds (macOS self-extracting .app,
+	// Linux self-extracting installer). It is never referenced by `electrobun dev`,
+	// and Windows uses the NSIS/WiX installer pipeline instead.
+	if (OS === "win" || CHANNEL === "debug") return;
 
-	if (CHANNEL === "debug") {
-		await $`cd src/extractor && ../../vendors/zig/zig build ${zigArgs}`;
-	} else if (CHANNEL === "release") {
-		await $`cd src/extractor && ../../vendors/zig/zig build -Doptimize=ReleaseSmall ${zigArgs}`;
-	}
+	const zigArgs = ARCH === "x64" ? ["-Dcpu=baseline"] : [];
+
+	await $`cd src/extractor && ../../vendors/zig/zig build -Doptimize=ReleaseSmall ${zigArgs}`;
 }
 
 async function buildCli() {

--- a/package/src/bun/ElectrobunConfig.ts
+++ b/package/src/bun/ElectrobunConfig.ts
@@ -323,13 +323,172 @@ export interface ElectrobunConfig {
 			 */
 			chromiumFlags?: Record<string, string | boolean>;
 
-			/**
-			 * Path to application icon (.ico format)
-			 * Used for the installer/extractor wrapper, desktop shortcuts, and taskbar
-			 * Should include multiple sizes (16x16, 32x32, 48x48, 256x256) for best results
-			 * @example "assets/icon.ico"
-			 */
+		/**
+		 * Path to application icon (.ico format)
+		 * Used for the installer/extractor wrapper, desktop shortcuts, and taskbar
+		 * Should include multiple sizes (16x16, 32x32, 48x48, 256x256) for best results
+		 * @example "assets/icon.ico"
+		 */
 			icon?: string;
+
+			/**
+			 * NSIS .exe installer settings.
+			 * Electrobun auto-downloads NSIS if makensis is not found on PATH.
+			 */
+			nsis?: {
+				/**
+				 * Generate a NSIS installer during non-dev Windows builds.
+				 * @default true
+				 */
+				enabled?: boolean;
+
+				/**
+				 * Whether to install for the current user only or for all users.
+				 * "perMachine" requires the installer to run as Administrator.
+				 * @default "currentUser"
+				 */
+				installMode?: "currentUser" | "perMachine";
+
+				/**
+				 * Allow installing an older version over a newer one without
+				 * prompting the user to uninstall first.
+				 * @default false
+				 */
+				allowDowngrades?: boolean;
+
+				/**
+				 * Publisher / company name shown in Add/Remove Programs.
+				 * @default config.app.name
+				 */
+				publisher?: string;
+
+				/**
+				 * Homepage URL shown in Add/Remove Programs.
+				 */
+				homepage?: string;
+
+				/**
+				 * Create a desktop shortcut during install.
+				 * @default true
+				 */
+				desktopShortcut?: boolean;
+
+				/**
+				 * Start Menu folder name.
+				 * @default config.app.name
+				 */
+				startMenuFolder?: string;
+
+				/**
+				 * Paths relative to %LOCALAPPDATA% that the uninstaller will offer
+				 * to delete when the user checks "Also delete application data".
+				 * Wallet / credential data should NOT be listed here.
+				 *
+				 * @example ["MyApp", "MyApp\\Cache"]
+				 */
+				appDataPaths?: string[];
+			};
+
+			/**
+			 * WiX v3 .msi installer settings.
+			 * Produces a native Windows Installer package for GPO / SCCM / Intune.
+			 * Electrobun auto-downloads WiX v3 if candle.exe is not found on PATH.
+			 */
+			msi?: {
+				/**
+				 * Generate a MSI installer during non-dev Windows builds.
+				 * @default true
+				 */
+				enabled?: boolean;
+
+				/**
+				 * Publisher / manufacturer name embedded in the MSI.
+				 * @default config.app.name
+				 */
+				publisher?: string;
+
+				/**
+				 * Override the stable UpgradeCode GUID used by Windows Installer to
+				 * identify this product across upgrades. Must be a valid UUID.
+				 * By default, a deterministic UUID v5 is derived from config.app.identifier
+				 * so you only need this if you need to match an existing MSI already in
+				 * production.
+				 * @example "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+				 */
+				upgradeCode?: string;
+
+				/**
+				 * Whether to install for the current user only or for all users.
+				 * "perMachine" sets InstallScope to perMachine and requires the MSI to
+				 * run as Administrator (elevated). "currentUser" requires no elevation.
+				 * @default "currentUser"
+				 */
+				installMode?: "currentUser" | "perMachine";
+
+				/**
+				 * Allow installing an older version over a newer one.
+				 * When false, the installer shows an error if a newer version is detected.
+				 * @default false
+				 */
+				allowDowngrades?: boolean;
+
+				/**
+				 * Create a desktop shortcut during install.
+				 * @default true
+				 */
+				desktopShortcut?: boolean;
+
+				/**
+				 * Start Menu folder name for the application shortcut.
+				 * @default config.app.name
+				 */
+				startMenuFolder?: string;
+
+			/**
+			 * Path to an RTF license file displayed in the installer.
+			 * When omitted the license dialog is skipped entirely.
+			 * @example "assets/license.rtf"
+			 */
+			license?: string;
+
+			/**
+			 * Path to a 493 x 58 BMP used as the top banner on installer pages.
+			 * When omitted the default WiX banner is used.
+			 */
+			bannerImage?: string;
+
+			/**
+			 * Path to a 493 x 312 BMP used as the background on the
+			 * Welcome and Finish dialogs.
+			 * When omitted the default WiX dialog image is used.
+			 */
+			dialogImage?: string;
+
+			/**
+			 * Homepage URL shown in Add/Remove Programs.
+			 */
+			homepage?: string;
+
+			/**
+			 * Show a "Launch application" checkbox on the finish page.
+			 * @default true
+			 */
+			launchAfterInstall?: boolean;
+
+			/**
+			 * Extra arguments passed verbatim to candle.exe (WiX compiler).
+			 * Use for advanced WiX extensions or preprocessor defines.
+			 * @example ["-ext", "WixUtilExtension"]
+			 */
+			additionalCandleArgs?: string[];
+
+			/**
+			 * Extra arguments passed verbatim to light.exe (WiX linker).
+			 * Use for ICE suppression, cultures, or WiX extensions.
+			 * @example ["-cultures:en-US", "-ext", "WixUIExtension"]
+			 */
+			additionalLightArgs?: string[];
+		};
 		};
 
 		/**

--- a/package/src/bun/core/Updater.ts
+++ b/package/src/bun/core/Updater.ts
@@ -7,10 +7,11 @@ import {
 	rmSync,
 	statSync,
 	readdirSync,
+	writeFileSync,
 } from "fs";
 import { execSync } from "child_process";
 import { OS as currentOS, ARCH as currentArch } from "../../shared/platform";
-import { getPlatformPrefix, getTarballFileName, getAppFileName } from "../../shared/naming";
+import { getPlatformPrefix, getTarballFileName, getAppFileName, getNsisSetupFileName } from "../../shared/naming";
 import { quit } from "./Utils";
 
 // Update status types for granular progress tracking
@@ -111,6 +112,22 @@ function getAppDataDir(): string {
 		default:
 			// Fallback to home directory with .config
 			return join(homedir(), ".config");
+	}
+}
+
+/**
+ * Test whether the current process can write to a directory by creating
+ * and immediately removing a temp file. Returns false on access denied
+ * or any other error.
+ */
+function canWriteToDir(dir: string): boolean {
+	const probe = join(dir, `.electrobun-write-test-${Date.now()}`);
+	try {
+		writeFileSync(probe, "");
+		unlinkSync(probe);
+		return true;
+	} catch {
+		return false;
 	}
 }
 
@@ -878,14 +895,15 @@ const Updater = {
 				}
 				// Platform-specific app path calculation
 				let runningAppBundlePath: string;
-				const appDataFolder = await Updater.appDataFolder();
 				
 				if (currentOS === "macos") {
 					// On macOS, executable is at Contents/MacOS/binary inside .app bundle
 					runningAppBundlePath = resolve(dirname(process.execPath), "..", "..");
 				} else if (currentOS === "linux" || currentOS === "win") {
-					// On Linux and Windows, use fixed 'app' folder to match extractor
-					runningAppBundlePath = join(appDataFolder, "app");
+					// bin/ is where the bun exe lives; parent is the app root.
+					// Works for any install location (NSIS default, custom dir,
+					// Program Files, or legacy extractor path).
+					runningAppBundlePath = resolve(dirname(process.execPath), "..");
 				} else {
 					throw new Error(`Unsupported platform: ${currentOS}`);
 				}
@@ -914,26 +932,22 @@ const Updater = {
 							// Ignore errors - attribute may not exist
 						}
 					} else if (currentOS === "linux") {
-						// On Linux, we now have directory bundles instead of AppImage files
-						// The app is stored in {appDataFolder}/app/
-						const appBundleDir = join(appDataFolder, "app");
-						
 						// Remove existing app directory if it exists
-						if (statSync(appBundleDir, { throwIfNoEntry: false })) {
-							rmSync(appBundleDir, { recursive: true });
+						if (statSync(runningAppBundlePath, { throwIfNoEntry: false })) {
+							rmSync(runningAppBundlePath, { recursive: true });
 						}
 
 						// Move new app bundle directory to app location
-						renameSync(newAppBundlePath, appBundleDir);
+						renameSync(newAppBundlePath, runningAppBundlePath);
 
 						// Ensure launcher binary is executable
-						const launcherPath = join(appBundleDir, "bin", "launcher");
+						const launcherPath = join(runningAppBundlePath, "bin", "launcher");
 						if (statSync(launcherPath, { throwIfNoEntry: false })) {
 							execSync(`chmod +x "${launcherPath}"`);
 						}
 
 						// Also ensure other binaries are executable
-						const bunPath = join(appBundleDir, "bin", "bun");
+						const bunPath = join(runningAppBundlePath, "bin", "bun");
 						if (statSync(bunPath, { throwIfNoEntry: false })) {
 							execSync(`chmod +x "${bunPath}"`);
 						}
@@ -945,29 +959,22 @@ const Updater = {
 					}
 
 					if (currentOS === "win") {
-						// On Windows, files are locked while in use, so we need a helper script
-						// that runs after the app exits to do the replacement
-						const parentDir = dirname(runningAppBundlePath);
-						const updateScriptPath = join(parentDir, "update.bat");
-						const launcherPath = join(
-							runningAppBundlePath,
-							"bin",
-							"launcher.exe",
-						);
+						if (canWriteToDir(runningAppBundlePath)) {
+							// User-writable install dir — use update.bat + Task Scheduler
+							const parentDir = dirname(runningAppBundlePath);
+							const updateScriptPath = join(parentDir, "update.bat");
+							const launcherPath = join(
+								runningAppBundlePath,
+								"bin",
+								"launcher.exe",
+							);
 
-						// Convert paths to Windows format
-						const runningAppWin = runningAppBundlePath.replace(/\//g, "\\");
-						const newAppWin = newAppBundlePath.replace(/\//g, "\\");
-						const extractionDirWin = extractionDir.replace(/\//g, "\\");
-						const launcherPathWin = launcherPath.replace(/\//g, "\\");
+							const runningAppWin = runningAppBundlePath.replace(/\//g, "\\");
+							const newAppWin = newAppBundlePath.replace(/\//g, "\\");
+							const extractionDirWin = extractionDir.replace(/\//g, "\\");
+							const launcherPathWin = launcherPath.replace(/\//g, "\\");
 
-						// Create a batch script that will:
-						// 1. Wait for the current app to exit
-						// 2. Remove current app folder
-						// 3. Move new app to current location
-						// 4. Launch the new app
-						// 5. Clean up
-						const updateScript = `@echo off
+							const updateScript = `@echo off
 setlocal
 
 :: Wait for the app to fully exit (check if launcher.exe is still running)
@@ -1005,23 +1012,57 @@ ping -n 2 127.0.0.1 >nul
 del "%~f0"
 `;
 
-						await Bun.write(updateScriptPath, updateScript);
+							await Bun.write(updateScriptPath, updateScript);
 
-						// Use Windows Task Scheduler to run the update script independently
-						// This ensures the script runs even after the app exits
-						const scriptPathWin = updateScriptPath.replace(/\//g, "\\");
-						const taskName = `ElectrobunUpdate_${Date.now()}`;
+							const scriptPathWin = updateScriptPath.replace(/\//g, "\\");
+							const taskName = `ElectrobunUpdate_${Date.now()}`;
 
-						// Create a scheduled task that runs immediately and deletes itself
-						execSync(
-							`schtasks /create /tn "${taskName}" /tr "cmd /c \\"${scriptPathWin}\\"" /sc once /st 00:00 /f`,
-							{ stdio: "ignore" },
-						);
-						execSync(`schtasks /run /tn "${taskName}"`, { stdio: "ignore" });
-						// The task will be cleaned up by Windows after it runs, or we delete it in the batch script
+							execSync(
+								`schtasks /create /tn "${taskName}" /tr "cmd /c \\"${scriptPathWin}\\"" /sc once /st 00:00 /f`,
+								{ stdio: "ignore" },
+							);
+							execSync(`schtasks /run /tn "${taskName}"`, { stdio: "ignore" });
 
-						// Use quit() for graceful shutdown - this closes all windows and processes
-						quit();
+							quit();
+						} else {
+							// Elevated install dir (e.g. Program Files) — download and
+							// run the NSIS installer with /UPDATE /P /R which triggers
+							// UAC elevation and handles file replacement natively.
+							emitStatus("applying", "Elevated install detected, downloading installer...");
+							const platformPrefix = getPlatformPrefix(
+								localInfo.channel,
+								currentOS,
+								currentArch,
+							);
+							const nsisFileName = getNsisSetupFileName(localInfo.name, localInfo.channel);
+							const nsisUrl = `${localInfo.baseUrl.replace(/\/+$/, "")}/${platformPrefix}-${nsisFileName}`;
+							const nsisDownloadPath = join(extractionFolder, nsisFileName);
+
+							try {
+								const response = await fetch(nsisUrl);
+								if (!response.ok) {
+									throw new Error(`HTTP ${response.status} fetching ${nsisUrl}`);
+								}
+								const buffer = await response.arrayBuffer();
+								await Bun.write(nsisDownloadPath, buffer);
+
+								emitStatus("applying", "Running elevated installer...");
+								execSync(
+									`start "" "${nsisDownloadPath.replace(/\//g, "\\")}" /UPDATE /P /R`,
+									{ stdio: "ignore" },
+								);
+
+								quit();
+							} catch (err) {
+								emitStatus(
+									"error",
+									`Failed to download/run elevated installer: ${(err as Error).message}`,
+									{ errorMessage: (err as Error).message },
+								);
+								console.error("Elevated update failed:", err);
+								return;
+							}
+						}
 					}
 				} catch (error) {
 					emitStatus(

--- a/package/src/cli/index.ts
+++ b/package/src/cli/index.ts
@@ -15,7 +15,7 @@ import {
 	copyFileSync,
 	renameSync,
 } from "fs";
-import { execSync } from "child_process";
+import { execSync, spawnSync } from "child_process";
 import * as readline from "readline";
 import { OS, ARCH } from "../shared/platform";
 import { DEFAULT_CEF_VERSION_STRING } from "../shared/cef-version";
@@ -26,12 +26,18 @@ import {
 	getBundleFileName,
 	getPlatformPrefix,
 	getTarballFileName,
-	getWindowsSetupFileName,
+	getNsisSetupFileName,
+	getMsiFileName,
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	sanitizeVolumeNameForHdiutil as _sanitizeVolumeNameForHdiutil,
 	getDmgVolumeName,
 	getMacOSBundleDisplayName,
 } from "../shared/naming";
+import { ensureNsis, ensureWix } from "../installer/tools";
+import {
+	generateNsisInstaller,
+} from "../installer/nsis";
+import { generateMsiInstaller } from "../installer/wix";
 import { getTemplate, getTemplateNames } from "./templates/embedded";
 // import { loadBsdiff, loadBspatch } from 'bsdiff-wasm';
 // MacOS named pipes hang at around 4KB
@@ -40,21 +46,101 @@ const _MAX_CHUNK_SIZE = 1024 * 2;
 
 // const binExt = OS === 'win' ? '.exe' : '';
 
+/**
+ * Embeds a Windows icon into an EXE using rcedit.
+ *
+ * When the CLI is compiled with `bun build --compile`, dynamic `import("rcedit")`
+ * freezes __dirname to the *build-machine* path (e.g. D:\... on GitHub Actions)
+ * rather than the runtime machine's path, causing ENOENT on any developer machine.
+ * We instead locate rcedit-x64.exe at runtime relative to process.execPath (the
+ * running electrobun binary), which is always a sibling package in node_modules.
+ *
+ * Layout:
+ * <project>/node_modules/electrobun/bin/electrobun.exe <- process.execPath
+ * <project>/node_modules/rcedit/bin/rcedit-x64.exe    <- resolved here
+ */
+function spawnRcedit(exePath: string, iconPath: string): void {
+	const rceditExe = process.arch === "x64" ? "rcedit-x64.exe" : "rcedit.exe";
+	const rceditPath = join(
+		dirname(process.execPath),
+		"..",
+		"..",
+		"rcedit",
+		"bin",
+		rceditExe,
+	);
+	if (!existsSync(rceditPath)) {
+		throw new Error(
+			`rcedit binary not found at ${rceditPath}. ` +
+				`Make sure 'rcedit' is installed in your project's node_modules.`,
+		);
+	}
+	execSync(`"${rceditPath}" "${exePath}" --set-icon "${iconPath}"`, {
+		stdio: "pipe",
+	});
+}
+
+/**
+ * Convert the configured Windows icon to a real .ico file in the build folder.
+ *
+ * If the source icon is a PNG, it is converted using png-to-ico.
+ * The produced ICO is written to <buildFolder>/installer-icon.ico and its
+ * path is returned. Returns null when no icon is configured or conversion fails.
+ */
+async function generateWindowsIco(
+	config: { build?: { win?: { icon?: string } } },
+	buildFolder: string,
+	projectRoot: string,
+): Promise<string | null> {
+	const iconRelPath = config.build?.win?.icon;
+	if (!iconRelPath) return null;
+
+	const iconSrcPath =
+		iconRelPath.startsWith("/") || /^[a-zA-Z]:/.test(iconRelPath)
+			? iconRelPath
+			: join(projectRoot, iconRelPath);
+
+	if (!existsSync(iconSrcPath)) {
+		console.warn(`[installer] Windows icon not found at ${iconSrcPath}`);
+		return null;
+	}
+
+	const icoDestPath = join(buildFolder, "installer-icon.ico");
+
+	try {
+		if (iconSrcPath.toLowerCase().endsWith(".png")) {
+			// Dynamically import png-to-ico (optional dependency bundled with electrobun)
+			const pngToIco = (await import("png-to-ico")).default;
+			const icoBuffer = await pngToIco(iconSrcPath);
+			writeFileSync(icoDestPath, new Uint8Array(icoBuffer));
+		} else {
+			// Already an ICO (or other format) — copy as-is
+			copyFileSync(iconSrcPath, icoDestPath);
+		}
+		return icoDestPath;
+	} catch (err) {
+		console.warn(`[installer] Failed to generate installer icon: ${err}`);
+		return null;
+	}
+}
+
 // Create a tar file using system tar command (preserves file permissions unlike Bun.Archive)
 function createTar(tarPath: string, cwd: string, entries: string[]) {
 	// Use a relative path for the tar output on Windows to avoid bsdtar
 	// interpreting the "C:" drive letter as a remote host specifier.
 	const resolvedTarPath =
 		process.platform === "win32" ? path.relative(cwd, tarPath) : tarPath;
-	execSync(
-		`tar -cf "${resolvedTarPath}" ${entries.map((e) => `"${e}"`).join(" ")}`,
-		{
-			cwd,
-			stdio: "pipe",
-			// Prevent macOS tar from including Apple Double (._*) files. No-op on other platforms.
-			env: { ...process.env, COPYFILE_DISABLE: "1" },
-		},
-	);
+	const result = spawnSync("tar", ["-cf", resolvedTarPath, ...entries], {
+		cwd,
+		stdio: "pipe",
+		env: { ...process.env, COPYFILE_DISABLE: "1" },
+	});
+	if (result.error) throw result.error;
+	if (result.status !== 0) {
+		throw new Error(
+			`tar exited with code ${result.status}: ${result.stderr?.toString()}`,
+		);
+	}
 }
 
 // Create a tar.gz file using system tar command
@@ -615,7 +701,7 @@ async function downloadCustomBun(
 		// Extract zip file
 		if (platformOS === "win") {
 			execSync(
-				`powershell -command "Expand-Archive -Path '${tempZipPath}' -DestinationPath '${overrideDir}' -Force"`,
+				`powershell -command "Expand-Archive -Path '${tempZipPath.replace(/'/g, "''")}' -DestinationPath '${overrideDir.replace(/'/g, "''")}' -Force"`,
 				{ stdio: "inherit" },
 			);
 		} else {
@@ -2281,7 +2367,7 @@ Categories=Utility;Application;
 			// This bypasses Bun's PATHEXT behavior that treats launcher and launcher.exe as the same
 			try {
 				execSync(
-					`powershell -Command "if (Test-Path '${launcherWithoutExt}') { Rename-Item -Path '${launcherWithoutExt}' -NewName 'launcher.exe' -Force }"`,
+					`powershell -Command "if (Test-Path '${launcherWithoutExt.replace(/'/g, "''")}') { Rename-Item -Path '${launcherWithoutExt.replace(/'/g, "''")}' -NewName 'launcher.exe' -Force }"`,
 					{ stdio: "pipe" },
 				);
 				console.log(`Ensured launcher has .exe extension on Windows`);
@@ -3446,8 +3532,6 @@ Categories=Utility;Application;
 			// 6.5. code sign and notarize the dmg
 			// 7. copy artifacts to directory [self-extractor dmg, zstd app bundle, bsdiff patch, update.json]
 
-			// Platform suffix is only used for folder names, not file names
-			const platformSuffix = `-${targetOS}-${targetARCH}`;
 			// Use sanitized appFileName for tarball path (URL-safe), but tar content uses actual bundle folder name
 			const tarPath = join(
 				buildFolder,
@@ -3457,7 +3541,75 @@ Categories=Utility;Application;
 			// Tar the app bundle for all platforms
 			createTar(tarPath, buildFolder, [basename(appBundleFolderPath)]);
 
-			// Remove the app bundle folder after tarring (except on Linux where it might be needed for dev)
+			// ── Windows installer generation (NSIS + MSI) ─────────────────────────
+			// This must happen BEFORE the app bundle folder is deleted below, because
+			// both generators need to read the bundle files directly.
+			// The tar.zst (for the auto-update system) is produced independently later.
+			if (targetOS === "win") {
+				const nsisEnabled = (config.build?.win as any)?.nsis?.enabled !== false;
+				const msiEnabled = (config.build?.win as any)?.msi?.enabled !== false;
+
+				if (nsisEnabled || msiEnabled) {
+					// Convert PNG icon → .ico once; reused by both generators
+					const icoPath = await generateWindowsIco(config, buildFolder, projectRoot);
+
+					if (nsisEnabled) {
+						console.log("[installer] Generating NSIS installer...");
+						const makensisPath = await ensureNsis();
+						if (makensisPath) {
+							const nsisOutName = getNsisSetupFileName(config.app.name, buildEnvironment);
+							const nsisResult = await generateNsisInstaller({
+								makensisPath,
+								buildFolder,
+								appBundleFolder: appBundleFolderPath,
+								appFileName: nsisOutName.replace(".exe", ""),
+								config: config as any,
+								buildEnvironment,
+								icoPath: icoPath ?? undefined,
+							});
+							if (nsisResult) {
+								artifactsToUpload.push(nsisResult);
+								console.log(`[installer] NSIS installer: ${nsisResult}`);
+							}
+						} else {
+							console.warn(
+								"[installer] NSIS not available — skipping NSIS installer. " +
+								"Install NSIS (https://nsis.sourceforge.io) or add `choco install nsis` to your CI.",
+							);
+						}
+					}
+
+					if (msiEnabled) {
+						console.log("[installer] Generating MSI installer...");
+						const wixPaths = await ensureWix();
+						if (wixPaths) {
+							const msiOutName = getMsiFileName(config.app.name, buildEnvironment);
+							const msiResult = await generateMsiInstaller({
+								candlePath: wixPaths.candle,
+								lightPath: wixPaths.light,
+								buildFolder,
+								appBundleFolder: appBundleFolderPath,
+								appFileName: msiOutName.replace(".msi", ""),
+								config: config as any,
+								buildEnvironment,
+								icoPath: icoPath ?? undefined,
+							});
+							if (msiResult) {
+								artifactsToUpload.push(msiResult);
+								console.log(`[installer] MSI installer: ${msiResult}`);
+							}
+						} else {
+							console.warn(
+								"[installer] WiX v3 not available — skipping MSI installer. " +
+								"Install WiX v3 (https://github.com/wixtoolset/wix3/releases).",
+							);
+						}
+					}
+				}
+			}
+
+			// Remove the app bundle folder after tarring (and after installer generation)
+			// Exception: Linux dev builds keep the folder for local testing
 			if (targetOS !== "linux" || buildEnvironment !== "dev") {
 				rmSync(appBundleFolderPath, { recursive: true });
 			}
@@ -3689,200 +3841,162 @@ Categories=Utility;Application;
 				unlinkSync(tarPath);
 			}
 
-			const selfExtractingBundle = createAppBundle(
-				bundleName,
-				buildFolder,
-				targetOS,
-			);
-			const compressedTarballInExtractingBundlePath = join(
-				selfExtractingBundle.appBundleFolderResourcesPath,
-				`${hash}.tar.zst`,
-			);
-
-			// copy the zstd tarball to the self-extracting app bundle
-			cpSync(compressedTarPath, compressedTarballInExtractingBundlePath, {
-				dereference: true,
-			});
-
-			const selfExtractorBinSourcePath = targetPaths.EXTRACTOR;
-			const selfExtractorBinDestinationPath = join(
-				selfExtractingBundle.appBundleMacOSPath,
-				"launcher",
-			);
-
-			cpSync(selfExtractorBinSourcePath, selfExtractorBinDestinationPath, {
-				dereference: true,
-			});
-
-			buildIcons(
-				selfExtractingBundle.appBundleFolderResourcesPath,
-				selfExtractingBundle.appBundleFolderPath,
-			);
-			await Bun.write(
-				join(selfExtractingBundle.appBundleFolderContentsPath, "Info.plist"),
-				InfoPlistContents,
-			);
-
-			// Write metadata.json to outer bundle (consistent with Windows/Linux)
-			const extractorMetadata = {
-				identifier: config.app.identifier,
-				name: config.app.name,
-				channel: buildEnvironment,
-				hash: hash,
-			};
-			await Bun.write(
-				join(
+			if (targetOS === "macos") {
+				// macOS: build a self-extracting .app wrapper, then optionally create a DMG
+				const selfExtractingBundle = createAppBundle(
+					bundleName,
+					buildFolder,
+					targetOS,
+				);
+				const compressedTarballInExtractingBundlePath = join(
 					selfExtractingBundle.appBundleFolderResourcesPath,
-					"metadata.json",
-				),
-				JSON.stringify(extractorMetadata, null, 2),
-			);
-
-			// Run postWrap hook after self-extracting bundle is created, before code signing
-			// This is where you can add files to the wrapper (e.g., for liquid glass support)
-			runHook("postWrap", {
-				ELECTROBUN_WRAPPER_BUNDLE_PATH:
-					selfExtractingBundle.appBundleFolderPath,
-			});
-
-			if (shouldCodesign) {
-				codesignAppBundle(
-					selfExtractingBundle.appBundleFolderPath,
-					join(buildFolder, "entitlements.plist"),
-					config,
-				);
-			} else {
-				console.log("skipping codesign");
-			}
-
-			// Note: we need to notarize the original app bundle, the self-extracting app bundle, and the dmg
-			if (shouldNotarize) {
-				notarizeAndStaple(selfExtractingBundle.appBundleFolderPath, config);
-			} else {
-				console.log("skipping notarization");
-			}
-
-			// DMG creation for macOS only
-			if (targetOS === "macos" && config.build.mac?.createDmg !== false) {
-				console.log("creating dmg...");
-				const finalDmgPath = join(buildFolder, `${appFileName}.dmg`);
-				// NOTE: For some ungodly reason using the bare name in CI can conflict with some mysterious
-				// already mounted volume. I suspect the sanitized appFileName can match your github repo
-				// or some other tool is mounting something somewhere. Either way, as a workaround
-				// while creating the dmg for a stable build we temporarily give it a -stable suffix
-				// to match the behaviour of -canary builds.
-				const dmgCreationPath =
-					buildEnvironment === "stable"
-						? join(buildFolder, `${appFileName}-stable.dmg`)
-						: finalDmgPath;
-				const dmgVolumeName = getDmgVolumeName(
-					config.app.name,
-					buildEnvironment,
+					`${hash}.tar.zst`,
 				);
 
-				// Create a staging directory for DMG contents (app + Applications shortcut)
-				const dmgStagingDir = join(buildFolder, ".dmg-staging");
-				if (existsSync(dmgStagingDir)) {
-					rmSync(dmgStagingDir, { recursive: true });
+				cpSync(compressedTarPath, compressedTarballInExtractingBundlePath, {
+					dereference: true,
+				});
+
+				const selfExtractorBinSourcePath = targetPaths.EXTRACTOR;
+				const selfExtractorBinDestinationPath = join(
+					selfExtractingBundle.appBundleMacOSPath,
+					"launcher",
+				);
+
+				cpSync(selfExtractorBinSourcePath, selfExtractorBinDestinationPath, {
+					dereference: true,
+				});
+
+				buildIcons(
+					selfExtractingBundle.appBundleFolderResourcesPath,
+					selfExtractingBundle.appBundleFolderPath,
+				);
+				await Bun.write(
+					join(selfExtractingBundle.appBundleFolderContentsPath, "Info.plist"),
+					InfoPlistContents,
+				);
+
+				const extractorMetadata = {
+					identifier: config.app.identifier,
+					name: config.app.name,
+					channel: buildEnvironment,
+					hash: hash,
+				};
+				await Bun.write(
+					join(
+						selfExtractingBundle.appBundleFolderResourcesPath,
+						"metadata.json",
+					),
+					JSON.stringify(extractorMetadata, null, 2),
+				);
+
+				runHook("postWrap", {
+					ELECTROBUN_WRAPPER_BUNDLE_PATH:
+						selfExtractingBundle.appBundleFolderPath,
+				});
+
+				if (shouldCodesign) {
+					codesignAppBundle(
+						selfExtractingBundle.appBundleFolderPath,
+						join(buildFolder, "entitlements.plist"),
+						config,
+					);
+				} else {
+					console.log("skipping codesign");
 				}
-				mkdirSync(dmgStagingDir, { recursive: true });
-				try {
-					// Copy the app bundle to the staging directory
-					const stagedAppPath = join(
-						dmgStagingDir,
-						basename(selfExtractingBundle.appBundleFolderPath),
+
+				if (shouldNotarize) {
+					notarizeAndStaple(selfExtractingBundle.appBundleFolderPath, config);
+				} else {
+					console.log("skipping notarization");
+				}
+
+				if (config.build.mac?.createDmg !== false) {
+					console.log("creating dmg...");
+					const finalDmgPath = join(buildFolder, `${appFileName}.dmg`);
+					// NOTE: For some ungodly reason using the bare name in CI can conflict with some mysterious
+					// already mounted volume. I suspect the sanitized appFileName can match your github repo
+					// or some other tool is mounting something somewhere. Either way, as a workaround
+					// while creating the dmg for a stable build we temporarily give it a -stable suffix
+					// to match the behaviour of -canary builds.
+					const dmgCreationPath =
+						buildEnvironment === "stable"
+							? join(buildFolder, `${appFileName}-stable.dmg`)
+							: finalDmgPath;
+					const dmgVolumeName = getDmgVolumeName(
+						config.app.name,
+						buildEnvironment,
 					);
-					execSync(
-						`cp -R ${escapePathForTerminal(selfExtractingBundle.appBundleFolderPath)} ${escapePathForTerminal(stagedAppPath)}`,
-					);
 
-					// Create a symlink to /Applications for easy drag-and-drop installation
-					const applicationsLink = join(dmgStagingDir, "Applications");
-					symlinkSync("/Applications", applicationsLink);
-
-					// hdiutil create -volname "YourAppName" -srcfolder /path/to/staging -ov -format UDZO YourAppName.dmg
-					// Note: use ULFO (lzfse) for better compatibility with large CEF frameworks and modern macOS
-					execSync(
-						`hdiutil create -volname "${dmgVolumeName}" -srcfolder ${escapePathForTerminal(
-							dmgStagingDir,
-						)} -ov -format ULFO ${escapePathForTerminal(dmgCreationPath)}`,
-					);
-
-					if (
-						buildEnvironment === "stable" &&
-						dmgCreationPath !== finalDmgPath
-					) {
-						renameSync(dmgCreationPath, finalDmgPath);
-					}
-					artifactsToUpload.push(finalDmgPath);
-
-					if (shouldCodesign) {
-						codesignAppBundle(finalDmgPath, undefined, config);
-					} else {
-						console.log("skipping codesign");
-					}
-
-					if (shouldNotarize) {
-						notarizeAndStaple(finalDmgPath, config);
-					} else {
-						console.log("skipping notarization");
-					}
-				} finally {
+					const dmgStagingDir = join(buildFolder, ".dmg-staging");
 					if (existsSync(dmgStagingDir)) {
 						rmSync(dmgStagingDir, { recursive: true });
 					}
-				}
-			} else {
-				if (targetOS === "macos") {
+					mkdirSync(dmgStagingDir, { recursive: true });
+					try {
+						const stagedAppPath = join(
+							dmgStagingDir,
+							basename(selfExtractingBundle.appBundleFolderPath),
+						);
+						execSync(
+							`cp -R ${escapePathForTerminal(selfExtractingBundle.appBundleFolderPath)} ${escapePathForTerminal(stagedAppPath)}`,
+						);
+
+						const applicationsLink = join(dmgStagingDir, "Applications");
+						symlinkSync("/Applications", applicationsLink);
+
+						execSync(
+							`hdiutil create -volname "${dmgVolumeName}" -srcfolder ${escapePathForTerminal(
+								dmgStagingDir,
+							)} -ov -format ULFO ${escapePathForTerminal(dmgCreationPath)}`,
+						);
+
+						if (
+							buildEnvironment === "stable" &&
+							dmgCreationPath !== finalDmgPath
+						) {
+							renameSync(dmgCreationPath, finalDmgPath);
+						}
+						artifactsToUpload.push(finalDmgPath);
+
+						if (shouldCodesign) {
+							codesignAppBundle(finalDmgPath, undefined, config);
+						} else {
+							console.log("skipping codesign");
+						}
+
+						if (shouldNotarize) {
+							notarizeAndStaple(finalDmgPath, config);
+						} else {
+							console.log("skipping notarization");
+						}
+					} finally {
+						if (existsSync(dmgStagingDir)) {
+							rmSync(dmgStagingDir, { recursive: true });
+						}
+					}
+				} else {
 					console.log("skipping dmg");
 				}
-				// For Windows and Linux, add the self-extracting bundle directly
-				// @ts-expect-error - reserved for future use
-				const _platformBundlePath = join(
+			} else if (targetOS === "win") {
+				// Windows NSIS + MSI installers were already generated above
+				// (before the app bundle was deleted) and added to artifactsToUpload.
+				console.log("[installer] Windows installer artifacts already generated.");
+			} else if (targetOS === "linux") {
+				const linuxCompressedTarPath = join(
 					buildFolder,
-					`${appFileName}${platformSuffix}${targetOS === "win" ? ".exe" : ""}`,
+					`${appFileName}.tar.zst`,
 				);
-				// Copy the self-extracting bundle to platform-specific filename
-				if (targetOS === "win") {
-					// On Windows, create a self-extracting exe
-					const selfExtractingExePath = await createWindowsSelfExtractingExe(
-						buildFolder,
-						compressedTarPath,
-						appFileName,
-						targetPaths,
-						buildEnvironment,
-						hash,
-						config,
-						projectRoot,
-					);
-
-					// Wrap Windows installer files in zip for distribution
-					const wrappedExePath = await wrapWindowsInstallerInZip(
-						selfExtractingExePath,
-						buildFolder,
-					);
-					artifactsToUpload.push(wrappedExePath);
-
-					// Also keep the raw exe for backwards compatibility (optional)
-					// artifactsToUpload.push(selfExtractingExePath);
-				} else if (targetOS === "linux") {
-					// On Linux, create a self-extracting installer archive
-					// Use the Linux-specific compressed tar path
-					const linuxCompressedTarPath = join(
-						buildFolder,
-						`${appFileName}.tar.zst`,
-					);
-					const installerArchivePath = await createLinuxInstallerArchive(
-						buildFolder,
-						linuxCompressedTarPath,
-						appFileName,
-						config,
-						buildEnvironment,
-						hash,
-						targetPaths,
-					);
-					artifactsToUpload.push(installerArchivePath);
-				}
+				const installerArchivePath = await createLinuxInstallerArchive(
+					buildFolder,
+					linuxCompressedTarPath,
+					appFileName,
+					config,
+					buildEnvironment,
+					hash,
+					targetPaths,
+				);
+				artifactsToUpload.push(installerArchivePath);
 			}
 
 			// refresh artifacts folder
@@ -4524,174 +4638,6 @@ Categories=Utility;Application;
 			return `<array>\n${value.map((v) => `        <string>${v}</string>`).join("\n")}\n    </array>`;
 		} else {
 			return `<string>${value}</string>`;
-		}
-	}
-
-	async function createWindowsSelfExtractingExe(
-		buildFolder: string,
-		compressedTarPath: string,
-		_appFileName: string,
-		targetPaths: any,
-		buildEnvironment: string,
-		hash: string,
-		config: any,
-		projectRoot: string,
-	): Promise<string> {
-		console.log("Creating Windows installer with separate archive...");
-
-		const setupFileName = getWindowsSetupFileName(
-			config.app.name,
-			buildEnvironment,
-		);
-		const outputExePath = join(buildFolder, setupFileName);
-
-		// Copy the extractor exe
-		const extractorExe = readFileSync(targetPaths.EXTRACTOR);
-		writeFileSync(outputExePath, new Uint8Array(extractorExe));
-
-		// Embed icon into the wrapper EXE if provided
-		if (config.build.win?.icon) {
-			const iconSourcePath =
-				config.build.win.icon.startsWith("/") ||
-				config.build.win.icon.match(/^[a-zA-Z]:/)
-					? config.build.win.icon
-					: join(projectRoot, config.build.win.icon);
-
-			if (existsSync(iconSourcePath)) {
-				console.log(`Embedding icon into Windows installer: ${iconSourcePath}`);
-				try {
-					let iconPath = iconSourcePath;
-
-					// Convert PNG to ICO if needed
-					if (iconSourcePath.toLowerCase().endsWith(".png")) {
-						const pngToIco = (await import("png-to-ico")).default;
-						const tempIcoPath = join(buildFolder, "temp-icon.ico");
-						const icoBuffer = await pngToIco(iconSourcePath);
-						writeFileSync(tempIcoPath, new Uint8Array(icoBuffer));
-						iconPath = tempIcoPath;
-						console.log(`Converted PNG to ICO format: ${tempIcoPath}`);
-					}
-
-					// Use rcedit to embed the icon
-					const rcedit = (await import("rcedit")).default;
-					await rcedit(outputExePath, {
-						icon: iconPath,
-					});
-					console.log(`Successfully embedded icon into ${setupFileName}`);
-
-					// Clean up temp ICO file
-					if (iconPath !== iconSourcePath && existsSync(iconPath)) {
-						unlinkSync(iconPath);
-					}
-				} catch (error) {
-					console.warn(
-						`Warning: Failed to embed icon into Windows installer: ${error}`,
-					);
-				}
-			} else {
-				console.warn(`Warning: Windows icon not found at ${iconSourcePath}`);
-			}
-		}
-
-		// Create metadata JSON file
-		const metadata = {
-			identifier: config.app.identifier,
-			name: config.app.name,
-			channel: buildEnvironment,
-			hash: hash,
-		};
-		const metadataJson = JSON.stringify(metadata, null, 2);
-		const metadataFileName = setupFileName.replace(".exe", ".metadata.json");
-		const metadataPath = join(buildFolder, metadataFileName);
-		writeFileSync(metadataPath, metadataJson);
-
-		// Copy the compressed archive with matching name
-		const archiveFileName = setupFileName.replace(".exe", ".tar.zst");
-		const archivePath = join(buildFolder, archiveFileName);
-		copyFileSync(compressedTarPath, archivePath);
-
-		// Make the exe executable (though Windows doesn't need chmod)
-		if (OS !== "win") {
-			execSync(`chmod +x ${escapePathForTerminal(outputExePath)}`);
-		}
-
-		const exeSize = statSync(outputExePath).size;
-		const archiveSize = statSync(archivePath).size;
-		const totalSize = exeSize + archiveSize;
-
-		console.log(`Created Windows installer:`);
-		console.log(
-			`  - Extractor: ${outputExePath} (${(exeSize / 1024 / 1024).toFixed(2)} MB)`,
-		);
-		console.log(
-			`  - Archive: ${archivePath} (${(archiveSize / 1024 / 1024).toFixed(2)} MB)`,
-		);
-		console.log(`  - Metadata: ${metadataPath}`);
-		console.log(`  - Total size: ${(totalSize / 1024 / 1024).toFixed(2)} MB`);
-
-		return outputExePath;
-	}
-
-	async function wrapWindowsInstallerInZip(
-		exePath: string,
-		buildFolder: string,
-	): Promise<string> {
-		const exeName = basename(exePath);
-		const exeStem = exeName.replace(".exe", "");
-
-		// Derive the paths for metadata and archive files
-		const metadataPath = join(buildFolder, `${exeStem}.metadata.json`);
-		const archivePath = join(buildFolder, `${exeStem}.tar.zst`);
-		// Sanitize the zip filename (no spaces in artifact URLs) while inner files keep their original names
-		const zipPath = join(buildFolder, `${exeStem.replace(/ /g, "")}.zip`);
-
-		// Verify all files exist
-		if (!existsSync(exePath)) {
-			throw new Error(`Installer exe not found: ${exePath}`);
-		}
-		if (!existsSync(metadataPath)) {
-			throw new Error(`Metadata file not found: ${metadataPath}`);
-		}
-		if (!existsSync(archivePath)) {
-			throw new Error(`Archive file not found: ${archivePath}`);
-		}
-
-		// Create staging directory to control zip layout
-		const stagingDir = join(
-			buildFolder,
-			`.installer-zip-${exeStem.replace(/[^a-zA-Z0-9_-]/g, "")}`,
-		);
-		const stagingInstallerDir = join(stagingDir, ".installer");
-
-		if (existsSync(stagingDir)) {
-			rmSync(stagingDir, { recursive: true, force: true });
-		}
-		mkdirSync(stagingInstallerDir, { recursive: true });
-
-		// Add Setup.exe at the root level for easy access
-		copyFileSync(exePath, join(stagingDir, basename(exePath)));
-		// Put metadata and archive in a subdirectory to discourage manual extraction
-		copyFileSync(metadataPath, join(stagingInstallerDir, basename(metadataPath)));
-		copyFileSync(archivePath, join(stagingInstallerDir, basename(archivePath)));
-
-		try {
-			// Create zip archive (Windows only)
-			execSync(
-				`powershell -command "Compress-Archive -Path '${stagingDir}\\\\*' -DestinationPath '${zipPath}' -Force"`,
-				{ stdio: "inherit" },
-			);
-
-			const zipSizeMb = existsSync(zipPath)
-				? (statSync(zipPath).size / 1024 / 1024).toFixed(2)
-				: "0.00";
-			console.log(
-				`Created Windows installer package: ${zipPath} (${zipSizeMb} MB)`,
-			);
-			return zipPath;
-		} finally {
-			if (existsSync(stagingDir)) {
-				rmSync(stagingDir, { recursive: true, force: true });
-			}
 		}
 	}
 

--- a/package/src/cli/index.ts
+++ b/package/src/cli/index.ts
@@ -2517,6 +2517,15 @@ Categories=Utility;Application;
 			}
 		}
 
+		// Refresh Windows icon cache so updated icons display immediately
+		if (targetOS === "win" && OS === "win" && config.build.win?.icon) {
+			try {
+				Bun.spawnSync(["ie4uinit.exe", "-show"], { stdio: ["ignore", "ignore", "ignore"] });
+			} catch {
+				// Non-fatal: icon cache refresh is best-effort
+			}
+		}
+
 		// copy native wrapper dynamic library
 		if (targetOS === "macos") {
 			const nativeWrapperMacosSource = targetPaths.NATIVE_WRAPPER_MACOS;

--- a/package/src/extractor/main.zig
+++ b/package/src/extractor/main.zig
@@ -61,13 +61,6 @@ const ProgressIndicator = struct {
     }
 
     fn startProgressDialog(self: *ProgressIndicator, metadata: AppMetadata) !void {
-        // On Windows, start a spinner thread in the console
-        if (builtin.os.tag == .windows) {
-            // Start spinner thread
-            self.spinner_thread = try std.Thread.spawn(.{}, spinnerThread, .{self});
-            return;
-        }
-
         if (builtin.os.tag != .linux) return;
 
         // Try zenity first (most common)
@@ -142,138 +135,7 @@ fn extractFromSelf(allocator: std.mem.Allocator) !bool {
     const exe_path = try std.fs.selfExePathAlloc(allocator);
     defer allocator.free(exe_path);
 
-    // For Windows, check for adjacent archive file first
-    if (builtin.os.tag == .windows) {
-        // Try to read from adjacent .tar.zst file
-        const exe_dir = std.fs.path.dirname(exe_path) orelse return error.InvalidPath;
-        const exe_name = std.fs.path.basename(exe_path);
-        const exe_stem = std.fs.path.stem(exe_name);
-
-        // Look for archive file - first in .installer subdirectory, then adjacent
-        const archive_name = try std.fmt.allocPrint(allocator, "{s}.tar.zst", .{exe_stem});
-        defer allocator.free(archive_name);
-
-        // Try .installer subdirectory first (new location)
-        const installer_archive_path = try std.fs.path.join(allocator, &.{ exe_dir, ".installer", archive_name });
-        defer allocator.free(installer_archive_path);
-
-        // Fallback to adjacent location (legacy)
-        const archive_path = try std.fs.path.join(allocator, &.{ exe_dir, archive_name });
-        defer allocator.free(archive_path);
-
-        // Determine which archive path exists
-        const final_archive_path = if (std.fs.accessAbsolute(installer_archive_path, .{})) |_|
-            installer_archive_path
-        else |_|
-            archive_path;
-
-        // Also check for metadata file
-        const metadata_name = try std.fmt.allocPrint(allocator, "{s}.metadata.json", .{exe_stem});
-        defer allocator.free(metadata_name);
-
-        // Try .installer subdirectory first (new location)
-        const installer_metadata_path = try std.fs.path.join(allocator, &.{ exe_dir, ".installer", metadata_name });
-        defer allocator.free(installer_metadata_path);
-
-        // Fallback to adjacent location (legacy)
-        const metadata_path = try std.fs.path.join(allocator, &.{ exe_dir, metadata_name });
-        defer allocator.free(metadata_path);
-
-        // Determine which metadata path exists
-        const final_metadata_path = if (std.fs.accessAbsolute(installer_metadata_path, .{})) |_|
-            installer_metadata_path
-        else |_|
-            metadata_path;
-
-        // Try to open the metadata file
-        if (std.fs.cwd().openFile(final_metadata_path, .{})) |metadata_file| {
-            defer metadata_file.close();
-
-            // Read metadata
-            const metadata_contents = try metadata_file.readToEndAlloc(allocator, 4096);
-            defer allocator.free(metadata_contents);
-
-            const parsed = try std.json.parseFromSlice(struct {
-                identifier: []const u8,
-                name: []const u8,
-                channel: []const u8,
-                hash: []const u8,
-            }, allocator, metadata_contents, .{ .ignore_unknown_fields = true });
-            defer parsed.deinit();
-
-            const metadata = AppMetadata{
-                .identifier = try allocator.dupe(u8, parsed.value.identifier),
-                .name = try allocator.dupe(u8, parsed.value.name),
-                .channel = try allocator.dupe(u8, parsed.value.channel),
-                .hash = try allocator.dupe(u8, parsed.value.hash),
-            };
-
-            std.debug.print("DEBUG: Parsed metadata hash: {s}\n", .{parsed.value.hash});
-
-            // Don't free metadata fields here - they need to persist through extractAndInstall
-            // They will be freed at the end of this function
-
-            // Try to open the archive file
-            if (std.fs.cwd().openFile(final_archive_path, .{})) |archive_file| {
-                defer archive_file.close();
-
-                std.debug.print("Found adjacent archive file: {s}\n", .{final_archive_path});
-                std.debug.print("Using metadata: identifier={s}, name={s}, channel={s}\n", .{ metadata.identifier, metadata.name, metadata.channel });
-
-                // Build application support directory path
-                const app_data_dir = try getAppDataDir(allocator);
-                defer allocator.free(app_data_dir);
-
-                // Use identifier + channel for the app data folder
-                // e.g., ~/Library/Application Support/sh.blackboard.myapp/canary/
-                const app_base_dir = try std.fs.path.join(allocator, &.{ app_data_dir, metadata.identifier, metadata.channel });
-                defer allocator.free(app_base_dir);
-
-                const self_extraction_dir = try std.fs.path.join(allocator, &.{ app_base_dir, "self-extraction" });
-                defer allocator.free(self_extraction_dir);
-
-                // Handle Windows versioned app directories
-                std.debug.print("\nDEBUG: Building app_dir path...\n", .{});
-                std.debug.print("DEBUG: builtin.os.tag = {}\n", .{builtin.os.tag});
-                std.debug.print("DEBUG: metadata.hash = {s}\n", .{metadata.hash orelse "null"});
-                std.debug.print("DEBUG: app_base_dir = '{s}'\n", .{app_base_dir});
-
-                // Always use "app" folder instead of hash-based versioning
-                const app_dir = try std.fs.path.join(allocator, &.{ app_base_dir, "app" });
-                defer allocator.free(app_dir);
-
-                std.debug.print("DEBUG: Final app_dir = '{s}'\n", .{app_dir});
-                std.debug.print("DEBUG: app_dir length = {}\n", .{app_dir.len});
-
-                std.debug.print("Extracting to: {s}\n", .{self_extraction_dir});
-                std.debug.print("App will be installed to: {s}\n", .{app_dir});
-                std.debug.print("DEBUG: app_base_dir = {s}\n", .{app_base_dir});
-                std.debug.print("DEBUG: metadata.hash = {s}\n", .{metadata.hash orelse "null"});
-
-                // Read compressed data from archive file
-                const file_size = try archive_file.getEndPos();
-                const compressed_data = try allocator.alloc(u8, file_size);
-                defer allocator.free(compressed_data);
-
-                try archive_file.seekTo(0);
-                _ = try archive_file.read(compressed_data);
-
-                // Continue with decompression (shared code path)
-                const result = try extractAndInstall(allocator, compressed_data, metadata, self_extraction_dir, app_dir);
-                // Clean up metadata fields
-                allocator.free(metadata.identifier);
-                allocator.free(metadata.name);
-                allocator.free(metadata.channel);
-                if (metadata.hash) |hash| {
-                    allocator.free(hash);
-                }
-
-                return result;
-            } else |_| {}
-        } else |_| {}
-    }
-
-    // Fall back to embedded archive approach (for Linux or if adjacent files not found on Windows)
+    // Embedded archive approach (Linux self-extracting installer)
     // Open self for reading
     const self_file = try std.fs.openFileAbsolute(exe_path, .{});
     defer self_file.close();
@@ -463,60 +325,10 @@ fn extractAndInstall(allocator: std.mem.Allocator, compressed_data: []const u8, 
     };
     std.debug.print("DEBUG: Source directory exists\n", .{});
 
-    // On Windows, we need to create the parent directory first, then copy contents
-    if (builtin.os.tag == .windows) {
-        // Create the app directory and all parent directories
-        std.debug.print("\nDEBUG: Windows directory creation...\n", .{});
-        std.debug.print("DEBUG: Current working directory = {s}\n", .{try std.fs.cwd().realpathAlloc(allocator, ".")});
-        std.debug.print("DEBUG: About to create Windows app directory: '{s}'\n", .{app_dir});
-        std.debug.print("DEBUG: app_dir length = {}\n", .{app_dir.len});
-
-        // Check if parent directory exists
-        if (std.fs.path.dirname(app_dir)) |parent| {
-            std.debug.print("DEBUG: Parent directory = '{s}'\n", .{parent});
-            std.fs.cwd().access(parent, .{}) catch |err| {
-                std.debug.print("DEBUG: Parent directory does not exist, will create it. Error: {}\n", .{err});
-            };
-        }
-
-        // Print each character to debug the string
-        std.debug.print("DEBUG: app_dir bytes: ", .{});
-        for (app_dir) |byte| {
-            if (byte >= 32 and byte <= 126) {
-                std.debug.print("'{c}' ", .{byte});
-            } else {
-                std.debug.print("0x{x:02} ", .{byte});
-            }
-        }
-        std.debug.print("\n", .{});
-
-        std.debug.print("DEBUG: Calling makePath...\n", .{});
-        std.fs.cwd().makePath(app_dir) catch |err| {
-            std.debug.print("ERROR: Failed to create app directory '{s}': {}\n", .{ app_dir, err });
-
-            // Try to create parent directory first
-            if (std.fs.path.dirname(app_dir)) |parent| {
-                std.debug.print("DEBUG: Trying to create parent directory first: '{s}'\n", .{parent});
-                std.fs.cwd().makePath(parent) catch |parent_err| {
-                    std.debug.print("ERROR: Failed to create parent directory: {}\n", .{parent_err});
-                };
-            }
-
-            return err;
-        };
-        std.debug.print("DEBUG: Successfully created app directory\n", .{});
-
-        // Copy contents from extracted path to app directory
-        try copyDirectory(allocator, extracted_app_path, app_dir);
-
-        // Remove the extracted directory after successful copy
-        std.fs.cwd().deleteTree(extracted_app_path) catch {};
-    } else {
-        // On Unix systems, rename works across directories
-        std.fs.cwd().rename(extracted_app_path, app_dir) catch |err| {
-            return err;
-        };
-    }
+    // Move the extracted app to the target directory
+    std.fs.cwd().rename(extracted_app_path, app_dir) catch |err| {
+        return err;
+    };
 
     // Fix executable permissions on extracted binaries
     try fixExecutablePermissions(allocator, app_dir);
@@ -530,22 +342,17 @@ fn extractAndInstall(allocator: std.mem.Allocator, compressed_data: []const u8, 
     try fixCefSymlinks(allocator, app_dir);
 
     // On macOS, replace self with launcher shortcut (due to .app bundle structure)
-    // On Windows/Linux, keep the self-extractor and create desktop shortcuts
     if (builtin.os.tag == .macos) {
         try replaceSelfWithLauncher(allocator, exe_path, app_dir);
     }
 
-    // Create desktop shortcuts on Linux and Windows
+    // Create desktop shortcuts on Linux
     if (builtin.os.tag == .linux) {
         try createDesktopShortcut(allocator, app_dir, metadata);
     }
 
-    if (builtin.os.tag == .windows) {
-        try createWindowsShortcut(allocator, app_dir, metadata);
-    }
-
-    // Save tar file for Updater API on Linux and Windows after everything else is done
-    if (builtin.os.tag == .linux or builtin.os.tag == .windows) {
+    // Save tar file for Updater API on Linux after everything else is done
+    if (builtin.os.tag == .linux) {
         std.debug.print("\n✓ Saving tar file for Updater API...\n", .{});
         // Make a defensive copy of the hash to prevent memory corruption
         const safe_hash = if (metadata.hash) |h| try allocator.dupe(u8, h) else null;
@@ -829,17 +636,6 @@ fn readEmbeddedMetadata(allocator: std.mem.Allocator, file: std.fs.File, metadat
 
 fn getAppDataDir(allocator: std.mem.Allocator) ![]const u8 {
     return switch (builtin.os.tag) {
-        .windows => blk: {
-            // Use %LOCALAPPDATA% on Windows
-            const local_appdata = std.process.getEnvVarOwned(allocator, "LOCALAPPDATA") catch
-                std.process.getEnvVarOwned(allocator, "APPDATA") catch {
-                // Fallback to user profile
-                const userprofile = try std.process.getEnvVarOwned(allocator, "USERPROFILE");
-                defer allocator.free(userprofile);
-                break :blk try std.fs.path.join(allocator, &.{ userprofile, "AppData", "Local" });
-            };
-            break :blk local_appdata;
-        },
         .linux => blk: {
             // Use XDG_DATA_HOME or ~/.local/share on Linux
             const xdg_data_home = std.process.getEnvVarOwned(allocator, "XDG_DATA_HOME") catch {
@@ -1070,153 +866,6 @@ fn createDesktopShortcut(allocator: std.mem.Allocator, app_dir: []const u8, meta
     std.debug.print("Note: If the desktop icon opens as text, right-click it and select 'Allow Launching' or 'Trust and Launch'\n", .{});
 }
 
-fn createWindowsShortcutFile(allocator: std.mem.Allocator, shortcut_dir: []const u8, app_name: []const u8, target_path: []const u8, working_dir: []const u8, icon_path: []const u8) !void {
-    // Create a .lnk shortcut using PowerShell
-    const lnk_name = try std.fmt.allocPrint(allocator, "{s}.lnk", .{app_name});
-    defer allocator.free(lnk_name);
-
-    const lnk_path = try std.fs.path.join(allocator, &.{ shortcut_dir, lnk_name });
-    defer allocator.free(lnk_path);
-
-    // Create PowerShell script to create the shortcut with icon
-    const ps_content = try std.fmt.allocPrint(allocator,
-        \\$WshShell = New-Object -ComObject WScript.Shell
-        \\$Shortcut = $WshShell.CreateShortcut("{s}")
-        \\$Shortcut.TargetPath = "{s}"
-        \\$Shortcut.WorkingDirectory = "{s}"
-        \\$Shortcut.IconLocation = "{s}"
-        \\$Shortcut.WindowStyle = 1
-        \\$Shortcut.Save()
-        \\
-    , .{ lnk_path, target_path, working_dir, icon_path });
-    defer allocator.free(ps_content);
-
-    // Execute PowerShell command
-    const ps_args = [_][]const u8{
-        "powershell",
-        "-NoProfile",
-        "-NonInteractive",
-        "-WindowStyle",
-        "Hidden",
-        "-Command",
-        ps_content,
-    };
-
-    var child = std.process.Child.init(&ps_args, allocator);
-    child.stdout_behavior = .Ignore;
-    child.stderr_behavior = .Ignore;
-
-    _ = child.spawn() catch |err| {
-        std.debug.print("Warning: Could not spawn PowerShell to create shortcut: {}\n", .{err});
-        return;
-    };
-
-    _ = child.wait() catch |err| {
-        std.debug.print("Warning: PowerShell shortcut creation failed: {}\n", .{err});
-        return;
-    };
-
-    std.debug.print("Created Windows shortcut: {s}\n", .{lnk_path});
-}
-
-fn createWindowsShortcut(allocator: std.mem.Allocator, app_dir: []const u8, metadata: AppMetadata) !void {
-    // Get user directories
-    const userprofile = std.process.getEnvVarOwned(allocator, "USERPROFILE") catch {
-        std.debug.print("Warning: Could not get USERPROFILE directory\n", .{});
-        return;
-    };
-    defer allocator.free(userprofile);
-
-    const desktop_dir = try std.fs.path.join(allocator, &.{ userprofile, "Desktop" });
-    defer allocator.free(desktop_dir);
-
-    const start_menu_dir = try std.fs.path.join(allocator, &.{ userprofile, "AppData", "Roaming", "Microsoft", "Windows", "Start Menu", "Programs" });
-    defer allocator.free(start_menu_dir);
-
-    // Check if Desktop directory exists
-    std.fs.cwd().access(desktop_dir, .{}) catch {
-        std.debug.print("Warning: Desktop directory not found at {s}\n", .{desktop_dir});
-        // Continue anyway, might work
-    };
-
-    // Point directly to launcher.exe (no more run.bat wrapper)
-    const target_path = try std.fs.path.join(allocator, &.{ app_dir, "bin", "launcher.exe" });
-    defer allocator.free(target_path);
-
-    // Check if target exists
-    std.fs.cwd().access(target_path, .{}) catch |err| {
-        std.debug.print("Warning: Could not find launcher.exe at {s}: {}\n", .{ target_path, err });
-        return;
-    };
-
-    // Working directory is the bin directory
-    const working_dir = try std.fs.path.join(allocator, &.{ app_dir, "bin" });
-    defer allocator.free(working_dir);
-
-    // Icon is embedded in launcher.exe, so use it directly as icon source
-    const icon_to_use = target_path;
-
-    // Create desktop shortcut
-    try createWindowsShortcutFile(allocator, desktop_dir, metadata.name, target_path, working_dir, icon_to_use);
-
-    // Create Start Menu shortcut
-    // Make sure Start Menu directory exists
-    std.fs.cwd().makePath(start_menu_dir) catch {
-        std.debug.print("Warning: Could not create Start Menu directory\n", .{});
-    };
-    try createWindowsShortcutFile(allocator, start_menu_dir, metadata.name, target_path, working_dir, icon_to_use);
-
-    std.debug.print("Created Windows shortcuts for: {s}\n", .{metadata.name});
-
-    // Add uninstall registry entry for better Windows integration
-    try addWindowsUninstallEntry(allocator, metadata, app_dir);
-}
-
-fn addWindowsUninstallEntry(allocator: std.mem.Allocator, metadata: AppMetadata, app_dir: []const u8) !void {
-    // Create a simple registry file that users can double-click to install uninstall info
-    // This is a safer approach than directly modifying the registry from our code
-    const reg_name = try std.fmt.allocPrint(allocator, "{s}_uninstall.reg", .{metadata.name});
-    defer allocator.free(reg_name);
-
-    const reg_path = try std.fs.path.join(allocator, &.{ app_dir, reg_name });
-    defer allocator.free(reg_path);
-
-    const app_display_name = try std.fmt.allocPrint(allocator, "{s} ({s})", .{ metadata.name, metadata.channel });
-    defer allocator.free(app_display_name);
-
-    // Create registry content for Windows uninstall entry
-    const reg_content = try std.fmt.allocPrint(allocator,
-        \\Windows Registry Editor Version 5.00
-        \\
-        \\[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Uninstall\{s}]
-        \\@="{s}"
-        \\"DisplayName"="{s}"
-        \\"DisplayVersion"="1.0"
-        \\"Publisher"="Electrobun"
-        \\"InstallLocation"="{s}"
-        \\"UninstallString"="cmd.exe /c rmdir /s /q \"{s}\""
-        \\"NoModify"=dword:00000001
-        \\"NoRepair"=dword:00000001
-        \\
-    , .{ metadata.identifier, app_display_name, app_display_name, app_dir, app_dir });
-    defer allocator.free(reg_content);
-
-    // Create and write registry file
-    const reg_file = std.fs.cwd().createFile(reg_path, .{}) catch |err| {
-        std.debug.print("Warning: Could not create uninstall registry file: {}\n", .{err});
-        return;
-    };
-    defer reg_file.close();
-
-    reg_file.writeAll(reg_content) catch |err| {
-        std.debug.print("Warning: Could not write registry content: {}\n", .{err});
-        return;
-    };
-
-    std.debug.print("Created uninstall registry file: {s}\n", .{reg_path});
-    std.debug.print("Note: Users can double-click {s} to add uninstall info to Windows\n", .{reg_name});
-}
-
 pub fn main() !void {
     std.debug.print("Electrobun self-extractor v1.3 starting...\n", .{});
     var allocator = std.heap.page_allocator;
@@ -1233,8 +882,8 @@ pub fn main() !void {
     const APPBUNDLE_MACOS_PATH = try std.fs.selfExeDirPath(exePathBuffer[0..]);
 
     // Platform-specific extraction
-    if (builtin.os.tag == .windows or builtin.os.tag == .linux) {
-        // Windows and Linux ONLY use self-extraction with magic bytes
+    if (builtin.os.tag == .linux) {
+        // Linux uses self-extraction with magic bytes
         const extracted = try extractFromSelf(allocator);
         if (!extracted) {
             std.debug.print("ERROR: Not a valid self-extracting installer\n", .{});
@@ -1394,11 +1043,9 @@ pub fn main() !void {
     const argv = switch (builtin.os.tag) {
         .macos => &[_][]const u8{ "open", APPBUNDLE_PATH },
         .linux => blk: {
-            // On Linux, find the launcher binary inside the app bundle
             const launcher_path = try std.fs.path.join(allocator, &.{ APPBUNDLE_PATH, "bin", "launcher" });
             break :blk &[_][]const u8{launcher_path};
         },
-        .windows => &[_][]const u8{ "cmd", "/c", "start", "", APPBUNDLE_PATH },
         else => @compileError("Unsupported platform for app launching"),
     };
 
@@ -1714,110 +1361,3 @@ fn getPlistStringValue(plistContents: []const u8, key: []const u8) !?[]const u8 
     return null; // Key not found or malformed plist
 }
 
-fn createWindowsLauncherScript(allocator: std.mem.Allocator, app_dir: []const u8, metadata: AppMetadata) !void {
-    // Get the parent directory (contains app-<hash> and where run.bat should go)
-    const parent_dir = std.fs.path.dirname(app_dir) orelse return error.InvalidPath;
-    const run_bat_path = try std.fs.path.join(allocator, &.{ parent_dir, "run.bat" });
-    defer allocator.free(run_bat_path);
-
-    // Create launcher batch file content
-    const launcher_content = try std.fmt.allocPrint(allocator,
-        \\@echo off
-        \\:: Electrobun App Launcher
-        \\:: This file launches the current version
-        \\
-        \\:: Set current version
-        \\set CURRENT_HASH={s}
-        \\set APP_DIR=%~dp0app-%CURRENT_HASH%
-        \\
-        \\:: TODO: Implement proper cleanup mechanism that checks for running processes
-        \\:: For now, old versions are kept to avoid race conditions during updates
-        \\:: :: Clean up old app versions (keep current only)
-        \\:: for /d %%D in ("%~dp0app-*") do (
-        \\::     if not "%%~nxD"=="app-%CURRENT_HASH%" (
-        \\::         echo Removing old version: %%~nxD
-        \\::         rmdir /s /q "%%D" 2>nul
-        \\::     )
-        \\:: )
-        \\
-        \\:: Launch the app
-        \\cd /d "%APP_DIR%\bin"
-        \\start "" launcher.exe
-        \\
-    , .{metadata.hash orelse "unknown"});
-    defer allocator.free(launcher_content);
-
-    // Write the launcher batch file
-    const run_bat_file = try std.fs.cwd().createFile(run_bat_path, .{});
-    defer run_bat_file.close();
-    try run_bat_file.writeAll(launcher_content);
-
-    std.debug.print("Created Windows launcher script: {s}\n", .{run_bat_path});
-}
-fn copyDirectory(allocator: std.mem.Allocator, src_path: []const u8, dest_path: []const u8) !void {
-    std.debug.print("\nDEBUG copyDirectory: src='{s}' dest='{s}'\n", .{ src_path, dest_path });
-
-    var src_dir = std.fs.cwd().openDir(src_path, .{ .iterate = true }) catch |err| {
-        std.debug.print("ERROR: Failed to open source directory '{s}': {}\n", .{ src_path, err });
-        return err;
-    };
-    defer src_dir.close();
-
-    var iterator = src_dir.iterate();
-    while (try iterator.next()) |entry| {
-        const src_item_path = try std.fs.path.join(allocator, &.{ src_path, entry.name });
-        defer allocator.free(src_item_path);
-
-        const dest_item_path = try std.fs.path.join(allocator, &.{ dest_path, entry.name });
-        defer allocator.free(dest_item_path);
-
-        switch (entry.kind) {
-            .directory => {
-                // Create directory and recursively copy contents
-                std.fs.cwd().makeDir(dest_item_path) catch |err| switch (err) {
-                    error.PathAlreadyExists => {},
-                    else => return err,
-                };
-                try copyDirectory(allocator, src_item_path, dest_item_path);
-            },
-            .file => {
-                // Copy file
-                try std.fs.cwd().copyFile(src_item_path, std.fs.cwd(), dest_item_path, .{});
-            },
-            else => {
-                // Skip other file types (symlinks, etc.)
-                std.debug.print("Skipping file type for: {s}\n", .{entry.name});
-            },
-        }
-    }
-}
-
-fn sanitizeWindowsPath(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
-    // Windows invalid characters: < > : " | ? * and control chars (0-31)
-    var sanitized = try allocator.alloc(u8, path.len);
-    var write_pos: usize = 0;
-
-    for (path) |char| {
-        switch (char) {
-            // Replace invalid characters with underscore
-            '<', '>', ':', '"', '|', '?', '*' => {
-                sanitized[write_pos] = '_';
-                write_pos += 1;
-            },
-            // Skip control characters (0-31)
-            0...31 => {},
-            // Keep valid characters
-            else => {
-                sanitized[write_pos] = char;
-                write_pos += 1;
-            },
-        }
-    }
-
-    // Resize to actual length
-    const result = try allocator.alloc(u8, write_pos);
-    @memcpy(result, sanitized[0..write_pos]);
-    allocator.free(sanitized);
-
-    return result;
-}

--- a/package/src/installer/nsis.ts
+++ b/package/src/installer/nsis.ts
@@ -1,0 +1,800 @@
+/**
+ * NSIS .exe installer generator for Electrobun Windows builds.
+ *
+ * Produces a production-ready installer with:
+ *  - DPI awareness (PerMonitorV2)
+ *  - Silent (/S), passive (/P), update (/UPDATE), no-shortcut (/NS) modes
+ *  - Version comparison and upgrade/reinstall detection
+ *  - URL protocol registration (config.app.urlSchemes)
+ *  - Per-user (default) or per-machine installation
+ *  - Add/Remove Programs registry entries with estimated size
+ *  - Desktop + Start Menu shortcuts
+ *  - Uninstaller with optional app-data deletion
+ *  - LZMA solid compression
+ */
+
+import { join } from "path";
+import { writeFileSync, mkdirSync, existsSync } from "fs";
+import { spawnSync } from "child_process";
+
+// ── NSIS template ─────────────────────────────────────────────────────────────
+
+/**
+ * The raw NSIS script template. Placeholders use {{UPPER_SNAKE_CASE}} syntax.
+ *
+ * Variables injected by renderNsisTemplate():
+ *   {{APP_NAME}}             Display name (may contain spaces)
+ *   {{APP_NAME_SANITIZED}}   No-space name used for registry paths
+ *   {{APP_VERSION}}          e.g. "1.2.3"
+ *   {{APP_VERSION_4SEG}}     e.g. "1.2.3.0" (required by VIProductVersion)
+ *   {{APP_IDENTIFIER}}       e.g. "com.example.myapp"
+ *   {{APP_PUBLISHER}}        Publisher / company name
+ *   {{APP_DESCRIPTION}}      Short description string
+ *   {{HOMEPAGE}}             Homepage URL (may be empty)
+ *   {{OUTPUT_FILE}}          Absolute path for the compiled installer .exe
+ *   {{BUNDLE_DIR}}           Absolute path to the extracted app bundle folder
+ *   {{INSTALL_DIR}}          Default install directory NSIS expression
+ *   {{INSTALL_MODE}}         "currentUser" | "perMachine"
+ *   {{ALLOW_DOWNGRADES}}     "true" | "false"
+ *   {{DESKTOP_SHORTCUT}}     "true" | "false"
+ *   {{START_MENU_FOLDER}}    Start menu folder name
+ *   {{MUI_ICON_LINE}}        !define MUI_ICON "…" or empty string
+ *   {{MUI_UNICON_LINE}}      !define MUI_UNICON "…" or empty string
+ *   {{URL_PROTOCOLS_INSTALL}}  NSIS WriteRegStr block for URL protocols
+ *   {{URL_PROTOCOLS_UNINSTALL}} NSIS DeleteRegKey block for URL protocols
+ *   {{APPDATA_DELETE_SECTION}}  NSIS block to delete app data dirs on uninstall
+ *   {{LEGACY_DETECT_BLOCK}}     NSIS block in .onInit to detect legacy extractor installs
+ *   {{LEGACY_CLEANUP_BLOCK}}    NSIS block in Install section to clean up legacy installs
+ *   {{WEBVIEW2_INSTALL_SECTION}} NSIS block to download and install WebView2 if missing
+ */
+const NSIS_TEMPLATE = `Unicode true
+ManifestDPIAware true
+; PerMonitorV2 DPI awareness (Windows 10 1607+; ignored on older systems)
+ManifestDPIAwareness PerMonitorV2
+
+SetCompressor /SOLID lzma
+SetCompressorDictSize 32
+
+!include "MUI2.nsh"
+!include "FileFunc.nsh"
+!include "WordFunc.nsh"
+!include "nsDialogs.nsh"
+
+; ── App metadata ─────────────────────────────────────────────────────────────
+!define APP_NAME        "{{APP_NAME}}"
+!define APP_NAME_SAN    "{{APP_NAME_SANITIZED}}"
+!define APP_VERSION     "{{APP_VERSION}}"
+!define APP_IDENTIFIER  "{{APP_IDENTIFIER}}"
+!define APP_PUBLISHER   "{{APP_PUBLISHER}}"
+!define INSTALL_MODE    "{{INSTALL_MODE}}"
+!define ALLOW_DOWNGRADES {{ALLOW_DOWNGRADES}}
+
+; Registry keys
+!define REG_UNINSTALL "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\$\{APP_IDENTIFIER}"
+!define REG_APP       "Software\\$\{APP_PUBLISHER}\\$\{APP_NAME_SAN}"
+
+; ── MUI2 appearance ───────────────────────────────────────────────────────────
+{{MUI_ICON_LINE}}
+{{MUI_UNICON_LINE}}
+!define MUI_ABORTWARNING
+!define MUI_FINISHPAGE_NOAUTOCLOSE
+
+; ── General ───────────────────────────────────────────────────────────────────
+Name "$\{APP_NAME} $\{APP_VERSION}"
+OutFile "{{OUTPUT_FILE}}"
+
+!if "$\{INSTALL_MODE}" == "perMachine"
+  RequestExecutionLevel admin
+  InstallDir "$PROGRAMFILES64\\$\{APP_NAME}"
+!else
+  RequestExecutionLevel user
+  InstallDir "{{INSTALL_DIR}}"
+!endif
+
+InstallDirRegKey HKCU "$\{REG_APP}" "InstallLocation"
+
+; ── Version info (embedded in .exe PE header) ─────────────────────────────────
+VIProductVersion "{{APP_VERSION_4SEG}}"
+VIAddVersionKey "ProductName"     "$\{APP_NAME}"
+VIAddVersionKey "ProductVersion"  "$\{APP_VERSION}"
+VIAddVersionKey "CompanyName"     "$\{APP_PUBLISHER}"
+VIAddVersionKey "FileDescription" "$\{APP_NAME} Installer"
+VIAddVersionKey "FileVersion"     "$\{APP_VERSION}"
+VIAddVersionKey "LegalCopyright"  "$\{APP_PUBLISHER}"
+
+; ── Runtime variables ─────────────────────────────────────────────────────────
+Var PassiveMode
+Var UpdateMode
+Var NoShortcutMode
+Var ReinstallAction     ; 1=reinstall/upgrade  2=uninstall
+Var InstalledVersion
+Var VersionCmp          ; 0=same 1=newer 2=downgrade
+Var LegacyFound         ; 1 if a legacy extractor install was detected
+
+; ── Installer pages ───────────────────────────────────────────────────────────
+!define MUI_PAGE_CUSTOMFUNCTION_PRE SkipIfPassive
+!insertmacro MUI_PAGE_WELCOME
+
+; Custom reinstall/upgrade page (shown only when an existing install is found)
+Page custom PageReinstall PageLeaveReinstall
+
+!define MUI_PAGE_CUSTOMFUNCTION_PRE SkipIfPassive
+!insertmacro MUI_PAGE_DIRECTORY
+
+!insertmacro MUI_PAGE_INSTFILES
+
+; Finish page — offer to launch the app
+!define MUI_FINISHPAGE_RUN          "$INSTDIR\\bin\\launcher.exe"
+!define MUI_FINISHPAGE_RUN_TEXT     "Launch $\{APP_NAME}"
+!define MUI_PAGE_CUSTOMFUNCTION_PRE SkipIfPassive
+!insertmacro MUI_PAGE_FINISH
+
+; ── Uninstaller pages ─────────────────────────────────────────────────────────
+Var DeleteAppDataCheckbox
+Var DeleteAppDataCheckboxState
+
+!define MUI_PAGE_CUSTOMFUNCTION_SHOW un.AddDeleteDataCheckbox
+!define MUI_PAGE_CUSTOMFUNCTION_LEAVE un.ReadDeleteDataCheckbox
+!define MUI_PAGE_CUSTOMFUNCTION_PRE  un.SkipIfPassive
+!insertmacro MUI_UNPAGE_CONFIRM
+
+!insertmacro MUI_UNPAGE_INSTFILES
+
+; ── Language ──────────────────────────────────────────────────────────────────
+!insertmacro MUI_LANGUAGE "English"
+
+; ── .onInit ───────────────────────────────────────────────────────────────────
+Function .onInit
+  ; Parse command-line flags
+  $\{GetOptions} $CMDLINE "/P" $PassiveMode
+  $\{IfNot} $\{Errors}
+    StrCpy $PassiveMode 1
+  $\{EndIf}
+
+  $\{GetOptions} $CMDLINE "/NS" $NoShortcutMode
+  $\{IfNot} $\{Errors}
+    StrCpy $NoShortcutMode 1
+  $\{EndIf}
+
+  $\{GetOptions} $CMDLINE "/UPDATE" $UpdateMode
+  $\{IfNot} $\{Errors}
+    StrCpy $UpdateMode 1
+  $\{EndIf}
+
+  ; Restore previous install location (if user has installed before)
+  Call RestorePreviousInstallLocation
+
+  ; Detect legacy extractor-based install (flag only — cleanup after install succeeds)
+{{LEGACY_DETECT_BLOCK}}
+
+  !if "$\{INSTALL_MODE}" == "perMachine"
+    SetShellVarContext all
+    SetRegView 64
+  !else
+    SetShellVarContext current
+  !endif
+FunctionEnd
+
+; ── Reinstall detection page ──────────────────────────────────────────────────
+Function PageReinstall
+  ; Check for an existing installation
+  ReadRegStr $0 HKCU "$\{REG_UNINSTALL}" "DisplayVersion"
+  ; Also check HKLM for per-machine installs
+  $\{If} $0 == ""
+    ReadRegStr $0 HKLM "$\{REG_UNINSTALL}" "DisplayVersion"
+  $\{EndIf}
+  $\{IfThen} $0 == "" $\{|} Abort $\{|}  ; No existing install — skip this page
+
+  StrCpy $InstalledVersion $0
+
+  ; Compare versions: 0=same, 1=new>installed (upgrade), 2=new<installed (downgrade)
+  $\{VersionCompare} "$\{APP_VERSION}" "$InstalledVersion" $VersionCmp
+
+  ; In update mode, always overlay-install (skip this page)
+  $\{If} $UpdateMode = 1
+    Abort
+  $\{EndIf}
+
+  ; In passive/silent mode, handle automatically
+  $\{If} $PassiveMode = 1
+  $\{OrIf} $\{Silent}
+    ; Upgrading: proceed (will overwrite files)
+    $\{If} $VersionCmp = 1
+      Abort
+    $\{EndIf}
+    ; Downgrading and not allowed: abort
+    !if "$\{ALLOW_DOWNGRADES}" == "false"
+      $\{If} $VersionCmp = 2
+        MessageBox MB_ICONSTOP "A newer version of $\{APP_NAME} ($InstalledVersion) is already installed.$\\nDowngrades are not allowed." /SD IDOK
+        Abort
+      $\{EndIf}
+    !endif
+    ; Same version or allowed downgrade: reinstall
+    Abort
+  $\{EndIf}
+
+  ; ── Show reinstall/upgrade dialog ─────────────────────────────────────────
+  nsDialogs::Create 1018
+  Pop $R0
+  $\{If} $R0 == error
+    Abort
+  $\{EndIf}
+
+  ; Determine dialog text based on version comparison
+  $\{If} $VersionCmp = 0
+    $\{NSD_CreateLabel} 0 0 100% 40u "Version $InstalledVersion of $\{APP_NAME} is already installed.$\\n$\\nChoose an option below:"
+    Pop $R1
+    $\{NSD_CreateRadioButton} 20u 50u -20u 10u "Reinstall (overwrite existing files)"
+    Pop $R2
+    $\{NSD_CreateRadioButton} 20u 65u -20u 10u "Uninstall $\{APP_NAME}"
+    Pop $R3
+  $\{ElseIf} $VersionCmp = 1
+    $\{NSD_CreateLabel} 0 0 100% 40u "Version $InstalledVersion of $\{APP_NAME} is installed.$\\nYou are installing version $\{APP_VERSION} (upgrade).$\\n$\\nChoose an option below:"
+    Pop $R1
+    $\{NSD_CreateRadioButton} 20u 50u -20u 10u "Upgrade (recommended)"
+    Pop $R2
+    $\{NSD_CreateRadioButton} 20u 65u -20u 10u "Keep existing version (cancel)"
+    Pop $R3
+  $\{Else}
+    ; Downgrading
+    !if "$\{ALLOW_DOWNGRADES}" == "false"
+      MessageBox MB_ICONSTOP "A newer version of $\{APP_NAME} ($InstalledVersion) is already installed.$\\nDowngrades are not allowed." /SD IDOK
+      Abort
+    !endif
+    $\{NSD_CreateLabel} 0 0 100% 40u "Version $InstalledVersion of $\{APP_NAME} is installed.$\\nYou are installing an older version ($\{APP_VERSION}).$\\n$\\nDowngrading:"
+    Pop $R1
+    $\{NSD_CreateRadioButton} 20u 50u -20u 10u "Downgrade (uninstall current, install older)"
+    Pop $R2
+    $\{NSD_CreateRadioButton} 20u 65u -20u 10u "Cancel"
+    Pop $R3
+  $\{EndIf}
+
+  SendMessage $R2 $\{BM_SETCHECK} $\{BST_CHECKED} 0  ; default: first option
+  $\{NSD_SetFocus} $R2
+  nsDialogs::Show
+FunctionEnd
+
+Function PageLeaveReinstall
+  $\{NSD_GetState} $R2 $0
+
+  ; If the first radio button is checked — proceed with install/reinstall/upgrade
+  $\{If} $0 = $\{BST_CHECKED}
+    StrCpy $ReinstallAction 1
+    ; Uninstall the existing version first (for upgrade/downgrade/reinstall)
+    ReadRegStr $R1 HKCU "$\{REG_UNINSTALL}" "UninstallString"
+    $\{If} $R1 == ""
+      ReadRegStr $R1 HKLM "$\{REG_UNINSTALL}" "UninstallString"
+    $\{EndIf}
+    $\{If} $R1 != ""
+      HideWindow
+      ExecWait '"$R1" /S _?=$INSTDIR' $0
+      BringToFront
+    $\{EndIf}
+  $\{Else}
+    ; Second option: cancel or uninstall only
+    $\{If} $VersionCmp = 0
+      ; Uninstall only
+      ReadRegStr $R1 HKCU "$\{REG_UNINSTALL}" "UninstallString"
+      $\{If} $R1 == ""
+        ReadRegStr $R1 HKLM "$\{REG_UNINSTALL}" "UninstallString"
+      $\{EndIf}
+      $\{If} $R1 != ""
+        HideWindow
+        ExecWait '"$R1" /S _?=$INSTDIR' $0
+        BringToFront
+      $\{EndIf}
+    $\{EndIf}
+    Abort  ; Cancel the install
+  $\{EndIf}
+FunctionEnd
+
+; ── Install section ───────────────────────────────────────────────────────────
+Section "Install" SecInstall
+  SectionIn RO  ; Required — cannot be deselected
+
+  ; Set working output path to install dir
+  SetOutPath "$INSTDIR"
+
+  ; Copy all files from the extracted app bundle
+  File /r "{{BUNDLE_DIR}}\\*.*"
+
+  ; ── WebView2 runtime installation (if needed) ────────────────────────────
+{{WEBVIEW2_INSTALL_SECTION}}
+
+  ; Write uninstaller
+  WriteUninstaller "$INSTDIR\\Uninstall.exe"
+
+  ; Save install location to registry (used by InstallDirRegKey on re-run)
+  WriteRegStr HKCU "$\{REG_APP}" "InstallLocation" "$INSTDIR"
+
+  ; ── Add/Remove Programs ────────────────────────────────────────────────────
+  WriteRegStr   HKCU "$\{REG_UNINSTALL}" "DisplayName"          "$\{APP_NAME}"
+  WriteRegStr   HKCU "$\{REG_UNINSTALL}" "DisplayVersion"       "$\{APP_VERSION}"
+  WriteRegStr   HKCU "$\{REG_UNINSTALL}" "Publisher"            "$\{APP_PUBLISHER}"
+  WriteRegStr   HKCU "$\{REG_UNINSTALL}" "InstallLocation"      "$INSTDIR"
+  WriteRegStr   HKCU "$\{REG_UNINSTALL}" "UninstallString"      '"$INSTDIR\\Uninstall.exe"'
+  WriteRegStr   HKCU "$\{REG_UNINSTALL}" "QuietUninstallString" '"$INSTDIR\\Uninstall.exe" /S'
+  WriteRegStr   HKCU "$\{REG_UNINSTALL}" "DisplayIcon"          "$INSTDIR\\bin\\launcher.exe"
+  WriteRegDWORD HKCU "$\{REG_UNINSTALL}" "NoModify"             1
+  WriteRegDWORD HKCU "$\{REG_UNINSTALL}" "NoRepair"             1
+
+  ; ── Estimated install size ─────────────────────────────────────────────────
+  $\{GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
+  IntFmt $0 "0x%08X" $0
+  WriteRegDWORD HKCU "$\{REG_UNINSTALL}" "EstimatedSize" "$0"
+
+  ; ── Shortcuts (skip if /NS was passed) ────────────────────────────────────
+  $\{If} $NoShortcutMode != 1
+  $\{AndIf} $UpdateMode != 1
+    CreateDirectory "$SMPROGRAMS\\{{START_MENU_FOLDER}}"
+    CreateShortcut  "$SMPROGRAMS\\{{START_MENU_FOLDER}}\\$\{APP_NAME}.lnk" \\
+                    "$INSTDIR\\bin\\launcher.exe" "" \\
+                    "$INSTDIR\\bin\\launcher.exe" 0 \\
+                    SW_SHOWNORMAL "" "{{APP_DESCRIPTION}}"
+
+    !if "{{DESKTOP_SHORTCUT}}" == "true"
+      CreateShortcut "$DESKTOP\\$\{APP_NAME}.lnk" \\
+                     "$INSTDIR\\bin\\launcher.exe" "" \\
+                     "$INSTDIR\\bin\\launcher.exe" 0 \\
+                     SW_SHOWNORMAL "" "{{APP_DESCRIPTION}}"
+    !endif
+  $\{EndIf}
+
+  ; ── URL protocol registration ──────────────────────────────────────────────
+{{URL_PROTOCOLS_INSTALL}}
+
+  ; ── Legacy migration cleanup (only after successful install) ───────────────
+{{LEGACY_CLEANUP_BLOCK}}
+
+  ; ── Auto-close in passive/silent/update mode ──────────────────────────────
+  $\{If} $PassiveMode = 1
+  $\{OrIf} $\{Silent}
+    SetAutoClose true
+  $\{EndIf}
+SectionEnd
+
+; ── Post-install: optionally launch app ───────────────────────────────────────
+Function .onInstSuccess
+  $\{If} $PassiveMode = 1
+  $\{OrIf} $\{Silent}
+    $\{GetOptions} $CMDLINE "/R" $R0
+    $\{IfNot} $\{Errors}
+      Exec '"$INSTDIR\\bin\\launcher.exe"'
+    $\{EndIf}
+  $\{EndIf}
+FunctionEnd
+
+; ── Uninstaller ───────────────────────────────────────────────────────────────
+Function un.onInit
+  !if "$\{INSTALL_MODE}" == "perMachine"
+    SetShellVarContext all
+    SetRegView 64
+  !else
+    SetShellVarContext current
+  !endif
+
+  $\{GetOptions} $CMDLINE "/P" $PassiveMode
+  $\{IfNot} $\{Errors}
+    StrCpy $PassiveMode 1
+  $\{EndIf}
+
+  $\{GetOptions} $CMDLINE "/UPDATE" $UpdateMode
+  $\{IfNot} $\{Errors}
+    StrCpy $UpdateMode 1
+  $\{EndIf}
+FunctionEnd
+
+; Add "Delete app data" checkbox to the uninstall confirmation page
+Function un.AddDeleteDataCheckbox
+  FindWindow $R0 "#32770" "" $HWNDPARENT
+  $\{NSD_CreateCheckbox} 0 120u 100% 12u "Also delete application data"
+  Pop $DeleteAppDataCheckbox
+FunctionEnd
+
+Function un.ReadDeleteDataCheckbox
+  $\{NSD_GetState} $DeleteAppDataCheckbox $DeleteAppDataCheckboxState
+FunctionEnd
+
+Function un.SkipIfPassive
+  $\{IfThen} $PassiveMode = 1 $\{|} Abort $\{|}
+FunctionEnd
+
+Section "Uninstall"
+  ; Remove files
+  RMDir /r "$INSTDIR\\bin"
+  RMDir /r "$INSTDIR\\Resources"
+  RMDir /r "$INSTDIR\\lib"
+  Delete    "$INSTDIR\\Info.plist"
+  Delete    "$INSTDIR\\Uninstall.exe"
+  RMDir     "$INSTDIR"
+
+  ; Remove shortcuts (skip if this is an update)
+  $\{If} $UpdateMode != 1
+    Delete "$SMPROGRAMS\\{{START_MENU_FOLDER}}\\$\{APP_NAME}.lnk"
+    RMDir  "$SMPROGRAMS\\{{START_MENU_FOLDER}}"
+    Delete "$DESKTOP\\$\{APP_NAME}.lnk"
+  $\{EndIf}
+
+  ; Remove URL protocols
+{{URL_PROTOCOLS_UNINSTALL}}
+
+  ; Remove registry entries
+  DeleteRegKey HKCU "$\{REG_UNINSTALL}"
+  DeleteRegKey HKCU "$\{REG_APP}"
+
+  ; Remove app data (only when checkbox checked and NOT an update)
+  $\{If} $DeleteAppDataCheckboxState = 1
+  $\{AndIf} $UpdateMode != 1
+{{APPDATA_DELETE_SECTION}}
+  $\{EndIf}
+
+  $\{If} $PassiveMode = 1
+  $\{OrIf} $UpdateMode = 1
+    SetAutoClose true
+  $\{EndIf}
+SectionEnd
+
+; ── Helpers ───────────────────────────────────────────────────────────────────
+Function RestorePreviousInstallLocation
+  ReadRegStr $R0 HKCU "$\{REG_APP}" "InstallLocation"
+  $\{If} $R0 != ""
+    StrCpy $INSTDIR $R0
+  $\{EndIf}
+FunctionEnd
+
+Function SkipIfPassive
+  $\{IfThen} $PassiveMode = 1 $\{|} Abort $\{|}
+FunctionEnd
+`;
+
+// ── Helper functions ──────────────────────────────────────────────────────────
+
+/**
+ * Escape a string for safe use inside an NSIS double-quoted string.
+ * Handles $, ", \, `, !, newlines.
+ */
+export function escapeNsisString(value: string): string {
+	return value
+		.replace(/\\/g, "\\\\")
+		.replace(/"/g, '$\\"')
+		.replace(/\$/g, "$$")
+		.replace(/`/g, "$\\`")
+		.replace(/!/g, "$\\!")
+		.replace(/\n/g, "")
+		.replace(/\r/g, "");
+}
+
+/**
+ * Normalize a semver string to X.Y.Z.W format required by VIProductVersion.
+ * Strips pre-release tags, pads missing segments with 0.
+ *   "1.2.3"        → "1.2.3.0"
+ *   "1.2.3-beta.1" → "1.2.3.0"
+ *   "1.2"          → "1.2.0.0"
+ */
+export function normalizeVersion(version: string): string {
+	const clean = version.split(/[-+]/)[0] ?? "0";
+	const parts = clean.split(".").map((p) => parseInt(p, 10) || 0);
+	while (parts.length < 4) parts.push(0);
+	return parts.slice(0, 4).join(".");
+}
+
+/** Generate NSIS WriteRegStr blocks to register URL protocols. */
+function buildUrlProtocolsInstall(
+	schemes: string[],
+	escapedName: string,
+): string {
+	if (!schemes.length) return "  ; (no URL protocols configured)";
+	return schemes
+		.map((scheme) => {
+			const s = scheme.replace(/[^\w-]/g, "");
+			return [
+				`  WriteRegStr HKCU "Software\\Classes\\${s}" "" "URL:${escapedName} protocol"`,
+				`  WriteRegStr HKCU "Software\\Classes\\${s}" "URL Protocol" ""`,
+				`  WriteRegStr HKCU "Software\\Classes\\${s}\\DefaultIcon" "" "$INSTDIR\\bin\\launcher.exe,0"`,
+				`  WriteRegStr HKCU "Software\\Classes\\${s}\\shell\\open\\command" "" '"$INSTDIR\\bin\\launcher.exe" "%1"'`,
+			].join("\n");
+		})
+		.join("\n\n");
+}
+
+/** Generate NSIS DeleteRegKey blocks to remove URL protocols. */
+function buildUrlProtocolsUninstall(schemes: string[]): string {
+	if (!schemes.length) return "  ; (no URL protocols configured)";
+	return schemes
+		.map((scheme) => {
+			const s = scheme.replace(/[^\w-]/g, "");
+			return `  DeleteRegKey HKCU "Software\\Classes\\${s}"`;
+		})
+		.join("\n");
+}
+
+/**
+ * Generate the NSIS block that detects a legacy extractor-based install.
+ * Placed inside .onInit — only sets $LegacyFound, never deletes anything.
+ */
+function buildLegacyDetectBlock(identifier: string, channel: string): string {
+	const legacyDir = `$LOCALAPPDATA\\${escapeNsisString(identifier)}\\${escapeNsisString(channel)}\\app`;
+	return [
+		`  IfFileExists "${legacyDir}\\bin\\launcher.exe" 0 +2`,
+		`    StrCpy $LegacyFound 1`,
+	].join("\n");
+}
+
+/**
+ * Generate the NSIS block that cleans up a legacy extractor install.
+ * Runs inside the Install section AFTER new files are copied and verified.
+ * Only executes if $LegacyFound was set in .onInit AND the new install
+ * succeeded (verified by checking $INSTDIR\bin\launcher.exe exists).
+ */
+function buildLegacyCleanupBlock(
+	identifier: string,
+	channel: string,
+	appName: string,
+): string {
+	const legacyAppDir = `$LOCALAPPDATA\\${escapeNsisString(identifier)}\\${escapeNsisString(channel)}\\app`;
+	const legacyExtractionDir = `$LOCALAPPDATA\\${escapeNsisString(identifier)}\\${escapeNsisString(channel)}\\self-extraction`;
+	const legacyChannelDir = `$LOCALAPPDATA\\${escapeNsisString(identifier)}\\${escapeNsisString(channel)}`;
+	const legacyIdDir = `$LOCALAPPDATA\\${escapeNsisString(identifier)}`;
+	const escapedAppName = escapeNsisString(appName);
+
+	return [
+		`  $\{If} $LegacyFound = 1`,
+		`    ; Verify new install succeeded before touching legacy files`,
+		`    IfFileExists "$INSTDIR\\bin\\launcher.exe" 0 legacy_skip`,
+		``,
+		`    ; Remove legacy app directory`,
+		`    RMDir /r "${legacyAppDir}"`,
+		``,
+		`    ; Remove legacy self-extraction cache (tars won't match new paths)`,
+		`    RMDir /r "${legacyExtractionDir}"`,
+		``,
+		`    ; Remove legacy desktop shortcut (created by extractor's PowerShell)`,
+		`    Delete "$DESKTOP\\${escapedAppName}.lnk"`,
+		``,
+		`    ; Remove legacy Start Menu shortcut`,
+		`    Delete "$SMPROGRAMS\\${escapedAppName}.lnk"`,
+		``,
+		`    ; Remove parent dirs only if empty`,
+		`    RMDir "${legacyChannelDir}"`,
+		`    RMDir "${legacyIdDir}"`,
+		``,
+		`    legacy_skip:`,
+		`  $\{EndIf}`,
+	].join("\n");
+}
+
+/**
+ * Generate the NSIS block that checks for and installs the WebView2 runtime.
+ * Only emitted when bundleCEF is false (app depends on system WebView2).
+ * Checks both HKLM and HKCU registry keys; downloads the bootstrapper
+ * (~1.8 KB stub) if the runtime is not found.
+ */
+function buildWebView2InstallSection(bundleCEF: boolean): string {
+	if (bundleCEF) {
+		return "  ; (CEF bundled — WebView2 runtime not required)";
+	}
+	return [
+		`  ; Check if WebView2 runtime is already installed`,
+		`  ReadRegStr $0 HKLM "SOFTWARE\\Microsoft\\EdgeUpdate\\Clients\\{F3017226-FE2A-4295-8BEE-13A6279FE04D}" "pv"`,
+		`  $\{If} $0 == ""`,
+		`    ReadRegStr $0 HKCU "SOFTWARE\\Microsoft\\EdgeUpdate\\Clients\\{F3017226-FE2A-4295-8BEE-13A6279FE04D}" "pv"`,
+		`  $\{EndIf}`,
+		`  $\{If} $0 == ""`,
+		`    ; WebView2 runtime not found — download and install the bootstrapper`,
+		`    DetailPrint "Installing Microsoft WebView2 Runtime..."`,
+		`    NSISdl::download "https://go.microsoft.com/fwlink/p/?LinkId=2124703" "$TEMP\\MicrosoftEdgeWebview2Setup.exe"`,
+		`    Pop $0`,
+		`    $\{If} $0 == "success"`,
+		`      ExecWait '"$TEMP\\MicrosoftEdgeWebview2Setup.exe" /silent /install' $0`,
+		`      Delete "$TEMP\\MicrosoftEdgeWebview2Setup.exe"`,
+		`    $\{Else}`,
+		`      ; Download failed — warn but continue (WebView2 may be available via Windows Update)`,
+		`      DetailPrint "Warning: Could not download WebView2 runtime ($0). The app may not work correctly."`,
+		`    $\{EndIf}`,
+		`  $\{Else}`,
+		`    DetailPrint "WebView2 runtime already installed (version $0)"`,
+		`  $\{EndIf}`,
+	].join("\n");
+}
+
+/** Generate NSIS RMDir/Delete blocks for app data directories. */
+function buildAppDataDeleteSection(appDataPaths: string[]): string {
+	if (!appDataPaths.length)
+		return "    ; (no appDataPaths configured — no app data deleted)";
+	return appDataPaths
+		.map(
+			(p) =>
+				`    RMDir /r "$LOCALAPPDATA\\${escapeNsisString(p)}"` +
+				"\n" +
+				`    RMDir /r "$APPDATA\\${escapeNsisString(p)}"`,
+		)
+		.join("\n");
+}
+
+/** Replace all occurrences of {{KEY}} in the template. */
+function renderTemplate(
+	template: string,
+	vars: Record<string, string>,
+): string {
+	let result = template;
+	for (const [key, value] of Object.entries(vars)) {
+		// Replace {{KEY}} globally
+		result = result.replaceAll(`{{${key}}}`, value);
+	}
+	return result;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+export interface NsisInstallerOptions {
+	/** Path to makensis.exe */
+	makensisPath: string;
+	/** Path to the build folder (e.g. build/stable-win-x64) */
+	buildFolder: string;
+	/** Path to the pre-tar extracted app bundle directory */
+	appBundleFolder: string;
+	/** App file name without extension (e.g. "NovaWallet" or "NovaWallet-canary") */
+	appFileName: string;
+	/** The Electrobun config object */
+	config: {
+		app: {
+			name: string;
+			version: string;
+			identifier: string;
+			description?: string;
+			urlSchemes?: string[];
+		};
+		build?: {
+			win?: {
+				bundleCEF?: boolean;
+				nsis?: {
+					enabled?: boolean;
+					installMode?: "currentUser" | "perMachine";
+					allowDowngrades?: boolean;
+					publisher?: string;
+					homepage?: string;
+					desktopShortcut?: boolean;
+					startMenuFolder?: string;
+					appDataPaths?: string[];
+				};
+			};
+		};
+	};
+	/** Build environment: "stable" | "canary" | … */
+	buildEnvironment: string;
+	/** Path to the .ico file for the installer (optional) */
+	icoPath?: string;
+}
+
+/**
+ * Generate a NSIS .exe installer for the given app bundle.
+ *
+ * @returns Absolute path to the compiled installer .exe, or null if NSIS is
+ *          disabled, makensisPath is unavailable, or compilation fails.
+ */
+export async function generateNsisInstaller(
+	opts: NsisInstallerOptions,
+): Promise<string | null> {
+	const { makensisPath, buildFolder, appBundleFolder, appFileName, config, icoPath } =
+		opts;
+
+	const nsisConfig = config.build?.win?.nsis ?? {};
+	if (nsisConfig.enabled === false) return null;
+
+	if (!makensisPath) {
+		console.warn("[nsis] makensisPath not provided — skipping NSIS installer");
+		return null;
+	}
+
+	if (!existsSync(appBundleFolder)) {
+		console.error(`[nsis] App bundle folder not found: ${appBundleFolder}`);
+		return null;
+	}
+
+	// ── Resolve config values ──────────────────────────────────────────────────
+	const appName = config.app.name;
+	const appNameSanitized = appName.replace(/\s+/g, "");
+	const appVersion = config.app.version;
+	const appIdentifier = config.app.identifier;
+	const publisher = nsisConfig.publisher ?? appName;
+	const description = config.app.description ?? appName;
+	const homepage = nsisConfig.homepage ?? "";
+	const installMode = nsisConfig.installMode ?? "currentUser";
+	const allowDowngrades = nsisConfig.allowDowngrades === true ? "true" : "false";
+	const desktopShortcut =
+		nsisConfig.desktopShortcut !== false ? "true" : "false";
+	const startMenuFolder = nsisConfig.startMenuFolder ?? appName;
+	const urlSchemes = config.app.urlSchemes ?? [];
+	const appDataPaths = nsisConfig.appDataPaths ?? [];
+
+	// Install directory
+	const installDir =
+		installMode === "perMachine"
+			? `$PROGRAMFILES64\\${escapeNsisString(appName)}`
+			: `$LOCALAPPDATA\\${escapeNsisString(appName)}`;
+
+	// appFileName already includes the full naming convention (e.g.
+	// "NovaWallet-Setup-nsis" or "NovaWallet-canary-Setup-nsis") as produced
+	// by getNsisSetupFileName() in naming.ts, so just append the extension.
+	const outputFile = join(buildFolder, `${appFileName}.exe`);
+
+	// Icon directives
+	const muiIconLine = icoPath
+		? `!define MUI_ICON    "${icoPath.replace(/\\/g, "\\\\")}"`
+		: "";
+	const muiUniconLine = icoPath
+		? `!define MUI_UNICON  "${icoPath.replace(/\\/g, "\\\\")}"`
+		: "";
+
+	// ── Render template ───────────────────────────────────────────────────────
+	const vars: Record<string, string> = {
+		APP_NAME: escapeNsisString(appName),
+		APP_NAME_SANITIZED: escapeNsisString(appNameSanitized),
+		APP_VERSION: escapeNsisString(appVersion),
+		APP_VERSION_4SEG: normalizeVersion(appVersion),
+		APP_IDENTIFIER: escapeNsisString(appIdentifier),
+		APP_PUBLISHER: escapeNsisString(publisher),
+		APP_DESCRIPTION: escapeNsisString(description),
+		HOMEPAGE: escapeNsisString(homepage),
+		OUTPUT_FILE: outputFile.replace(/\\/g, "\\\\"),
+		BUNDLE_DIR: appBundleFolder.replace(/\\/g, "\\\\"),
+		INSTALL_DIR: installDir,
+		INSTALL_MODE: installMode,
+		ALLOW_DOWNGRADES: allowDowngrades,
+		DESKTOP_SHORTCUT: desktopShortcut,
+		START_MENU_FOLDER: escapeNsisString(startMenuFolder),
+		MUI_ICON_LINE: muiIconLine,
+		MUI_UNICON_LINE: muiUniconLine,
+		URL_PROTOCOLS_INSTALL: buildUrlProtocolsInstall(
+			urlSchemes,
+			escapeNsisString(appName),
+		),
+		URL_PROTOCOLS_UNINSTALL: buildUrlProtocolsUninstall(urlSchemes),
+		APPDATA_DELETE_SECTION: buildAppDataDeleteSection(appDataPaths),
+		LEGACY_DETECT_BLOCK: buildLegacyDetectBlock(
+			appIdentifier,
+			opts.buildEnvironment,
+		),
+		LEGACY_CLEANUP_BLOCK: buildLegacyCleanupBlock(
+			appIdentifier,
+			opts.buildEnvironment,
+			appName,
+		),
+		WEBVIEW2_INSTALL_SECTION: buildWebView2InstallSection(
+			config.build?.win?.bundleCEF ?? false,
+		),
+	};
+
+	const renderedScript = renderTemplate(NSIS_TEMPLATE, vars);
+
+	// ── Write .nsi script ─────────────────────────────────────────────────────
+	mkdirSync(buildFolder, { recursive: true });
+	const scriptPath = join(buildFolder, `${appFileName}-installer.nsi`);
+	writeFileSync(scriptPath, renderedScript, "utf8");
+	console.log(`[nsis] Script written to ${scriptPath}`);
+
+	// ── Compile ───────────────────────────────────────────────────────────────
+	console.log(`[nsis] Compiling installer with ${makensisPath}...`);
+	const result = spawnSync(makensisPath, [scriptPath], {
+		stdio: "inherit",
+		encoding: "utf8",
+		cwd: buildFolder,
+	});
+
+	if (result.error) {
+		console.error(`[nsis] Failed to spawn makensis: ${result.error.message}`);
+		return null;
+	}
+	if (result.status !== 0) {
+		console.error(`[nsis] makensis exited with code ${result.status}`);
+		return null;
+	}
+
+	if (!existsSync(outputFile)) {
+		console.error(`[nsis] Compiled installer not found at ${outputFile}`);
+		return null;
+	}
+
+	console.log(`[nsis] Installer created: ${outputFile}`);
+	return outputFile;
+}

--- a/package/src/installer/nsis.ts
+++ b/package/src/installer/nsis.ts
@@ -340,6 +340,9 @@ Section "Install" SecInstall
     !endif
   $\{EndIf}
 
+  ; Refresh Windows icon cache so new shortcuts display the correct icon
+  nsExec::ExecToLog 'ie4uinit.exe -show'
+
   ; ── URL protocol registration ──────────────────────────────────────────────
 {{URL_PROTOCOLS_INSTALL}}
 
@@ -414,6 +417,9 @@ Section "Uninstall"
     RMDir  "$SMPROGRAMS\\{{START_MENU_FOLDER}}"
     Delete "$DESKTOP\\$\{APP_NAME}.lnk"
   $\{EndIf}
+
+  ; Refresh Windows icon cache after removing shortcuts
+  nsExec::ExecToLog 'ie4uinit.exe -show'
 
   ; Remove URL protocols
 {{URL_PROTOCOLS_UNINSTALL}}

--- a/package/src/installer/tools.ts
+++ b/package/src/installer/tools.ts
@@ -1,0 +1,337 @@
+/**
+ * Installer tool auto-download and caching.
+ *
+ * Locates or downloads NSIS and WiX v3 to ~/.electrobun/tools/.
+ * Follows the same caching pattern as ensureCoreDependencies in the CLI.
+ *
+ * These tools are only relevant on Windows builds — both functions return null
+ * on non-Windows hosts.
+ */
+
+import { join } from "path";
+import {
+	existsSync,
+	mkdirSync,
+	unlinkSync,
+	renameSync,
+	rmSync,
+	readdirSync,
+	readFileSync,
+} from "fs";
+import { execSync, spawnSync } from "child_process";
+import { homedir } from "os";
+import { createHash } from "crypto";
+
+const ELECTROBUN_TOOLS_DIR = join(homedir(), ".electrobun", "tools");
+
+// ── NSIS ──────────────────────────────────────────────────────────────────────
+
+const NSIS_VERSION = "3.10";
+const NSIS_DIR = join(ELECTROBUN_TOOLS_DIR, `nsis-${NSIS_VERSION}`);
+const NSIS_MAKENSIS = join(NSIS_DIR, "makensis.exe");
+
+// SourceForge CDN direct link (no JS redirect)
+const NSIS_ZIP_URL = `https://netcologne.dl.sourceforge.net/project/nsis/NSIS%203/${NSIS_VERSION}/nsis-${NSIS_VERSION}.zip`;
+
+/** Common NSIS install locations on Windows */
+const NSIS_SYSTEM_PATHS = [
+	"C:\\Program Files (x86)\\NSIS\\makensis.exe",
+	"C:\\Program Files\\NSIS\\makensis.exe",
+];
+
+// ── WiX v3 ───────────────────────────────────────────────────────────────────
+
+const WIX_TAG = "wix3141rtm";
+const WIX_DIR = join(ELECTROBUN_TOOLS_DIR, "wix314");
+const WIX_CANDLE = join(WIX_DIR, "candle.exe");
+const WIX_LIGHT = join(WIX_DIR, "light.exe");
+const WIX_ZIP_URL = `https://github.com/wixtoolset/wix3/releases/download/${WIX_TAG}/wix314-binaries.zip`;
+
+// ── Pinned SHA-256 hashes for downloaded tool binaries ────────────────────────
+// These must be updated when tool versions are bumped.
+// To compute: sha256sum nsis-3.10.zip / wix314-binaries.zip
+const NSIS_ZIP_SHA256 =
+	"6b0f33ec631ac3218d7dddff44e3d7a1668610ed3ac1e24fcaeec4c458c3614b";
+const WIX_ZIP_SHA256 =
+	"34dcbba9952902bfb710161bd45ee2e721ffa878db99f738285a21c9b09c6edb";
+
+// ── Shared helpers ────────────────────────────────────────────────────────────
+
+function findOnPath(name: string): string | null {
+	try {
+		const result = spawnSync("where.exe", [name], { encoding: "utf8" });
+		if (result.status === 0) {
+			const first = result.stdout.trim().split(/\r?\n/)[0]?.trim();
+			return first || null;
+		}
+	} catch {
+		/* ignore */
+	}
+	return null;
+}
+
+async function downloadFile(url: string, destPath: string): Promise<void> {
+	console.log(`[electrobun] Downloading ${url}`);
+	const response = await fetch(url, { redirect: "follow" });
+	if (!response.ok) {
+		throw new Error(`HTTP ${response.status} fetching ${url}`);
+	}
+	const buffer = await response.arrayBuffer();
+	await Bun.write(destPath, buffer);
+	const mb = (buffer.byteLength / 1024 / 1024).toFixed(2);
+	console.log(`[electrobun] Downloaded ${mb} MB → ${destPath}`);
+}
+
+/**
+ * Verify that a file on disk matches the expected SHA-256 hash.
+ * Throws if the hash doesn't match (possible supply-chain compromise).
+ */
+function verifyFileHash(filePath: string, expectedHash: string): void {
+	const fileBuffer = readFileSync(filePath);
+	const actualHash = createHash("sha256").update(new Uint8Array(fileBuffer)).digest("hex");
+	if (actualHash !== expectedHash) {
+		throw new Error(
+			`SHA-256 mismatch for ${filePath}!\n` +
+				`  Expected: ${expectedHash}\n` +
+				`  Actual:   ${actualHash}\n` +
+				`  The downloaded file may be corrupted or tampered with.`,
+		);
+	}
+	console.log(`[electrobun] SHA-256 verified: ${filePath}`);
+}
+
+function extractZip(zipPath: string, destDir: string): void {
+	mkdirSync(destDir, { recursive: true });
+
+	// Windows tar.exe (bsdtar) misinterprets drive letters (e.g. "C:") as remote
+	// host specifiers and fails with "Cannot connect to C: resolve failed".
+	// PowerShell's Expand-Archive is the reliable cross-version solution on Windows.
+	// Escape single quotes in paths to prevent injection into PS strings.
+	const psZip = zipPath.replace(/\\/g, "/").replace(/'/g, "''");
+	const psDest = destDir.replace(/\\/g, "/").replace(/'/g, "''");
+	execSync(
+		`powershell -NoProfile -NonInteractive -Command ` +
+			`"Expand-Archive -LiteralPath '${psZip}' -DestinationPath '${psDest}' -Force"`,
+		{ stdio: "pipe" },
+	);
+
+	const count = readdirSync(destDir).length;
+	if (count === 0) {
+		throw new Error(
+			`Expand-Archive produced an empty directory. ` +
+				`Zip: ${zipPath} → Dest: ${destDir}`,
+		);
+	}
+}
+
+/**
+ * Search for an executable in a directory and its immediate subdirectories.
+ * Handles zip structures that are flat (exe at root) or have a single root folder.
+ */
+function findExeInDir(dir: string, exeName: string): string | null {
+	// Direct at root
+	const direct = join(dir, exeName);
+	if (existsSync(direct)) return direct;
+
+	// Inside a single subdirectory
+	try {
+		for (const entry of readdirSync(dir, { withFileTypes: true })) {
+			if (entry.isDirectory()) {
+				const candidate = join(dir, entry.name, exeName);
+				if (existsSync(candidate)) return candidate;
+			}
+		}
+	} catch {
+		/* ignore */
+	}
+	return null;
+}
+
+/**
+ * Find makensis.exe after extraction.
+ * NSIS zip has structure: nsis-3.10/makensis.exe OR makensis.exe at root.
+ */
+function findMakensisInDir(dir: string): string | null {
+	return findExeInDir(dir, "makensis.exe");
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Returns the path to makensis.exe, downloading NSIS if necessary.
+ * Returns null on non-Windows hosts or if install fails.
+ */
+export async function ensureNsis(): Promise<string | null> {
+	if (process.platform !== "win32") return null;
+
+	// 1. System PATH
+	const onPath = findOnPath("makensis");
+	if (onPath && verifyNsisVersion(onPath)) return onPath;
+
+	// 2. Common install locations
+	for (const candidate of NSIS_SYSTEM_PATHS) {
+		if (existsSync(candidate) && verifyNsisVersion(candidate)) return candidate;
+	}
+
+	// 3. Cached download
+	if (existsSync(NSIS_MAKENSIS) && verifyNsisVersion(NSIS_MAKENSIS)) {
+		return NSIS_MAKENSIS;
+	}
+
+	// 4. Auto-download
+	console.log(
+		`[electrobun] NSIS ${NSIS_VERSION} not found — downloading automatically...`,
+	);
+	mkdirSync(ELECTROBUN_TOOLS_DIR, { recursive: true });
+	const zipPath = join(ELECTROBUN_TOOLS_DIR, `nsis-${NSIS_VERSION}.zip`);
+	const tempDir = join(ELECTROBUN_TOOLS_DIR, `nsis-${NSIS_VERSION}-tmp`);
+
+	try {
+		await downloadFile(NSIS_ZIP_URL, zipPath);
+		verifyFileHash(zipPath, NSIS_ZIP_SHA256);
+
+		if (existsSync(tempDir)) rmSync(tempDir, { recursive: true, force: true });
+		extractZip(zipPath, tempDir);
+		unlinkSync(zipPath);
+
+		// Find makensis.exe in the extracted tree and promote it to NSIS_DIR
+		const found = findMakensisInDir(tempDir);
+		if (!found) throw new Error("makensis.exe not found in extracted zip");
+
+		if (existsSync(NSIS_DIR)) rmSync(NSIS_DIR, { recursive: true, force: true });
+
+		// The makensis.exe might be at tempDir/nsis-x.y/makensis.exe
+		// or at tempDir/makensis.exe (flat zip).
+		const makensisDirname = join(found, "..");
+		if (makensisDirname === tempDir) {
+			// Flat: rename the whole tempDir to NSIS_DIR
+			renameSync(tempDir, NSIS_DIR);
+		} else {
+			// Nested: rename the inner folder
+			renameSync(makensisDirname, NSIS_DIR);
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+
+		const finalMakensis = join(NSIS_DIR, "makensis.exe");
+		if (existsSync(finalMakensis) && verifyNsisVersion(finalMakensis)) {
+			console.log(`[electrobun] NSIS installed to ${NSIS_DIR}`);
+			return finalMakensis;
+		}
+		throw new Error(`makensis.exe not functional after download`);
+	} catch (err) {
+		// Clean up on failure
+		try {
+			if (existsSync(zipPath)) unlinkSync(zipPath);
+			if (existsSync(tempDir)) rmSync(tempDir, { recursive: true, force: true });
+		} catch {
+			/* ignore */
+		}
+		console.warn(`[electrobun] Failed to auto-install NSIS: ${err}`);
+		console.warn(
+			`[electrobun] Please install NSIS manually: https://nsis.sourceforge.io/Download`,
+		);
+		console.warn(
+			`[electrobun] Or via Chocolatey (CI): choco install nsis --yes --no-progress`,
+		);
+		return null;
+	}
+}
+
+function verifyNsisVersion(makensisPath: string): boolean {
+	try {
+		const result = spawnSync(makensisPath, ["/VERSION"], {
+			encoding: "utf8",
+			timeout: 5000,
+		});
+		if (result.status === 0 && result.stdout) {
+			// Output is e.g. "v3.11" — strip the leading "v" before parsing
+			const versionStr = result.stdout.trim().replace(/^v/i, "");
+			const major = parseInt(versionStr.split(".")[0] ?? "0", 10);
+			if (major >= 3) return true;
+			console.warn(
+				`[electrobun] Found NSIS ${result.stdout.trim()} at ${makensisPath}, but version 3.x+ is required`,
+			);
+		}
+	} catch {
+		/* ignore */
+	}
+	return false;
+}
+
+/**
+ * Returns paths to candle.exe and light.exe (WiX v3 compiler + linker),
+ * downloading WiX if necessary.
+ * Returns null on non-Windows hosts or if install fails.
+ */
+export async function ensureWix(): Promise<{
+	candle: string;
+	light: string;
+} | null> {
+	if (process.platform !== "win32") return null;
+
+	// 1. System PATH
+	const candleOnPath = findOnPath("candle");
+	const lightOnPath = findOnPath("light");
+	if (candleOnPath && lightOnPath) {
+		return { candle: candleOnPath, light: lightOnPath };
+	}
+
+	// 2. Cached download
+	if (existsSync(WIX_CANDLE) && existsSync(WIX_LIGHT)) {
+		return { candle: WIX_CANDLE, light: WIX_LIGHT };
+	}
+
+	// 3. Auto-download
+	console.log(`[electrobun] WiX v3 not found — downloading automatically...`);
+	mkdirSync(ELECTROBUN_TOOLS_DIR, { recursive: true });
+	const zipPath = join(ELECTROBUN_TOOLS_DIR, `wix314-binaries.zip`);
+
+	try {
+		await downloadFile(WIX_ZIP_URL, zipPath);
+		verifyFileHash(zipPath, WIX_ZIP_SHA256);
+
+		const tempWixDir = `${WIX_DIR}-tmp`;
+		if (existsSync(tempWixDir))
+			rmSync(tempWixDir, { recursive: true, force: true });
+		if (existsSync(WIX_DIR)) rmSync(WIX_DIR, { recursive: true, force: true });
+
+		// WiX zip is typically flat (binaries at root), but search subdirs too.
+		extractZip(zipPath, tempWixDir);
+		unlinkSync(zipPath);
+
+		// Find candle.exe — it may be at the root or inside a single subdirectory
+		const foundCandle = findExeInDir(tempWixDir, "candle.exe");
+		const foundLight = findExeInDir(tempWixDir, "light.exe");
+		if (!foundCandle || !foundLight) {
+			throw new Error("candle.exe / light.exe not found after extraction");
+		}
+
+		// Promote: if the exes are inside a subdirectory, rename that dir to WIX_DIR
+		const candleParent = join(foundCandle, "..");
+		if (candleParent === tempWixDir) {
+			renameSync(tempWixDir, WIX_DIR);
+		} else {
+			renameSync(candleParent, WIX_DIR);
+			rmSync(tempWixDir, { recursive: true, force: true });
+		}
+
+		const finalCandle = join(WIX_DIR, "candle.exe");
+		const finalLight = join(WIX_DIR, "light.exe");
+		if (existsSync(finalCandle) && existsSync(finalLight)) {
+			console.log(`[electrobun] WiX v3 installed to ${WIX_DIR}`);
+			return { candle: finalCandle, light: finalLight };
+		}
+		throw new Error("candle.exe / light.exe not functional after install");
+	} catch (err) {
+		try {
+			if (existsSync(zipPath)) unlinkSync(zipPath);
+		} catch {
+			/* ignore */
+		}
+		console.warn(`[electrobun] Failed to auto-install WiX v3: ${err}`);
+		console.warn(
+			`[electrobun] Please install WiX v3 manually: https://github.com/wixtoolset/wix3/releases`,
+		);
+		return null;
+	}
+}

--- a/package/src/installer/wix.ts
+++ b/package/src/installer/wix.ts
@@ -1,0 +1,727 @@
+/**
+ * WiX v3 .msi installer generator for Electrobun Windows builds.
+ *
+ * Generates a native Windows Installer (MSI) package suitable for:
+ *  - Group Policy / SCCM / Intune / MDM deployment
+ *  - Per-user installation (no admin rights required by default)
+ *  - Seamless major upgrades via the MajorUpgrade element
+ *  - Stable UpgradeCode GUID derived from config.app.identifier (UUID v5)
+ *  - Start Menu and Desktop shortcuts
+ *  - High compression (LZMA via WiX cab)
+ *
+ * Requires WiX v3 (candle.exe + light.exe).
+ * Auto-downloads via ensureWix() in tools.ts.
+ */
+
+import { join, relative } from "path";
+import { writeFileSync, mkdirSync, existsSync, readdirSync } from "fs";
+import { spawnSync } from "child_process";
+import { createHash } from "crypto";
+
+// ── UUID v5 (stable GUIDs) ────────────────────────────────────────────────────
+
+// Standard DNS namespace UUID as bytes (RFC 4122 §4.3)
+const UUID_NS_DNS = Uint8Array.from(
+	Buffer.from("6ba7b8109dad11d180b400c04fd430c8", "hex"),
+);
+
+/**
+ * Compute a UUID v5 from a namespace UUID + name string.
+ * Used to generate deterministic GUIDs for WiX components and the UpgradeCode.
+ */
+function uuidV5(name: string, ns: Uint8Array = UUID_NS_DNS): string {
+	// SHA-1 hash of namespace + name, then apply UUID v5 version and variant bits
+	const raw: number[] = Array.from(
+		createHash("sha1").update(ns).update(name).digest(),
+	);
+	// version 5
+	raw[6] = ((raw[6] ?? 0) & 0x0f) | 0x50;
+	// variant 10xx
+	raw[8] = ((raw[8] ?? 0) & 0x3f) | 0x80;
+	const h = raw
+		.slice(0, 16)
+		.map((b) => b.toString(16).padStart(2, "0"))
+		.join("");
+	return [
+		h.slice(0, 8),
+		h.slice(8, 12),
+		h.slice(12, 16),
+		h.slice(16, 20),
+		h.slice(20, 32),
+	]
+		.join("-")
+		.toUpperCase();
+}
+
+// ── Directory-tree walking ────────────────────────────────────────────────────
+
+interface FileEntry {
+	/** Absolute path on disk */
+	absolutePath: string;
+	/** Relative path from the bundle root (uses OS path separators) */
+	relativePath: string;
+}
+
+/** Recursively enumerate all files in a directory. */
+function walkDirectory(dir: string, base: string = dir): FileEntry[] {
+	const entries: FileEntry[] = [];
+	for (const dirent of readdirSync(dir, { withFileTypes: true })) {
+		const full = join(dir, dirent.name);
+		if (dirent.isDirectory()) {
+			entries.push(...walkDirectory(full, base));
+		} else if (dirent.isFile()) {
+			entries.push({
+				absolutePath: full,
+				relativePath: relative(base, full),
+			});
+		}
+	}
+	return entries;
+}
+
+// ── ID generation helpers ────────────────────────────────────────────────────
+
+/**
+ * Turn a relative path into a valid WiX XML ID.
+ * IDs must start with a letter or underscore and contain only
+ * letters, digits, underscores, or dots (max 72 chars).
+ */
+function toWixId(prefix: string, relativePath: string): string {
+	const sanitized = relativePath
+		.replace(/[\\\/]/g, "_") // path separators → underscore
+		.replace(/[^a-zA-Z0-9_.]/g, "_") // other non-alnum → underscore
+		.replace(/^(\d)/, "_$1"); // must not start with digit
+	const combined = `${prefix}_${sanitized}`;
+	// WiX IDs are limited to 72 characters; truncate + append hash if needed
+	if (combined.length <= 72) return combined;
+	const tail = createHash("sha1")
+		.update(relativePath)
+		.digest("hex")
+		.slice(0, 8)
+		.toUpperCase();
+	return combined.slice(0, 63) + "_" + tail;
+}
+
+// ── WXS XML generation ────────────────────────────────────────────────────────
+
+interface DirectoryNode {
+	name: string;
+	id: string;
+	children: Map<string, DirectoryNode>;
+	files: FileEntry[];
+}
+
+/** Build a tree of directory nodes from the flat file list. */
+function buildDirTree(files: FileEntry[]): DirectoryNode {
+	const root: DirectoryNode = {
+		name: "",
+		id: "INSTALLFOLDER",
+		children: new Map(),
+		files: [],
+	};
+
+	for (const file of files) {
+		const parts = file.relativePath.split(/[\\/]/);
+		let node = root;
+
+		// Walk down to the containing directory node
+		for (let i = 0; i < parts.length - 1; i++) {
+			const segment = parts[i] as string;
+			if (!node.children.has(segment)) {
+				const childId = toWixId(
+					"Dir",
+					parts.slice(0, i + 1).join("_"),
+				);
+				node.children.set(segment, {
+					name: segment,
+					id: childId,
+					children: new Map(),
+					files: [],
+				});
+			}
+			node = node.children.get(segment)!;
+		}
+		node.files.push(file);
+	}
+
+	return root;
+}
+
+/** Render a DirectoryNode and its children as WiX XML. */
+function renderDirectoryNode(
+	node: DirectoryNode,
+	appIdentifier: string,
+	componentIds: string[],
+	indent: string,
+	perUser: boolean,
+	regRoot: string,
+	registryKeyBase: string,
+): string {
+	const lines: string[] = [];
+
+	// ICE64: per-user directories need RemoveFolder entries for uninstall cleanup
+	if (perUser) {
+		const rmId = toWixId("RM", node.id);
+		const rmCompId = toWixId("CompRM", node.id);
+		const rmCompGuid = uuidV5(`${appIdentifier}/RemoveFolder/${node.id}`);
+		componentIds.push(rmCompId);
+		lines.push(
+			`${indent}<Component Id="${rmCompId}" Guid="${rmCompGuid}">`,
+			`${indent}  <RemoveFolder Id="${rmId}" On="uninstall" />`,
+			`${indent}  <RegistryValue Root="${regRoot}" Key="${registryKeyBase}\\Components" Name="${rmId}" Type="integer" Value="1" KeyPath="yes" />`,
+			`${indent}</Component>`,
+		);
+	}
+
+	// Files in this directory — each gets its own Component
+	for (const file of node.files) {
+		const relPath = file.relativePath;
+		const fileId = toWixId("File", relPath);
+		const compId = toWixId("Comp", relPath);
+		const compGuid = uuidV5(`${appIdentifier}/${relPath}`);
+
+		componentIds.push(compId);
+
+		if (perUser) {
+			// ICE38: per-user components must use a registry key under HKCU as KeyPath
+			lines.push(
+				`${indent}<Component Id="${compId}" Guid="${compGuid}">`,
+				`${indent}  <File Id="${fileId}" Source="${file.absolutePath}" />`,
+				`${indent}  <RegistryValue Root="${regRoot}" Key="${registryKeyBase}\\Components" Name="${fileId}" Type="integer" Value="1" KeyPath="yes" />`,
+				`${indent}</Component>`,
+			);
+		} else {
+			lines.push(
+				`${indent}<Component Id="${compId}" Guid="${compGuid}">`,
+				`${indent}  <File Id="${fileId}" Source="${file.absolutePath}" KeyPath="yes" />`,
+				`${indent}</Component>`,
+			);
+		}
+	}
+
+	// Subdirectories
+	for (const [, child] of node.children) {
+		lines.push(`${indent}<Directory Id="${child.id}" Name="${child.name}">`);
+		lines.push(
+			renderDirectoryNode(child, appIdentifier, componentIds, indent + "  ", perUser, regRoot, registryKeyBase),
+		);
+		lines.push(`${indent}</Directory>`);
+	}
+
+	return lines.join("\n");
+}
+
+/** Build the complete WXS XML document. */
+function buildWxs(opts: {
+	appName: string;
+	appVersion: string;
+	appIdentifier: string;
+	publisher: string;
+	description: string;
+	upgradeCode: string;
+	installFolderName: string;
+	bundleDir: string;
+	icoPath?: string;
+	installMode: "currentUser" | "perMachine";
+	allowDowngrades: boolean;
+	desktopShortcut: boolean;
+	startMenuFolder: string;
+	bundleCEF: boolean;
+	license?: string;
+	bannerImage?: string;
+	dialogImage?: string;
+	homepage?: string;
+	launchAfterInstall: boolean;
+}): string {
+	const {
+		appName,
+		appVersion,
+		appIdentifier,
+		publisher,
+		description,
+		upgradeCode,
+		installFolderName,
+		bundleDir,
+		icoPath,
+		installMode,
+		allowDowngrades,
+		desktopShortcut,
+		startMenuFolder,
+		bundleCEF,
+		license,
+		bannerImage,
+		dialogImage,
+		homepage,
+		launchAfterInstall,
+	} = opts;
+
+	// perMachine installs use HKLM; perUser installs use HKCU
+	const perUser = installMode === "currentUser";
+	const regRoot = perUser ? "HKCU" : "HKLM";
+	const installScope = perUser ? "perUser" : "perMachine";
+	const registryKeyBase = `Software\\${publisher}\\${appName}`;
+
+	// Collect all files from the app bundle
+	const files = walkDirectory(bundleDir);
+	const tree = buildDirTree(files);
+	const componentIds: string[] = [];
+	const directoryBody = renderDirectoryNode(
+		tree,
+		appIdentifier,
+		componentIds,
+		"          ",
+		perUser,
+		regRoot,
+		registryKeyBase,
+	);
+
+	// Stable GUIDs for non-file components
+	const startMenuShortcutGuid = uuidV5(`${appIdentifier}/StartMenuShortcut`);
+	const desktopShortcutGuid = uuidV5(`${appIdentifier}/DesktopShortcut`);
+	const registryCompGuid = uuidV5(`${appIdentifier}/RegistryEntries`);
+
+	// Component refs for the Feature element
+	const featureComponentIds = [
+		...componentIds,
+		"CompStartMenuShortcut",
+		...(desktopShortcut ? ["CompDesktopShortcut"] : []),
+		"CompRegistryEntries",
+	];
+	const compRefs = featureComponentIds
+		.map((id) => `      <ComponentRef Id="${id}" />`)
+		.join("\n");
+
+	// Icon element (optional)
+	const iconSection = icoPath
+		? `    <Icon Id="AppIcon.ico" SourceFile="${icoPath.replace(/\\/g, "\\\\")}" />\n` +
+		  `    <Property Id="ARPPRODUCTICON" Value="AppIcon.ico" />`
+		: "";
+
+	// ── WixUI_InstallDir with smart license handling ──────────────────────────
+	const hasLicense = !!license;
+	const licenseVariable = hasLicense
+		? `\n    <WixVariable Id="WixUILicenseRtf" Value="${escapeXml(license!)}" />`
+		: "";
+	const licenseSkipPublish = hasLicense
+		? ""
+		: `
+      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2">1</Publish>
+      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">1</Publish>`;
+
+	// ── Launch-app checkbox on exit dialog ─────────────────────────────────────
+	const launchSection = launchAfterInstall
+		? `
+    <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Launch ${escapeXml(appName)}" />
+    <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" Value="1" />
+    <CustomAction Id="LaunchApplication" Impersonate="yes"
+                  FileKey="File_bin_launcher.exe" ExeCommand="" Return="asyncNoWait" />`
+		: "";
+
+	const launchPublish = launchAfterInstall
+		? `
+      <Publish Dialog="ExitDialog" Control="Finish" Event="DoAction" Value="LaunchApplication">
+        WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 and NOT Installed
+      </Publish>`
+		: "";
+
+	// ── Banner and dialog image branding ───────────────────────────────────────
+	const bannerVariable = bannerImage
+		? `\n    <WixVariable Id="WixUIBannerBmp" Value="${escapeXml(bannerImage)}" />`
+		: "";
+	const dialogVariable = dialogImage
+		? `\n    <WixVariable Id="WixUIDialogBmp" Value="${escapeXml(dialogImage)}" />`
+		: "";
+
+	// ── Optional homepage ARP properties ──────────────────────────────────────
+	const homepageProperties = homepage
+		? `\n    <Property Id="ARPURLINFOABOUT" Value="${escapeXml(homepage)}" />` +
+		  `\n    <Property Id="ARPHELPLINK" Value="${escapeXml(homepage)}" />` +
+		  `\n    <Property Id="ARPURLUPDATEINFO" Value="${escapeXml(homepage)}" />`
+		: "";
+
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Product
+    Id="*"
+    Name="${escapeXml(appName)}"
+    Language="1033"
+    Version="${sanitizeVersionForMsi(appVersion)}"
+    Manufacturer="${escapeXml(publisher)}"
+    UpgradeCode="${upgradeCode}">
+
+    <!-- Windows Installer 5.0 required for per-user/per-machine install scope (Windows 7+) -->
+    <Package
+      InstallerVersion="500"
+      Compressed="yes"
+      InstallScope="${installScope}"
+      Platform="x64"${description ? `\n      Description="${escapeXml(description)}"` : ""}
+      Manufacturer="${escapeXml(publisher)}" />
+
+    <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
+
+    <!-- Seamless major upgrade: remove old version before installing new -->
+    <MajorUpgrade${allowDowngrades ? "" : `\n      DowngradeErrorMessage="A newer version of ${escapeXml(appName)} is already installed. Downgrading is not supported."`}
+      Schedule="afterInstallInitialize" />
+
+    <!-- Per-user non-advertised shortcuts require this property -->
+    <Property Id="DISABLEADVTSHORTCUTS" Value="1" />
+
+    <!-- Disable Repair/Modify in Add/Remove Programs -->
+    <Property Id="ARPNOREPAIR" Value="yes" Secure="yes" />
+    <SetProperty Id="ARPNOMODIFY" Value="1" After="InstallValidate" Sequence="execute" />
+
+    <!-- Force full file reinstall on upgrade (reinstall all files, rewrite registry, recreate shortcuts) -->
+    <Property Id="REINSTALLMODE" Value="amus" />${homepageProperties}
+
+${iconSection}
+
+    <!-- ── Detect previous install location via registry ───────────────── -->
+    <Property Id="INSTALLFOLDER">
+      <RegistrySearch Id="PrevInstallDir" Root="${regRoot}"
+        Key="Software\\${escapeXml(publisher)}\\${escapeXml(appName)}" Name="InstallDir" Type="raw" />
+    </Property>
+
+    <!-- ── Directory structure ─────────────────────────────────────────── -->
+    <Directory Id="TARGETDIR" Name="SourceDir">
+
+      <!-- Install folder: perUser → %LOCALAPPDATA%; perMachine → %ProgramFiles% -->
+${installMode === "perMachine"
+	? `      <Directory Id="ProgramFiles64Folder">
+        <Directory Id="INSTALLFOLDER" Name="${escapeXml(installFolderName)}">
+${directoryBody}
+        </Directory>
+      </Directory>`
+	: `      <Directory Id="LocalAppDataFolder">
+        <Directory Id="INSTALLFOLDER" Name="${escapeXml(installFolderName)}">
+${directoryBody}
+        </Directory>
+      </Directory>`
+}
+
+      <!-- Start menu -->
+      <Directory Id="ProgramMenuFolder">
+        <Directory Id="AppProgramMenuFolder" Name="${escapeXml(startMenuFolder)}" />
+      </Directory>
+
+      <!-- Desktop -->
+      <Directory Id="DesktopFolder" Name="Desktop" />
+
+    </Directory>
+
+    <!-- ── Start Menu shortcut component ──────────────────────────────── -->
+    <DirectoryRef Id="AppProgramMenuFolder">
+      <Component Id="CompStartMenuShortcut" Guid="${startMenuShortcutGuid}">
+        <Shortcut
+          Id="StartMenuShortcut"
+          Name="${escapeXml(appName)}"${description ? `\n          Description="${escapeXml(description)}"` : ""}
+          Target="[INSTALLFOLDER]bin\\launcher.exe"
+          WorkingDirectory="INSTALLFOLDER"
+          Advertise="no" />
+        <RemoveFolder Id="RemoveAppProgramMenuFolder" Directory="AppProgramMenuFolder" On="uninstall" />
+        <!-- Registry KeyPath required for shortcuts -->
+        <RegistryValue
+          Root="${regRoot}"
+          Key="Software\\${escapeXml(publisher)}\\${escapeXml(appName)}"
+          Name="StartMenuShortcut"
+          Type="integer"
+          Value="1"
+          KeyPath="yes" />
+      </Component>
+    </DirectoryRef>
+${desktopShortcut ? `
+    <!-- ── Desktop shortcut component ─────────────────────────────────── -->
+    <DirectoryRef Id="DesktopFolder">
+      <Component Id="CompDesktopShortcut" Guid="${desktopShortcutGuid}">
+        <Shortcut
+          Id="DesktopShortcut"
+          Name="${escapeXml(appName)}"${description ? `\n          Description="${escapeXml(description)}"` : ""}
+          Target="[INSTALLFOLDER]bin\\launcher.exe"
+          WorkingDirectory="INSTALLFOLDER"
+          Advertise="no" />
+        <RegistryValue
+          Root="${regRoot}"
+          Key="Software\\${escapeXml(publisher)}\\${escapeXml(appName)}"
+          Name="DesktopShortcut"
+          Type="integer"
+          Value="1"
+          KeyPath="yes" />
+      </Component>
+    </DirectoryRef>` : ""}
+
+    <!-- ── Add/Remove Programs registry entries + persist install dir ──── -->
+    <DirectoryRef Id="INSTALLFOLDER">
+      <Component Id="CompRegistryEntries" Guid="${registryCompGuid}">
+        <RegistryValue
+          Root="${regRoot}"
+          Key="Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\${escapeXml(appIdentifier)}"
+          Name="DisplayName"
+          Type="string"
+          Value="${escapeXml(appName)}"
+          KeyPath="yes" />
+        <RegistryValue
+          Root="${regRoot}"
+          Key="Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\${escapeXml(appIdentifier)}"
+          Name="Publisher"
+          Type="string"
+          Value="${escapeXml(publisher)}" />
+        <RegistryValue
+          Root="${regRoot}"
+          Key="Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\${escapeXml(appIdentifier)}"
+          Name="DisplayIcon"
+          Type="string"
+          Value="[INSTALLFOLDER]bin\\launcher.exe" />
+        <!-- Persist install dir for upgrades -->
+        <RegistryValue
+          Root="${regRoot}"
+          Key="Software\\${escapeXml(publisher)}\\${escapeXml(appName)}"
+          Name="InstallDir"
+          Type="string"
+          Value="[INSTALLFOLDER]" />
+      </Component>
+    </DirectoryRef>
+
+${!bundleCEF ? `    <!-- ── WebView2 runtime detection and installation ──────────────── -->
+    <Property Id="WEBVIEW2_INSTALLED">
+      <RegistrySearch
+        Id="WebView2RegSearch"
+        Root="HKLM"
+        Key="SOFTWARE\\Microsoft\\EdgeUpdate\\Clients\\{F3017226-FE2A-4295-8BEE-13A6279FE04D}"
+        Name="pv"
+        Type="raw" />
+    </Property>
+
+    <CustomAction
+      Id="InstallWebView2"
+      Directory="TARGETDIR"
+      ExeCommand='powershell -NoProfile -NonInteractive -WindowStyle Hidden -Command "&amp; { $$bootstrapper = Join-Path $$env:TEMP &apos;MicrosoftEdgeWebview2Setup.exe&apos;; Invoke-WebRequest -Uri &apos;https://go.microsoft.com/fwlink/p/?LinkId=2124703&apos; -OutFile $$bootstrapper -UseBasicParsing; Start-Process -FilePath $$bootstrapper -ArgumentList &apos;/silent /install&apos; -Wait; Remove-Item $$bootstrapper -ErrorAction SilentlyContinue }"'
+      Return="ignore" />
+
+    <InstallExecuteSequence>
+      <Custom Action="InstallWebView2" Before="InstallFinalize">
+        <![CDATA[NOT WEBVIEW2_INSTALLED AND NOT Installed]]>
+      </Custom>
+      <RemoveShortcuts>Installed AND NOT UPGRADINGPRODUCTCODE</RemoveShortcuts>
+    </InstallExecuteSequence>
+` : `    <!-- CEF bundled — WebView2 runtime not required -->
+    <InstallExecuteSequence>
+      <RemoveShortcuts>Installed AND NOT UPGRADINGPRODUCTCODE</RemoveShortcuts>
+    </InstallExecuteSequence>
+`}
+    <!-- ── Feature ─────────────────────────────────────────────────────── -->
+    <Feature Id="Main" Title="${escapeXml(appName)}" Level="1" ConfigurableDirectory="INSTALLFOLDER">
+${compRefs}
+    </Feature>
+${launchSection}
+
+    <!-- ── WixUI_InstallDir wizard UI ──────────────────────────────────── -->
+    <UIRef Id="WixUI_InstallDir" />
+    <UI>
+      <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />${licenseSkipPublish}${launchPublish}
+    </UI>${licenseVariable}${bannerVariable}${dialogVariable}
+
+  </Product>
+</Wix>
+`;
+}
+
+// ── XML / version helpers ──────────────────────────────────────────────────────
+
+function escapeXml(value: string): string {
+	return value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&apos;");
+}
+
+/**
+ * Strip pre-release tags and ensure version is X.Y.Z[.W] (max 4 segments,
+ * all numeric) — required by Windows Installer.
+ */
+function sanitizeVersionForMsi(version: string): string {
+	const clean = version.split(/[-+]/)[0] ?? "0";
+	const parts = clean.split(".").map((p) => parseInt(p, 10) || 0);
+	while (parts.length < 3) parts.push(0);
+	return parts.slice(0, 4).join(".");
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+export interface MsiInstallerOptions {
+	candlePath: string;
+	lightPath: string;
+	buildFolder: string;
+	/** Path to the pre-tar extracted app bundle directory */
+	appBundleFolder: string;
+	appFileName: string;
+	config: {
+		app: {
+			name: string;
+			version: string;
+			identifier: string;
+			description?: string;
+		};
+		build?: {
+			win?: {
+				bundleCEF?: boolean;
+				msi?: {
+					enabled?: boolean;
+					publisher?: string;
+					upgradeCode?: string;
+					installMode?: "currentUser" | "perMachine";
+					allowDowngrades?: boolean;
+					desktopShortcut?: boolean;
+					startMenuFolder?: string;
+					license?: string;
+					bannerImage?: string;
+					dialogImage?: string;
+					homepage?: string;
+					launchAfterInstall?: boolean;
+					additionalCandleArgs?: string[];
+					additionalLightArgs?: string[];
+				};
+			};
+		};
+	};
+	buildEnvironment: string;
+	icoPath?: string;
+}
+
+/**
+ * Generate a WiX v3 .msi installer.
+ *
+ * @returns Absolute path to the compiled .msi, or null if MSI is disabled,
+ *          WiX is unavailable, or compilation fails.
+ */
+export async function generateMsiInstaller(
+	opts: MsiInstallerOptions,
+): Promise<string | null> {
+	const { candlePath, lightPath, buildFolder, appBundleFolder, appFileName, config, icoPath } =
+		opts;
+
+	const msiConfig = config.build?.win?.msi ?? {};
+	if (msiConfig.enabled === false) return null;
+
+	if (!existsSync(appBundleFolder)) {
+		console.error(`[msi] App bundle folder not found: ${appBundleFolder}`);
+		return null;
+	}
+
+	if (!existsSync(candlePath) || !existsSync(lightPath)) {
+		console.error(`[msi] WiX binaries not found: candle=${candlePath} light=${lightPath}`);
+		return null;
+	}
+
+	// ── Config values ─────────────────────────────────────────────────────────
+	const appName = config.app.name;
+	const appVersion = config.app.version;
+	const appIdentifier = config.app.identifier;
+	const publisher = msiConfig.publisher ?? appName;
+	const description = config.app.description ?? "";
+	const installMode = msiConfig.installMode ?? "currentUser";
+	const allowDowngrades = msiConfig.allowDowngrades ?? false;
+	const desktopShortcut = msiConfig.desktopShortcut ?? true;
+	const startMenuFolder = msiConfig.startMenuFolder ?? appName;
+
+	// Stable UpgradeCode: prefer explicit user-supplied GUID, otherwise derive
+	// a deterministic UUID v5 from the app identifier so it never changes across
+	// versions of the same application.
+	const upgradeCode = msiConfig.upgradeCode ?? uuidV5(appIdentifier);
+
+	// Sanitized name matching NSIS convention (no spaces, channel suffix for non-stable)
+	const appNameSanitized = appName.replace(/\s+/g, "");
+	const installFolderName =
+		opts.buildEnvironment === "stable"
+			? appNameSanitized
+			: `${appNameSanitized}-${opts.buildEnvironment}`;
+
+	const outputBaseName = `${appFileName}-setup.msi`;
+	const outputMsi = join(buildFolder, outputBaseName);
+	const outputWxs = join(buildFolder, `${appFileName}-installer.wxs`);
+	const outputWixobj = join(buildFolder, `${appFileName}-installer.wixobj`);
+
+	// ── Generate WXS ──────────────────────────────────────────────────────────
+	console.log(`[msi] Generating WXS for ${appName} ${appVersion}...`);
+	const wxsContent = buildWxs({
+		appName,
+		appVersion,
+		appIdentifier,
+		publisher,
+		description,
+		upgradeCode,
+		installFolderName,
+		bundleDir: appBundleFolder,
+		icoPath,
+		installMode,
+		allowDowngrades,
+		desktopShortcut,
+		startMenuFolder,
+		bundleCEF: config.build?.win?.bundleCEF ?? false,
+		license: msiConfig.license,
+		bannerImage: msiConfig.bannerImage,
+		dialogImage: msiConfig.dialogImage,
+		homepage: msiConfig.homepage,
+		launchAfterInstall: msiConfig.launchAfterInstall ?? true,
+	});
+
+	mkdirSync(buildFolder, { recursive: true });
+	writeFileSync(outputWxs, wxsContent, "utf8");
+	console.log(`[msi] WXS written to ${outputWxs}`);
+
+	// ── candle.exe (compile WXS → .wixobj) ───────────────────────────────────
+	console.log(`[msi] Compiling with candle.exe...`);
+	const candleArgs = [
+		"-nologo",
+		"-arch", "x64",
+		"-ext", "WixUIExtension",
+		"-out", outputWixobj,
+		...(msiConfig.additionalCandleArgs ?? []),
+		outputWxs,
+	];
+	const candleResult = spawnSync(
+		candlePath,
+		candleArgs,
+		{ stdio: "inherit", cwd: buildFolder },
+	);
+
+	if (candleResult.error || candleResult.status !== 0) {
+		console.error(
+			`[msi] candle.exe failed: ${candleResult.error?.message ?? `exit code ${candleResult.status}`}`,
+		);
+		return null;
+	}
+
+	// ── light.exe (link .wixobj → .msi) ──────────────────────────────────────
+	console.log(`[msi] Linking with light.exe...`);
+	const lightArgs = [
+		"-nologo",
+		"-ext", "WixUIExtension",
+		// Suppress ICE validation warnings common with per-user installs
+		"-sw1076",  // ICE76: per-user shortcuts
+		"-sw1073",  // ICE73: per-user shortcuts referenced without advertise
+		"-out", outputMsi,
+		...(msiConfig.additionalLightArgs ?? []),
+		outputWixobj,
+	];
+	const lightResult = spawnSync(
+		lightPath,
+		lightArgs,
+		{ stdio: "inherit", cwd: buildFolder },
+	);
+
+	if (lightResult.error || lightResult.status !== 0) {
+		console.error(
+			`[msi] light.exe failed: ${lightResult.error?.message ?? `exit code ${lightResult.status}`}`,
+		);
+		return null;
+	}
+
+	if (!existsSync(outputMsi)) {
+		console.error(`[msi] Compiled installer not found at ${outputMsi}`);
+		return null;
+	}
+
+	console.log(`[msi] Installer created: ${outputMsi}`);
+	return outputMsi;
+}

--- a/package/src/installer/wix.ts
+++ b/package/src/installer/wix.ts
@@ -496,14 +496,31 @@ ${!bundleCEF ? `    <!-- ── WebView2 runtime detection and installation ─�
       ExeCommand='powershell -NoProfile -NonInteractive -WindowStyle Hidden -Command "&amp; { $$bootstrapper = Join-Path $$env:TEMP &apos;MicrosoftEdgeWebview2Setup.exe&apos;; Invoke-WebRequest -Uri &apos;https://go.microsoft.com/fwlink/p/?LinkId=2124703&apos; -OutFile $$bootstrapper -UseBasicParsing; Start-Process -FilePath $$bootstrapper -ArgumentList &apos;/silent /install&apos; -Wait; Remove-Item $$bootstrapper -ErrorAction SilentlyContinue }"'
       Return="ignore" />
 
+    <!-- Refresh Windows icon cache so shortcuts display the correct icon -->
+    <CustomAction
+      Id="RefreshIconCache"
+      Directory="TARGETDIR"
+      ExeCommand="ie4uinit.exe -show"
+      Return="ignore" />
+
     <InstallExecuteSequence>
       <Custom Action="InstallWebView2" Before="InstallFinalize">
         <![CDATA[NOT WEBVIEW2_INSTALLED AND NOT Installed]]>
       </Custom>
+      <Custom Action="RefreshIconCache" After="InstallFinalize">1</Custom>
       <RemoveShortcuts>Installed AND NOT UPGRADINGPRODUCTCODE</RemoveShortcuts>
     </InstallExecuteSequence>
 ` : `    <!-- CEF bundled — WebView2 runtime not required -->
+
+    <!-- Refresh Windows icon cache so shortcuts display the correct icon -->
+    <CustomAction
+      Id="RefreshIconCache"
+      Directory="TARGETDIR"
+      ExeCommand="ie4uinit.exe -show"
+      Return="ignore" />
+
     <InstallExecuteSequence>
+      <Custom Action="RefreshIconCache" After="InstallFinalize">1</Custom>
       <RemoveShortcuts>Installed AND NOT UPGRADINGPRODUCTCODE</RemoveShortcuts>
     </InstallExecuteSequence>
 `}

--- a/package/src/shared/naming.ts
+++ b/package/src/shared/naming.ts
@@ -92,17 +92,33 @@ export function getTarballFileName(
 }
 
 /**
- * Generates the Windows installer setup file name.
- * Preserves spaces in app name for user-friendly display.
- * Format: "App Name-Setup.exe" (stable) or "App Name-Setup-channel.exe" (non-stable)
+ * Generates the NSIS installer file name.
+ * Uses the sanitized (no-space) app name for artifact URLs.
+ * Format: "AppName-Setup-nsis.exe" (stable) or "AppName-canary-Setup-nsis.exe" (non-stable)
  */
-export function getWindowsSetupFileName(
+export function getNsisSetupFileName(
 	appName: string,
 	buildEnvironment: BuildEnvironment,
 ): string {
+	const sanitized = sanitizeAppName(appName);
 	return buildEnvironment === "stable"
-		? `${appName}-Setup.exe`
-		: `${appName}-Setup-${buildEnvironment}.exe`;
+		? `${sanitized}-Setup-nsis.exe`
+		: `${sanitized}-${buildEnvironment}-Setup-nsis.exe`;
+}
+
+/**
+ * Generates the MSI installer file name.
+ * Uses the sanitized (no-space) app name for artifact URLs.
+ * Format: "AppName-Setup.msi" (stable) or "AppName-canary-Setup.msi" (non-stable)
+ */
+export function getMsiFileName(
+	appName: string,
+	buildEnvironment: BuildEnvironment,
+): string {
+	const sanitized = sanitizeAppName(appName);
+	return buildEnvironment === "stable"
+		? `${sanitized}-Setup.msi`
+		: `${sanitized}-${buildEnvironment}-Setup.msi`;
 }
 
 /**


### PR DESCRIPTION
## Summary

- **NSIS `.exe` installer**: per-user/per-machine installs, desktop & Start Menu shortcuts, uninstaller with optional app-data cleanup, auto-download of NSIS toolchain when not on PATH
- **WiX v3 `.msi` installer**: enterprise-ready MSI packages for GPO/SCCM/Intune deployment, deterministic UpgradeCode, major upgrade support, customizable UI assets, auto-download of WiX v3 toolchain
- **Windows build system improvements**: auto-detect Visual Studio version for CMake generator, fix tar path handling for Git Bash/bsdtar, skip extractor build on Windows (replaced by installer pipeline)
- **Updater enhancements**: detect user-writable vs elevated install dirs — user-writable uses existing `update.bat` + Task Scheduler, elevated (e.g. Program Files) downloads and runs the NSIS installer with `/UPDATE /P /R` for UAC-elevated replacement
- **Config types**: `nsis` and `msi` configuration blocks added to `ElectrobunConfig` with full JSDoc documentation

## Test plan

- [ ] `electrobun build` on Windows produces `.exe` (NSIS) and `.msi` (WiX) installers alongside the existing `.tar.zst`
- [ ] NSIS installer: per-user install, desktop shortcut, Start Menu entry, uninstall via Add/Remove Programs
- [ ] MSI installer: per-user install, upgrade over existing version, uninstall
- [ ] Setting `nsis.enabled: false` or `msi.enabled: false` skips the respective installer
- [ ] Auto-update works from a user-writable install location (update.bat path)
- [ ] Auto-update works from an elevated install location (NSIS /UPDATE path)
- [ ] macOS and Linux builds are unaffected
- [ ] CI builds work without pre-installed NSIS/WiX (auto-download)
