### PR TITLE
fix: views:// URLs without folders fail to load

### DIFF
--- a/package/src/native/linux/nativeWrapper.cpp
+++ b/package/src/native/linux/nativeWrapper.cpp
@@ -536,6 +536,10 @@ public:
         std::string fullPath = "index.html"; // default
         if (url.find("views://") == 0) {
             fullPath = url.substr(8); // Skip "views://"
+            // Strip trailing slashes - WebKit may normalize URLs without folder components
+            while (!fullPath.empty() && (fullPath.back() == '/' || fullPath.back() == '\\')) {
+                fullPath.pop_back();
+            }
         }
         
         // Check if this is the internal HTML request
@@ -9788,6 +9792,10 @@ ELECTROBUN_EXPORT void setWindowIcon(void* window, const char* iconPath) {
         // Handle views:// protocol
         if (actualPath.substr(0, 8) == "views://") {
             std::string viewPath = actualPath.substr(8);
+            // Strip trailing slashes - WebKit may normalize URLs without folder components
+            while (!viewPath.empty() && (viewPath.back() == '/' || viewPath.back() == '\\')) {
+                viewPath.pop_back();
+            }
             
             // Try to load from ASAR archive first if available
             if (g_asarArchive) {

--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -620,6 +620,10 @@ static NSString* normalizeViewsRelativePath(NSString *urlString) {
     while ([relativePath hasPrefix:@"/"]) {
         relativePath = [relativePath substringFromIndex:1];
     }
+    // Strip trailing slashes - WebView may normalize URLs without folder components
+    while ([relativePath hasSuffix:@"/"] && [relativePath length] > 0) {
+        relativePath = [relativePath substringToIndex:[relativePath length] - 1];
+    }
 
     return relativePath;
 }
@@ -5625,6 +5629,10 @@ public:
                 NSLog(@"DEBUG CEF: Processing views:// URL: %s", urlStr.c_str());
                 // Remove the prefix (8 characters for "views://") - FIXED VERSION v2
                 std::string relativePath = urlStr.substr(8);
+                // Strip trailing slashes - WebView may normalize URLs without folder components
+                while (!relativePath.empty() && (relativePath.back() == '/' || relativePath.back() == '\\')) {
+                    relativePath.pop_back();
+                }
                 NSLog(@"DEBUG CEF FIXED: relativePath = '%s'", relativePath.c_str());
                 
                 // Check if this is the internal HTML request.

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -6055,6 +6055,10 @@ static std::shared_ptr<WebView2View> createWebView2View(uint32_t webviewId,
                                         
                                         if (uriStr.substr(0, 8) == "views://") {
                                             std::string filePath = uriStr.substr(8);
+                                            // Strip trailing slashes - WebView2 may normalize URLs without folder components
+                                            while (!filePath.empty() && (filePath.back() == '/' || filePath.back() == '\\')) {
+                                                filePath.pop_back();
+                                            }
                                             std::string content;
 
                                             // Check for internal/index.html (inline HTML content)
@@ -10426,6 +10430,10 @@ void handleViewsSchemeRequest(ICoreWebView2WebResourceRequestedEventArgs* args,
     std::string path;
     if (uriStr.length() > 8) {
         path = uriStr.substr(8); // Remove "views://" prefix
+        // Strip trailing slashes - WebView2 may normalize URLs without folder components
+        while (!path.empty() && (path.back() == '/' || path.back() == '\\')) {
+            path.pop_back();
+        }
     } else {
         path = "index.html"; // Default
     }


### PR DESCRIPTION
When setting up a view directly in the views folder (e.g. `views://home.html`) instead of a subfolder, the HTML file fails to load.

The error log shows:
```
ERROR: Could not open views file: .../views/home.html/
```

Looks like WebView2 adds a trailing slash when normalizing URLs without a path component, so it tries to load `home.html/` as a folder instead of a file.

Fixed by stripping trailing slashes from the path before attempting to load the file. This affects path handling on all three platforms.

Fixes #329