### PR TITLE
Add PiBun to Apps Built with Electrobun

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Visit <a href="https://blackboard.sh/electrobun/">https://blackboard.sh/electrob
 - [Marginalia](https://github.com/lars-hoeijmans/Marginalia) - a simple note taking app
 - [md-browse](https://github.com/needle-tools/md-browse) - a markdown-first browser that converts web pages to clean markdown
 - [peekachu](https://github.com/needle-tools/peekachu) - password manager for AIs; store secrets in your OS keychain and scrub output so AI assistants never see actual values
+- [PiBun](https://github.com/khairold/pibun) - desktop GUI for the Pi coding agent with chat, terminal, git integration, and plugin system
 - [PLEXI](https://github.com/ianjamesburke/PLEXI) - a multi-dimensional terminal multiplexer for the agentic era
 - [Prometheus](https://github.com/opensourcectl/prometheus) - desktop utility toolbox for file cleanup, document manipulation, and image processing
 - [Quiver](https://ataraxy-labs.github.io/quiver/) - desktop app for GitHub PR reviews, merge conflict resolution, and AI commit messages


### PR DESCRIPTION
Adding [PiBun](https://github.com/khairold/pibun) to the apps list.

PiBun is a desktop GUI for the [Pi coding agent](https://github.com/badlogic/pi-mono) — chat with AI, run tools, manage projects, built-in terminal, git integration, themes, and plugins. All in a native Electrobun app.

![PiBun screenshot](https://raw.githubusercontent.com/khairold/pibun/main/media/screenshot.png)

Thanks for building Electrobun — it's been great to work with!