### PR TITLE
fix(core): allow null for BrowserView.ptr type null assignment

### DIFF
--- a/package/src/bun/core/BrowserView.ts
+++ b/package/src/bun/core/BrowserView.ts
@@ -74,7 +74,7 @@ const randomId = Math.random().toString(36).substring(7);
 
 export class BrowserView<T extends RPCWithTransport = RPCWithTransport> {
 	id: number = nextWebviewId++;
-	ptr!: Pointer;
+	ptr: Pointer | null = null;
 	hostWebviewId?: number;
 	windowId!: number;
 	renderer!: "cef" | "native";
@@ -361,7 +361,7 @@ export class BrowserView<T extends RPCWithTransport = RPCWithTransport> {
 			unregisterHandler() {},
 		});
 		this.rpcHandler = undefined;
-		this.ptr = null as any;
+		this.ptr = null;
 		native.symbols.webviewRemove(ptr);
 	}
 


### PR DESCRIPTION
## What
Fixes a TypeScript type safety issue in `BrowserView` by properly allowing `null` values for the `ptr` property.

- Changed `ptr` from `Pointer!` (non-null assertion) to `Pointer | null = null`
- Removed `null as any` type hack in the `remove()` method

## Why
The `ptr` property represents a native pointer that becomes invalid after `remove()` is called. The previous code set it to `null` but the type didn't reflect this, requiring a type cast hack (`as any`) to work around TypeScript.

This fix:
- Makes the types accurately represent the runtime behavior
- Removes the type hack for cleaner code
- Prevents potential runtime errors from improper null handling

