### PR TITLE
feat: native .icon format support for macOS Liquid Glass icons

### DIFF
--- a/package/src/bun/ElectrobunConfig.ts
+++ b/package/src/bun/ElectrobunConfig.ts
@@ -262,7 +262,15 @@ export interface ElectrobunConfig {
 			entitlements?: Record<string, boolean | string | string[]>;
 
 			/**
-			 * Path to .iconset folder containing app icons
+			 * Path to .iconset folder or .icon file (from Icon Composer)
+			 * containing app icons.
+			 *
+			 * - `.iconset` folders are converted to .icns via iconutil
+			 *   (requires Command Line Tools)
+			 * - `.icon` files are compiled via actool, producing Assets.car
+			 *   for Liquid Glass on macOS 26+ and a .icns fallback for older
+			 *   macOS versions (requires Xcode)
+			 *
 			 * @default "icon.iconset"
 			 */
 			icons?: string;

--- a/package/src/cli/index.ts
+++ b/package/src/cli/index.ts
@@ -2039,18 +2039,97 @@ ${schemesXml}
 				const iconDestPath = join(appBundleFolderResourcesPath, "AppIcon.icns");
 				if (existsSync(iconSourceFolder)) {
 					if (OS === "macos") {
-						// Use iconutil to convert .iconset folder to .icns
-						Bun.spawnSync(
-							["iconutil", "-c", "icns", "-o", iconDestPath, iconSourceFolder],
-							{
-								cwd: appBundleFolderResourcesPath,
-								stdio: ["ignore", "inherit", "inherit"],
-								env: {
-									...process.env,
-									ELECTROBUN_BUILD_ENV: buildEnvironment,
+						if (config.build.mac.icons.endsWith(".icon")) {
+							// .icon format (Icon Composer) — compile with actool
+							// Produces Assets.car (Liquid Glass on macOS 26+) and .icns fallback
+							const actoolCheck = Bun.spawnSync(
+								["xcrun", "--find", "actool"],
+								{ stdio: ["ignore", "pipe", "pipe"] },
+							);
+							if (actoolCheck.exitCode !== 0) {
+								throw new Error(
+									"Building .icon files requires Xcode (actool is not available from Command Line Tools alone). " +
+										"Install Xcode from the App Store, or set mac.icons to an .iconset folder instead.",
+								);
+							}
+
+							const iconStem = basename(config.build.mac.icons, ".icon");
+							const partialPlistPath = join(
+								buildFolder,
+								".actool-partial-info.plist",
+							);
+
+							console.log(
+								"Compiling .icon file with actool (requires Xcode)...",
+							);
+							const result = Bun.spawnSync(
+								[
+									"xcrun",
+									"actool",
+									"--compile",
+									appBundleFolderResourcesPath,
+									"--app-icon",
+									iconStem,
+									"--platform",
+									"macosx",
+									"--minimum-deployment-target",
+									"11.0",
+									"--output-partial-info-plist",
+									partialPlistPath,
+									iconSourceFolder,
+								],
+								{
+									cwd: projectRoot,
+									stdio: ["ignore", "inherit", "inherit"],
+									env: {
+										...process.env,
+										ELECTROBUN_BUILD_ENV: buildEnvironment,
+									},
 								},
-							},
-						);
+							);
+
+							if (result.exitCode !== 0) {
+								throw new Error(
+									`actool failed to compile ${config.build.mac.icons} (exit code ${result.exitCode})`,
+								);
+							}
+
+							// actool produces <stem>.icns — rename to AppIcon.icns so
+							// CFBundleIconFile ("AppIcon") resolves correctly
+							const actoolIcns = join(
+								appBundleFolderResourcesPath,
+								`${iconStem}.icns`,
+							);
+							if (existsSync(actoolIcns) && actoolIcns !== iconDestPath) {
+								renameSync(actoolIcns, iconDestPath);
+							}
+						} else {
+							// Use iconutil to convert .iconset folder to .icns
+							const result = Bun.spawnSync(
+								[
+									"iconutil",
+									"-c",
+									"icns",
+									"-o",
+									iconDestPath,
+									iconSourceFolder,
+								],
+								{
+									cwd: appBundleFolderResourcesPath,
+									stdio: ["ignore", "inherit", "inherit"],
+									env: {
+										...process.env,
+										ELECTROBUN_BUILD_ENV: buildEnvironment,
+									},
+								},
+							);
+
+							if (result.exitCode !== 0) {
+								throw new Error(
+									`iconutil failed to convert ${config.build.mac.icons} (exit code ${result.exitCode})`,
+								);
+							}
+						}
 					} else {
 						console.log(
 							`WARNING: Cannot build macOS icons on ${OS} - iconutil is only available on macOS`,
@@ -2172,6 +2251,11 @@ Categories=Utility;Application;
 			config.app.identifier,
 		);
 
+		// When using .icon format, CFBundleIconName is needed for Assets.car lookup
+		const iconName = config.build.mac?.icons?.endsWith(".icon")
+			? basename(config.build.mac.icons, ".icon")
+			: null;
+
 		const InfoPlistContents = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -2187,7 +2271,7 @@ Categories=Utility;Application;
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleIconFile</key>
-    <string>AppIcon</string>${usageDescriptions ? "\n" + usageDescriptions : ""}${urlTypes ? "\n" + urlTypes : ""}
+    <string>AppIcon</string>${iconName ? `\n    <key>CFBundleIconName</key>\n    <string>${iconName}</string>` : ""}${usageDescriptions ? "\n" + usageDescriptions : ""}${urlTypes ? "\n" + urlTypes : ""}
 </dict>
 </plist>`;
 


### PR DESCRIPTION
## Summary

- When `mac.icons` points to a `.icon` file (from Icon Composer), the build pipeline compiles it via `xcrun actool`, producing `Assets.car` (Liquid Glass on macOS 26+) and a `.icns` fallback for older macOS versions
- When `mac.icons` points to an `.iconset` folder, the existing `iconutil` path is unchanged — no breaking changes
- Adds `CFBundleIconName` to Info.plist when using `.icon` format (required for `Assets.car` lookup)
- Adds exit code checking for both `actool` and `iconutil` (previously failures were silently swallowed)
- Pre-checks for `actool` availability with a clear error message about requiring Xcode

### Usage

```typescript
// electrobun.config.ts
{
  build: {
    mac: {
      icons: "icon.icon", // from Icon Composer
    }
  }
}
```

## Validation

Validated in a clean room build (`/tmp/electrobun-cleanroom/`):
- Cloned fresh from the branch, copied an `.icon` file into kitchen, set `icons: "icon.icon"` in config
- Ran `bun dev:canary` (codesign/notarize disabled)
- Confirmed `Assets.car` and `AppIcon.icns` both land in `Contents/Resources/`
- Confirmed `Info.plist` contains both `CFBundleIconFile` (AppIcon) and `CFBundleIconName` (icon)

actool compilation output:
```
Compiling .icon file with actool (requires Xcode)...
  output-files:
    .actool-partial-info.plist
    Electrobun Kitchen Sink-canary.app/Contents/Resources/Assets.car
    Electrobun Kitchen Sink-canary.app/Contents/Resources/icon.icns
```

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)