### PR TITLE
feat: add custom protocol handler API

### DIFF
--- a/kitchen/electrobun.config.ts
+++ b/kitchen/electrobun.config.ts
@@ -6,6 +6,18 @@ export default {
 		identifier: "sh.blackboard.electrobun-kitchen",
 		version: "1.17.1-beta.0",
 		urlSchemes: ["electrobun-playground"],
+		protocols: [
+			{
+				scheme: "electrobun-test",
+				privileges: {
+					standard: true,
+					secure: true,
+					corsEnabled: true,
+					supportFetchAPI: true,
+					stream: true,
+				},
+			},
+		],
 	},
 	runtime: {
 		// exitOnLastWindowClosed: false,

--- a/kitchen/src/bun/index.ts
+++ b/kitchen/src/bun/index.ts
@@ -8,12 +8,122 @@ import Electrobun, {
 	Utils,
 	BuildConfig,
 	Updater,
+	Protocol,
 } from "electrobun/bun";
 import { executor } from "../test-framework/executor";
 import { allTests } from "../tests";
 import type { TestRunnerRPC, UpdateInfo } from "../test-runner/rpc";
 import { mkdir, readFile, writeFile } from "fs/promises";
 import { dirname, join } from "path";
+
+const encoder = new TextEncoder();
+
+await Protocol.handle("electrobun-test", async (request) => {
+	const url = new URL(request.url);
+
+	if (url.pathname === "/index.html") {
+		return new Response(
+			'<!doctype html><html><head><title>Electrobun Protocol</title></head><body><h1>Electrobun Protocol</h1><script type="module" src="views://test-harness/index.js"></script></body></html>',
+			{ headers: { "content-type": "text/html; charset=utf-8" } },
+		);
+	}
+	if (url.pathname === "/text") {
+		return new Response("hello from electrobun protocol", {
+			headers: { "content-type": "text/plain; charset=utf-8", "x-electrobun-protocol": "ok" },
+		});
+	}
+	if (url.pathname === "/stream") {
+		return new Response(
+			new ReadableStream({
+				start(controller) {
+					controller.enqueue(encoder.encode("stream-"));
+					controller.enqueue(encoder.encode("response"));
+					controller.close();
+				},
+			}),
+			{ headers: { "content-type": "text/plain; charset=utf-8" } },
+		);
+	}
+	if (url.pathname === "/echo") {
+		return new Response(await request.text(), { headers: { "content-type": "text/plain; charset=utf-8" } });
+	}
+	if (url.pathname === "/stream-request-order") {
+		const chunks: string[] = [];
+		const reader = request.body?.getReader();
+		if (reader) {
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				chunks.push(new TextDecoder().decode(value));
+			}
+		}
+		return new Response(JSON.stringify({ chunkCount: chunks.length, chunks, joined: chunks.join("") }), {
+			headers: { "content-type": "application/json; charset=utf-8" },
+		});
+	}
+	if (url.pathname === "/status/204") return new Response(null, { status: 204 });
+	if (url.pathname === "/status/201") {
+		return new Response("created", { status: 201, statusText: "Created", headers: { "content-type": "text/plain; charset=utf-8" } });
+	}
+	if (url.pathname === "/status/400") {
+		return new Response("bad request body", { status: 400, statusText: "Bad Request", headers: { "content-type": "text/plain; charset=utf-8" } });
+	}
+	if (url.pathname === "/status/500") {
+		return new Response("internal error detail", { status: 500, statusText: "Internal Server Error", headers: { "content-type": "text/plain; charset=utf-8" } });
+	}
+	if (url.pathname === "/echo-method") {
+		const body = request.method !== "HEAD" && request.method !== "GET" ? await request.text() : "";
+		return new Response(JSON.stringify({ method: request.method, body }), { headers: { "content-type": "application/json; charset=utf-8" } });
+	}
+	if (url.pathname === "/head-resource") {
+		return new Response(request.method === "HEAD" ? null : "head-resource-body", {
+			headers: { "content-type": "text/plain; charset=utf-8", "content-length": "18", "x-resource-id": "head-test" },
+		});
+	}
+	if (url.pathname === "/headers/multi") {
+		const res = new Response("ok", { headers: { "content-type": "text/plain; charset=utf-8" } });
+		res.headers.append("x-multi", "first");
+		res.headers.append("x-multi", "second");
+		return res;
+	}
+	if (url.pathname === "/headers/echo-request") {
+		const echoed: Record<string, string> = {};
+		request.headers.forEach((value, name) => { echoed[name.toLowerCase()] = value; });
+		return new Response(JSON.stringify(echoed), { headers: { "content-type": "application/json; charset=utf-8" } });
+	}
+	if (url.pathname === "/body/binary") {
+		const bytes = new Uint8Array(256);
+		for (let i = 0; i < 256; i++) bytes[i] = i;
+		return new Response(bytes.buffer, { headers: { "content-type": "application/octet-stream" } });
+	}
+	if (url.pathname === "/body/echo-binary") {
+		return new Response(await request.arrayBuffer(), { headers: { "content-type": "application/octet-stream" } });
+	}
+	if (url.pathname === "/body/urlencoded") {
+		return new Response("key=value&foo=bar", { headers: { "content-type": "application/x-www-form-urlencoded" } });
+	}
+	if (url.pathname === "/body/formdata") {
+		const boundary = "boundary123";
+		const body = `--${boundary}\r\nContent-Disposition: form-data; name="field1"\r\n\r\nhello\r\n--${boundary}\r\nContent-Disposition: form-data; name="field2"\r\n\r\nworld\r\n--${boundary}--\r\n`;
+		return new Response(body, { headers: { "content-type": `multipart/form-data; boundary=${boundary}` } });
+	}
+	if (url.pathname === "/body/slow-stream") {
+		let cancelled = false;
+		const stream = new ReadableStream({
+			async start(controller) {
+				for (let i = 0; i < 10; i++) {
+					if (cancelled) break;
+					controller.enqueue(encoder.encode(`chunk-${i} `));
+					await new Promise((resolve) => setTimeout(resolve, 200));
+				}
+				if (!cancelled) controller.close();
+			},
+			cancel() { cancelled = true; },
+		});
+		return new Response(stream, { headers: { "content-type": "text/plain; charset=utf-8" } });
+	}
+	return new Response("not found", { status: 404, headers: { "content-type": "text/plain; charset=utf-8" } });
+});
 
 console.log("\n");
 console.log("╔════════════════════════════════════════════════════════════╗");

--- a/kitchen/src/tests/index.ts
+++ b/kitchen/src/tests/index.ts
@@ -13,6 +13,7 @@ import { navigationTests } from "./navigation.test";
 import { utilsTests } from "./utils.test";
 import { screenTests } from "./screen.test";
 import { sessionTests } from "./session.test";
+import { protocolTests } from "./protocol.test";
 import { eventsTests } from "./events.test";
 import { preloadTests } from "./preload.test";
 import { updaterTests } from "./updater.test";
@@ -45,6 +46,7 @@ export const allTests: TestDefinition[] = [
   ...utilsTests,
   ...screenTests,
   ...sessionTests,
+  ...protocolTests,
   ...eventsTests,
   ...preloadTests,
   ...updaterTests,
@@ -85,6 +87,7 @@ export {
   utilsTests,
   screenTests,
   sessionTests,
+  protocolTests,
   eventsTests,
   preloadTests,
   updaterTests,

--- a/kitchen/src/tests/protocol.test.ts
+++ b/kitchen/src/tests/protocol.test.ts
@@ -1,0 +1,826 @@
+import { BrowserView, Protocol, type CustomScheme } from "electrobun/bun";
+
+import { defineTest, expect } from "../test-framework/types";
+import type { TestHarnessRPC } from "../test-harness/index";
+
+function createTestHarnessRPC() {
+  return BrowserView.defineRPC<TestHarnessRPC>({
+    maxRequestTime: 10000,
+    handlers: {
+      requests: {
+        echo: ({ value }: { value: unknown }) => value,
+        add: ({ a, b }: { a: number; b: number }) => a + b,
+        throwError: ({ message }: { message?: string }) => {
+          throw new Error(message || "Intentional test error");
+        },
+        delayed: async ({ ms, value }: { ms: number; value: unknown }) => {
+          await new Promise((resolve) => setTimeout(resolve, ms));
+          return value;
+        },
+      },
+      messages: {
+        ping: () => {},
+      },
+    },
+  });
+}
+
+async function evaluateInHarness(
+  win: Awaited<ReturnType<Parameters<Parameters<typeof defineTest>[0]["run"]>[0]["createWindow"]>>,
+  script: string,
+) {
+  return await (win.webview.rpc as any)?.request.evaluateJavascriptWithResponse({
+    script,
+  });
+}
+
+export const protocolTests = [
+  defineTest({
+    name: "Custom protocol top-level navigation",
+    category: "Protocol",
+    description: "Load a top-level custom protocol page in the native renderer",
+    async run({ createWindow, log }) {
+      let didNavigate = false;
+      const win = await createWindow({
+        url: "about:blank",
+        rpc: createTestHarnessRPC(),
+        title: "Protocol Navigation Test",
+        renderer: "native",
+      });
+
+      win.webview.on("did-navigate", () => {
+        didNavigate = true;
+      });
+      win.webview.loadURL("electrobun-test://app/index.html");
+
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+      expect(didNavigate).toBe(true);
+      log("custom protocol page loaded in native renderer");
+    },
+  }),
+  defineTest({
+    name: "Custom protocol top-level navigation in CEF",
+    category: "Protocol",
+    description: "Load a top-level custom protocol page in the CEF renderer",
+    async run({ createWindow, log }) {
+      let didNavigate = false;
+      const win = await createWindow({
+        url: "about:blank",
+        rpc: createTestHarnessRPC(),
+        title: "Protocol Navigation Test CEF",
+        renderer: "cef",
+      });
+
+      win.webview.on("did-navigate", () => {
+        didNavigate = true;
+      });
+      win.webview.loadURL("electrobun-test://app/index.html");
+
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+      expect(didNavigate).toBe(true);
+      log("custom protocol page loaded in CEF renderer");
+    },
+  }),
+  defineTest({
+    name: "Custom protocol fetch response",
+    category: "Protocol",
+    description: "Fetch a text response from a custom protocol in the native renderer",
+    async run({ createWindow, log }) {
+      const win = await createWindow({
+        url: "views://test-harness/index.html",
+        rpc: createTestHarnessRPC(),
+        title: "Protocol Fetch Test",
+        renderer: "native",
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 1200));
+
+      const result = await evaluateInHarness(
+        win,
+        `return fetch("electrobun-test://app/text")
+					.then(async (response) => JSON.stringify({
+						ok: response.ok,
+						status: response.status,
+						text: await response.text(),
+						header: response.headers.get("x-electrobun-protocol"),
+					}))
+					.catch((error) => JSON.stringify({ error: String(error) }))`,
+      );
+      const parsed = JSON.parse(result);
+
+      expect(parsed.error).toBeUndefined();
+      expect(parsed.text).toBe("hello from electrobun protocol");
+      expect(parsed.header).toBe("ok");
+      log("custom protocol text fetch returned expected body and header");
+    },
+  }),
+  defineTest({
+    name: "Custom protocol streaming and request body",
+    category: "Protocol",
+    description:
+      "Stream a response body, echo POST content, and preserve large request bodies through a custom protocol in CEF",
+    timeout: 30000,
+    async run({ createWindow, log }) {
+      const win = await createWindow({
+        url: "views://test-harness/index.html",
+        rpc: createTestHarnessRPC(),
+        title: "Protocol Stream Test",
+        renderer: "cef",
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+
+      const streamed = await evaluateInHarness(
+        win,
+        `return fetch("electrobun-test://app/stream")
+					.then(async (response) => {
+						const reader = response.body.getReader();
+						const decoder = new TextDecoder();
+						const chunks = [];
+						while (true) {
+							const { done, value } = await reader.read();
+							if (done) break;
+							chunks.push(decoder.decode(value));
+						}
+						return JSON.stringify({
+							ok: response.ok,
+							status: response.status,
+							chunks,
+							text: chunks.join(""),
+						});
+					})
+					.catch((error) => JSON.stringify({ error: String(error) }))`,
+      );
+      const streamedResult = JSON.parse(streamed);
+      expect(streamedResult.error).toBeUndefined();
+      expect(streamedResult.chunks.length).toBeGreaterThan(0);
+      expect(streamedResult.text).toBe("stream-response");
+
+      const echoed = await evaluateInHarness(
+        win,
+        `return fetch("electrobun-test://app/echo", { method: "POST", body: "ping-body" })
+					.then(async (response) => JSON.stringify({
+						ok: response.ok,
+						status: response.status,
+						text: await response.text(),
+					}))
+					.catch((error) => JSON.stringify({ error: String(error) }))`,
+      );
+      const echoedResult = JSON.parse(echoed);
+      expect(echoedResult.error).toBeUndefined();
+      expect(echoedResult.text).toBe("ping-body");
+
+      const largeBody =
+        "A".repeat(1024 * 1024) + "B".repeat(1024 * 1024) + "C".repeat(6 * 1024 * 1024);
+      const streamedRequest = await evaluateInHarness(
+        win,
+        `return fetch("electrobun-test://app/stream-request-order", {
+					method: "POST",
+					body: ${JSON.stringify(largeBody)},
+				})
+					.then(async (response) => JSON.stringify({
+						ok: response.ok,
+						status: response.status,
+						payload: await response.json(),
+					}))
+					.catch((error) => JSON.stringify({ error: String(error) }))`,
+      );
+      const largeEchoResult = JSON.parse(streamedRequest);
+      expect(largeEchoResult.error).toBeUndefined();
+      expect(largeEchoResult.payload.chunkCount).toBeGreaterThan(0);
+      expect(largeEchoResult.payload.joined.length).toBe(largeBody.length);
+      expect(largeEchoResult.payload.joined).toBe(largeBody);
+
+      const noBody = await evaluateInHarness(
+        win,
+        `return fetch("electrobun-test://app/status/204")
+					.then(async (response) => JSON.stringify({
+						status: response.status,
+						text: await response.text(),
+					}))`,
+      );
+      const noBodyResult = JSON.parse(noBody);
+      expect(noBodyResult.status).toBe(204);
+      expect(noBodyResult.text).toBe("");
+      log("custom protocol streamed response and echoed POST body in CEF");
+    },
+  }),
+
+  defineTest({
+    name: "Custom protocol response properties",
+    category: "Protocol",
+    description:
+      "Verify response.ok, response.type, response.url, response.statusText, response.redirected",
+    async run({ createWindow, log }) {
+      const win = await createWindow({
+        url: "views://test-harness/index.html",
+        rpc: createTestHarnessRPC(),
+        title: "Protocol Response Properties",
+        renderer: "cef",
+      });
+      await new Promise((resolve) => setTimeout(resolve, 1200));
+
+      const result = await evaluateInHarness(
+        win,
+        `
+        return fetch("electrobun-test://app/text")
+          .then(async (r) => JSON.stringify({
+            ok: r.ok,
+            type: r.type,
+            url: r.url,
+            statusText: r.statusText,
+            redirected: r.redirected,
+            status: r.status,
+          }))
+          .catch((e) => JSON.stringify({ error: String(e) }))
+      `,
+      );
+      const r = JSON.parse(result);
+      expect(r.error).toBeUndefined();
+      expect(r.ok).toBe(true);
+      expect(r.status).toBe(200);
+      expect(typeof r.type).toBe("string");
+      expect(r.redirected).toBe(false);
+      expect(typeof r.url).toBe("string");
+      log("response properties verified");
+    },
+  }),
+
+  defineTest({
+    name: "Custom protocol status codes",
+    category: "Protocol",
+    description: "Verify 201 (ok=true), 400/500 (ok=false), body readable for error statuses",
+    async run({ createWindow, log }) {
+      const win = await createWindow({
+        url: "views://test-harness/index.html",
+        rpc: createTestHarnessRPC(),
+        title: "Protocol Status Codes",
+        renderer: "cef",
+      });
+      await new Promise((resolve) => setTimeout(resolve, 1200));
+
+      const r201 = JSON.parse(
+        await evaluateInHarness(
+          win,
+          `
+        return fetch("electrobun-test://app/status/201")
+          .then(async (r) => JSON.stringify({ ok: r.ok, status: r.status, text: await r.text() }))
+          .catch((e) => JSON.stringify({ error: String(e) }))
+      `,
+        ),
+      );
+      expect(r201.error).toBeUndefined();
+      expect(r201.ok).toBe(true);
+      expect(r201.status).toBe(201);
+      expect(r201.text).toBe("created");
+
+      const r400 = JSON.parse(
+        await evaluateInHarness(
+          win,
+          `
+        return fetch("electrobun-test://app/status/400")
+          .then(async (r) => JSON.stringify({ ok: r.ok, status: r.status, text: await r.text() }))
+          .catch((e) => JSON.stringify({ error: String(e) }))
+      `,
+        ),
+      );
+      expect(r400.error).toBeUndefined();
+      expect(r400.ok).toBe(false);
+      expect(r400.status).toBe(400);
+      expect(r400.text).toBe("bad request body");
+
+      const r500 = JSON.parse(
+        await evaluateInHarness(
+          win,
+          `
+        return fetch("electrobun-test://app/status/500")
+          .then(async (r) => JSON.stringify({ ok: r.ok, status: r.status, text: await r.text() }))
+          .catch((e) => JSON.stringify({ error: String(e) }))
+      `,
+        ),
+      );
+      expect(r500.error).toBeUndefined();
+      expect(r500.ok).toBe(false);
+      expect(r500.status).toBe(500);
+      log("status codes verified");
+    },
+  }),
+
+  defineTest({
+    name: "Custom protocol HTTP methods",
+    category: "Protocol",
+    description:
+      "PUT, DELETE, OPTIONS methods reach handler; HEAD strips body but preserves headers",
+    async run({ createWindow, log }) {
+      const win = await createWindow({
+        url: "views://test-harness/index.html",
+        rpc: createTestHarnessRPC(),
+        title: "Protocol Methods",
+        renderer: "cef",
+      });
+      await new Promise((resolve) => setTimeout(resolve, 1200));
+
+      for (const [method, body] of [
+        ["PUT", "put-payload"],
+        ["DELETE", ""],
+        ["OPTIONS", ""],
+      ]) {
+        const init = body
+          ? `{ method: "${method}", body: ${JSON.stringify(body)} }`
+          : `{ method: "${method}" }`;
+        const raw = await evaluateInHarness(
+          win,
+          `
+          return fetch("electrobun-test://app/echo-method", ${init})
+            .then(async (r) => JSON.stringify({ ok: r.ok, payload: await r.json() }))
+            .catch((e) => JSON.stringify({ error: String(e) }))
+        `,
+        );
+        const r = JSON.parse(raw);
+        expect(r.error).toBeUndefined();
+        expect(r.payload.method).toBe(method);
+        if (body) expect(r.payload.body).toBe(body);
+      }
+
+      const headRaw = await evaluateInHarness(
+        win,
+        `
+        return fetch("electrobun-test://app/head-resource", { method: "HEAD" })
+          .then(async (r) => JSON.stringify({
+            ok: r.ok,
+            status: r.status,
+            xResourceId: r.headers.get("x-resource-id"),
+            bodyText: await r.text(),
+          }))
+          .catch((e) => JSON.stringify({ error: String(e) }))
+      `,
+      );
+      const head = JSON.parse(headRaw);
+      expect(head.error).toBeUndefined();
+      expect(head.ok).toBe(true);
+      expect(head.xResourceId).toBe("head-test");
+      expect(head.bodyText).toBe("");
+      log("PUT, DELETE, OPTIONS, HEAD methods verified");
+    },
+  }),
+
+  defineTest({
+    name: "Custom protocol headers API",
+    category: "Protocol",
+    description:
+      "headers.has(), headers.forEach(), iteration, multiple same-name values, custom request header forwarding",
+    async run({ createWindow, log }) {
+      const win = await createWindow({
+        url: "views://test-harness/index.html",
+        rpc: createTestHarnessRPC(),
+        title: "Protocol Headers API",
+        renderer: "native",
+      });
+      await new Promise((resolve) => setTimeout(resolve, 1200));
+
+      const raw = await evaluateInHarness(
+        win,
+        `
+        return fetch("electrobun-test://app/headers/echo-request", {
+          headers: { "x-custom-req": "hello-from-browser" },
+        })
+          .then(async (r) => {
+            const body = await r.json();
+            const has = r.headers.has("content-type");
+            const entries = [];
+            r.headers.forEach((v, k) => entries.push([k, v]));
+            return JSON.stringify({ echoed: body, has, entries });
+          })
+          .catch((e) => JSON.stringify({ error: String(e) }))
+      `,
+      );
+      const r = JSON.parse(raw);
+      expect(r.error).toBeUndefined();
+      expect(r.echoed["x-custom-req"]).toBe("hello-from-browser");
+      expect(r.has).toBe(true);
+      expect(Array.isArray(r.entries)).toBe(true);
+      expect(r.entries.length).toBeGreaterThan(0);
+
+      const multiRaw = await evaluateInHarness(
+        win,
+        `
+        return fetch("electrobun-test://app/headers/multi")
+          .then((r) => JSON.stringify({
+            xMulti: r.headers.get("x-multi"),
+            hasXMulti: r.headers.has("x-multi"),
+          }))
+          .catch((e) => JSON.stringify({ error: String(e) }))
+      `,
+      );
+      const multi = JSON.parse(multiRaw);
+      expect(multi.error).toBeUndefined();
+      expect(multi.hasXMulti).toBe(true);
+      expect(multi.xMulti).toContain("first");
+      expect(multi.xMulti).toContain("second");
+      log("headers API verified");
+    },
+  }),
+
+  defineTest({
+    name: "Custom protocol body consumption methods",
+    category: "Protocol",
+    description: "arrayBuffer(), bytes(), blob(), formData(), bodyUsed, clone()",
+    async run({ createWindow, log }) {
+      const win = await createWindow({
+        url: "views://test-harness/index.html",
+        rpc: createTestHarnessRPC(),
+        title: "Protocol Body Consumption",
+        renderer: "cef",
+      });
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+
+      const abRaw = await evaluateInHarness(
+        win,
+        `
+        return fetch("electrobun-test://app/text")
+          .then(async (r) => {
+            const ab = await r.arrayBuffer();
+            return JSON.stringify({ byteLength: ab.byteLength, type: ab.constructor.name });
+          })
+          .catch((e) => JSON.stringify({ error: String(e) }))
+      `,
+      );
+      const ab = JSON.parse(abRaw);
+      expect(ab.error).toBeUndefined();
+      expect(ab.byteLength).toBeGreaterThan(0);
+      expect(ab.type).toBe("ArrayBuffer");
+
+      const bytesRaw = await evaluateInHarness(
+        win,
+        `
+        return fetch("electrobun-test://app/text")
+          .then(async (r) => {
+            const b = await r.bytes();
+            return JSON.stringify({ type: b.constructor.name, length: b.length });
+          })
+          .catch((e) => JSON.stringify({ error: String(e) }))
+      `,
+      );
+      const bytes = JSON.parse(bytesRaw);
+      expect(bytes.error).toBeUndefined();
+      expect(bytes.type).toBe("Uint8Array");
+      expect(bytes.length).toBeGreaterThan(0);
+
+      const blobRaw = await evaluateInHarness(
+        win,
+        `
+        return fetch("electrobun-test://app/text")
+          .then(async (r) => {
+            const b = await r.blob();
+            return JSON.stringify({ type: b.type, size: b.size });
+          })
+          .catch((e) => JSON.stringify({ error: String(e) }))
+      `,
+      );
+      const blob = JSON.parse(blobRaw);
+      expect(blob.error).toBeUndefined();
+      expect(blob.size).toBeGreaterThan(0);
+
+      const fdRaw = await evaluateInHarness(
+        win,
+        `
+        return fetch("electrobun-test://app/body/formdata")
+          .then(async (r) => {
+            const fd = await r.formData();
+            return JSON.stringify({ field1: fd.get("field1"), field2: fd.get("field2") });
+          })
+          .catch((e) => JSON.stringify({ error: String(e) }))
+      `,
+      );
+      const fd = JSON.parse(fdRaw);
+      expect(fd.error).toBeUndefined();
+      expect(fd.field1).toBe("hello");
+      expect(fd.field2).toBe("world");
+
+      const cloneRaw = await evaluateInHarness(
+        win,
+        `
+        return fetch("electrobun-test://app/text")
+          .then(async (r) => {
+            const c = r.clone();
+            const [t1, t2] = await Promise.all([r.text(), c.text()]);
+            return JSON.stringify({ t1, t2, match: t1 === t2 });
+          })
+          .catch((e) => JSON.stringify({ error: String(e) }))
+      `,
+      );
+      const clone = JSON.parse(cloneRaw);
+      expect(clone.error).toBeUndefined();
+      expect(clone.match).toBe(true);
+      expect(clone.t1).toBe("hello from electrobun protocol");
+
+      const bodyUsedRaw = await evaluateInHarness(
+        win,
+        `
+        return fetch("electrobun-test://app/text")
+          .then(async (r) => {
+            const before = r.bodyUsed;
+            await r.text();
+            const after = r.bodyUsed;
+            let threw = false;
+            try { await r.text(); } catch { threw = true; }
+            return JSON.stringify({ before, after, threw });
+          })
+          .catch((e) => JSON.stringify({ error: String(e) }))
+      `,
+      );
+      const bodyUsed = JSON.parse(bodyUsedRaw);
+      expect(bodyUsed.error).toBeUndefined();
+      expect(bodyUsed.before).toBe(false);
+      expect(bodyUsed.after).toBe(true);
+      expect(bodyUsed.threw).toBe(true);
+      log("body consumption methods and bodyUsed verified");
+    },
+  }),
+
+  defineTest({
+    name: "Custom protocol binary body",
+    category: "Protocol",
+    description:
+      "Binary response preserved byte-for-byte via arrayBuffer(); binary request body round-trips",
+    async run({ createWindow, log }) {
+      const win = await createWindow({
+        url: "views://test-harness/index.html",
+        rpc: createTestHarnessRPC(),
+        title: "Protocol Binary",
+        renderer: "cef",
+      });
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+
+      const binRaw = await evaluateInHarness(
+        win,
+        `
+        return fetch("electrobun-test://app/body/binary")
+          .then(async (r) => {
+            const ab = await r.arrayBuffer();
+            const u8 = new Uint8Array(ab);
+            let allCorrect = true;
+            for (let i = 0; i < 256; i++) {
+              if (u8[i] !== i) { allCorrect = false; break; }
+            }
+            return JSON.stringify({ length: u8.length, allCorrect });
+          })
+          .catch((e) => JSON.stringify({ error: String(e) }))
+      `,
+      );
+      const bin = JSON.parse(binRaw);
+      expect(bin.error).toBeUndefined();
+      expect(bin.length).toBe(256);
+      expect(bin.allCorrect).toBe(true);
+
+      const echoRaw = await evaluateInHarness(
+        win,
+        `
+        const body = new Uint8Array(128);
+        for (let i = 0; i < 128; i++) body[i] = i * 2;
+        return fetch("electrobun-test://app/body/echo-binary", {
+          method: "POST",
+          body: body.buffer,
+        })
+          .then(async (r) => {
+            const ab = await r.arrayBuffer();
+            const u8 = new Uint8Array(ab);
+            let allCorrect = true;
+            for (let i = 0; i < 128; i++) {
+              if (u8[i] !== i * 2) { allCorrect = false; break; }
+            }
+            return JSON.stringify({ length: u8.length, allCorrect });
+          })
+          .catch((e) => JSON.stringify({ error: String(e) }))
+      `,
+      );
+      const echo = JSON.parse(echoRaw);
+      expect(echo.error).toBeUndefined();
+      expect(echo.length).toBe(128);
+      expect(echo.allCorrect).toBe(true);
+      log("binary body round-trip verified");
+    },
+  }),
+
+  defineTest({
+    name: "Custom protocol stream chunks are Uint8Array",
+    category: "Protocol",
+    description: "Spec §2.2.4: response body stream yields Uint8Array chunks, not strings",
+    async run({ createWindow, log }) {
+      const win = await createWindow({
+        url: "views://test-harness/index.html",
+        rpc: createTestHarnessRPC(),
+        title: "Protocol Stream Uint8Array",
+        renderer: "cef",
+      });
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+
+      const raw = await evaluateInHarness(
+        win,
+        `
+        return fetch("electrobun-test://app/stream")
+          .then(async (r) => {
+            const reader = r.body.getReader();
+            const types = [];
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              types.push(value.constructor.name);
+            }
+            return JSON.stringify({ types, allUint8: types.every(t => t === "Uint8Array") });
+          })
+          .catch((e) => JSON.stringify({ error: String(e) }))
+      `,
+      );
+      const r = JSON.parse(raw);
+      expect(r.error).toBeUndefined();
+      expect(r.allUint8).toBe(true);
+      expect(r.types.length).toBeGreaterThan(0);
+      log("stream chunks are Uint8Array");
+    },
+  }),
+
+  defineTest({
+    name: "Custom protocol URLSearchParams and urlencoded body",
+    category: "Protocol",
+    description:
+      "URLSearchParams request body and application/x-www-form-urlencoded response via formData()",
+    async run({ createWindow, log }) {
+      const win = await createWindow({
+        url: "views://test-harness/index.html",
+        rpc: createTestHarnessRPC(),
+        title: "Protocol URLSearchParams",
+        renderer: "native",
+      });
+      await new Promise((resolve) => setTimeout(resolve, 1200));
+
+      const sendRaw = await evaluateInHarness(
+        win,
+        `
+        return fetch("electrobun-test://app/echo", {
+          method: "POST",
+          body: new URLSearchParams({ a: "1", b: "2" }),
+        })
+          .then(async (r) => JSON.stringify({ text: await r.text(), ct: r.headers.get("content-type") }))
+          .catch((e) => JSON.stringify({ error: String(e) }))
+      `,
+      );
+      const send = JSON.parse(sendRaw);
+      expect(send.error).toBeUndefined();
+      expect(send.text).toContain("a=1");
+      expect(send.text).toContain("b=2");
+
+      const recvRaw = await evaluateInHarness(
+        win,
+        `
+        return fetch("electrobun-test://app/body/urlencoded")
+          .then(async (r) => {
+            const fd = await r.formData();
+            return JSON.stringify({ key: fd.get("key"), foo: fd.get("foo") });
+          })
+          .catch((e) => JSON.stringify({ error: String(e) }))
+      `,
+      );
+      const recv = JSON.parse(recvRaw);
+      expect(recv.error).toBeUndefined();
+      expect(recv.key).toBe("value");
+      expect(recv.foo).toBe("bar");
+      log("URLSearchParams and urlencoded body verified");
+    },
+  }),
+
+  defineTest({
+    name: "Custom protocol AbortController",
+    category: "Protocol",
+    description:
+      "Abort before response rejects with AbortError; abort during streaming errors the body stream",
+    async run({ createWindow, log }) {
+      const win = await createWindow({
+        url: "views://test-harness/index.html",
+        rpc: createTestHarnessRPC(),
+        title: "Protocol Abort",
+        renderer: "cef",
+      });
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+
+      const abortBeforeRaw = await evaluateInHarness(
+        win,
+        `
+        const ac = new AbortController();
+        ac.abort();
+        return fetch("electrobun-test://app/text", { signal: ac.signal })
+          .then(() => JSON.stringify({ aborted: false }))
+          .catch((e) => JSON.stringify({ aborted: true, name: e.name }))
+      `,
+      );
+      const abortBefore = JSON.parse(abortBeforeRaw);
+      expect(abortBefore.aborted).toBe(true);
+      expect(abortBefore.name).toBe("AbortError");
+
+      const abortDuringRaw = await evaluateInHarness(
+        win,
+        `
+        const ac = new AbortController();
+        let errorName = null;
+        const p = fetch("electrobun-test://app/body/slow-stream", { signal: ac.signal })
+          .then(async (r) => {
+            const reader = r.body.getReader();
+            await reader.read();
+            ac.abort();
+            try {
+              while (true) {
+                const { done } = await reader.read();
+                if (done) break;
+              }
+            } catch (e) {
+              errorName = e.name;
+            }
+            return JSON.stringify({ aborted: ac.signal.aborted, errorName });
+          })
+          .catch((e) => JSON.stringify({ fetchAborted: true, name: e.name }));
+        return p;
+      `,
+      );
+      const abortDuring = JSON.parse(abortDuringRaw);
+      if (abortDuring.fetchAborted) {
+        expect(abortDuring.name).toBe("AbortError");
+      } else {
+        expect(abortDuring.aborted).toBe(true);
+      }
+      log("AbortController verified");
+    },
+  }),
+
+  defineTest({
+    name: "Custom protocol handler lifecycle",
+    category: "Protocol",
+    description:
+      "Protocol.isHandled(), Protocol.unhandle(), Protocol.getHandledSchemes(), and declaration enforcement",
+    async run({ log }) {
+      expect(Protocol.isHandled("electrobun-test")).toBe(true);
+
+      const handled = Protocol.getHandledSchemes();
+      expect(handled).toContain("electrobun-test");
+      expect(Array.isArray(handled)).toBe(true);
+
+      const declared = Protocol.getRegisteredSchemes();
+      expect(declared.some((s: CustomScheme) => s.scheme === "electrobun-test")).toBe(true);
+
+      const unhandled = Protocol.unhandle("electrobun-test");
+      expect(unhandled).toBe(true);
+      expect(Protocol.isHandled("electrobun-test")).toBe(false);
+      expect(Protocol.getHandledSchemes().includes("electrobun-test")).toBe(false);
+
+      const unhandledAgain = Protocol.unhandle("electrobun-test");
+      expect(unhandledAgain).toBe(false);
+
+      await Protocol.handle("electrobun-test", async () =>
+        new Response("restored", { headers: { "content-type": "text/plain; charset=utf-8" } }),
+      );
+
+      expect(Protocol.isHandled("electrobun-test")).toBe(true);
+
+      log("handler lifecycle verified: isHandled, unhandle, getHandledSchemes, getRegisteredSchemes");
+    },
+  }),
+
+  defineTest({
+    name: "Custom protocol declaration enforcement",
+    category: "Protocol",
+    description: "Protocol.handle() throws when scheme was not declared in electrobun.config.ts",
+    async run({ log }) {
+      let threw = false;
+      let errorMsg = "";
+      try {
+        await Protocol.handle("not-declared-scheme", async () => new Response("x"));
+      } catch (e) {
+        threw = true;
+        errorMsg = e instanceof Error ? e.message : String(e);
+      }
+
+      expect(threw).toBe(true);
+      expect(errorMsg).toContain("not-declared-scheme");
+      expect(errorMsg).toContain("not declared in electrobun.config.ts");
+      log("declaration enforcement verified");
+    },
+  }),
+
+  defineTest({
+    name: "Custom protocol reserved scheme rejection",
+    category: "Protocol",
+    description: "Protocol.handle() throws for reserved schemes like http and https",
+    async run({ log }) {
+      for (const reserved of ["http", "https", "file", "views"]) {
+        let threw = false;
+        try {
+          await Protocol.handle(reserved, async () => new Response("x"));
+        } catch {
+          threw = true;
+        }
+        expect(threw).toBe(true);
+      }
+
+      log("reserved scheme rejection verified");
+    },
+  }),
+];

--- a/package/src/bun/ElectrobunConfig.ts
+++ b/package/src/bun/ElectrobunConfig.ts
@@ -1,3 +1,5 @@
+import type { CustomScheme } from "../shared/protocol";
+
 /**
  * Electrobun configuration type definitions
  * Used in electrobun.config.ts files
@@ -56,6 +58,12 @@ export interface ElectrobunConfig {
 		 * ```
 		 */
 		urlSchemes?: string[];
+
+		/**
+		 * Custom content protocols to register before any webview initializes.
+		 * Pair with `Protocol.handle()` in your app entry point.
+		 */
+		protocols?: CustomScheme[];
 	};
 
 	/**

--- a/package/src/bun/core/BuildConfig.ts
+++ b/package/src/bun/core/BuildConfig.ts
@@ -1,8 +1,11 @@
+import type { CustomScheme } from "../../shared/protocol";
+
 export type BuildConfigType = {
 	defaultRenderer: "native" | "cef";
 	availableRenderers: ("native" | "cef")[];
 	cefVersion?: string;
 	bunVersion?: string;
+	protocols?: CustomScheme[];
 	runtime?: {
 		exitOnLastWindowClosed?: boolean;
 		[key: string]: unknown;

--- a/package/src/bun/core/Protocol.ts
+++ b/package/src/bun/core/Protocol.ts
@@ -1,0 +1,344 @@
+import { CString, FFIType, JSCallback, ptr, toArrayBuffer, type Pointer } from "bun:ffi";
+
+import { BuildConfig } from "./BuildConfig";
+import { native, toCString } from "../proc/native";
+import type { CustomScheme, CustomSchemePrivileges, ProtocolHandler } from "../../shared/protocol";
+
+type ProtocolRequestMeta = {
+	url: string;
+	method: string;
+	headers: [string, string][];
+	hasBody: boolean;
+};
+
+type PendingProtocolRequest = {
+	controller: AbortController;
+	reader: ReadableStreamDefaultReader<Uint8Array> | null;
+};
+
+const RESERVED_SCHEMES = new Set([
+	"http", "https", "file", "blob", "data", "about",
+	"javascript", "chrome", "chrome-extension", "ftp", "ws", "wss",
+]);
+
+const DEFAULT_PRIVILEGES: Required<CustomSchemePrivileges> = {
+	standard: true,
+	secure: true,
+	bypassCSP: false,
+	allowServiceWorkers: false,
+	supportFetchAPI: true,
+	corsEnabled: true,
+	stream: true,
+	codeCache: false,
+};
+
+const declaredSchemes = new Map<string, CustomScheme & { privileges: Required<CustomSchemePrivileges> }>();
+const protocolHandlers = new Map<string, ProtocolHandler>();
+const pendingRequests = new Map<bigint, PendingProtocolRequest>();
+const textEncoder = new TextEncoder();
+let callbacksInstalled = false;
+let schemesInitialized = false;
+let schemesLoadedFromConfig = false;
+let schemesInitPromise: Promise<void> | null = null;
+let protocolRequestCallback: JSCallback | null = null;
+let protocolCancelCallback: JSCallback | null = null;
+
+const NULL_BODY_STATUSES = new Set([101, 103, 204, 205, 304]);
+
+function normalizeScheme(scheme: string) {
+	return scheme.trim().replace(/:$/, "").toLowerCase();
+}
+
+function assertValidScheme(scheme: string) {
+	if (!/^[a-z][a-z0-9+.-]*$/.test(scheme)) {
+		throw new Error(`Invalid protocol scheme: "${scheme}"`);
+	}
+	if (RESERVED_SCHEMES.has(scheme)) {
+		throw new Error(
+			`Protocol scheme '${scheme}' is reserved and cannot be registered as a custom protocol.`,
+		);
+	}
+	if (scheme === "views") {
+		throw new Error(`Protocol scheme 'views' is reserved by Electrobun for bundled assets.`);
+	}
+}
+
+function resolvePrivileges(partial?: CustomSchemePrivileges): Required<CustomSchemePrivileges> {
+	return { ...DEFAULT_PRIVILEGES, ...partial };
+}
+
+function syncNativeProtocolConfig() {
+	const json = JSON.stringify([...declaredSchemes.values()]);
+	if (native) {
+		native.symbols.setCustomProtocolConfig(toCString(json));
+	}
+}
+
+function loadDeclaredSchemes(buildConfigProtocols?: CustomScheme[]) {
+	if (schemesInitialized) {
+		return;
+	}
+	schemesInitialized = true;
+	schemesLoadedFromConfig = true;
+
+	const configured = Array.isArray(buildConfigProtocols) ? buildConfigProtocols : [];
+	for (const entry of configured) {
+		const scheme = normalizeScheme(entry.scheme);
+		assertValidScheme(scheme);
+		declaredSchemes.set(scheme, {
+			scheme,
+			privileges: resolvePrivileges(entry.privileges),
+		});
+	}
+
+	syncNativeProtocolConfig();
+}
+
+async function ensureSchemesLoaded() {
+	if (schemesInitialized) return;
+	if (!schemesInitPromise) {
+		schemesInitPromise = BuildConfig.get()
+			.then((cfg) => loadDeclaredSchemes(cfg.protocols))
+			.catch(() => { schemesInitialized = true; });
+	}
+	await schemesInitPromise;
+}
+
+function getRequestBody(requestId: bigint) {
+	if (!native) {
+		return null;
+	}
+
+	const sizeBuffer = new BigUint64Array(1);
+	const dataPtr = native.symbols.protocolGetRequestBody(
+		requestId,
+		ptr(sizeBuffer),
+	) as Pointer | null;
+
+	if (!dataPtr) {
+		return null;
+	}
+
+	const size = Number(sizeBuffer[0]);
+	if (size === 0) {
+		native.symbols.freeProtocolBuffer(dataPtr);
+		return null;
+	}
+
+	const bytes = new Uint8Array(size);
+	bytes.set(new Uint8Array(toArrayBuffer(dataPtr, 0, size)));
+	native.symbols.freeProtocolBuffer(dataPtr);
+	return bytes;
+}
+
+function serializeHeaders(headers: Headers, scheme: string) {
+	const privileges = declaredSchemes.get(scheme)?.privileges ?? DEFAULT_PRIVILEGES;
+
+	if (privileges.corsEnabled) {
+		if (!headers.has("access-control-allow-origin")) {
+			headers.set("access-control-allow-origin", "*");
+		}
+		if (!headers.has("access-control-allow-methods")) {
+			headers.set("access-control-allow-methods", "GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS");
+		}
+		if (!headers.has("access-control-allow-headers")) {
+			headers.set("access-control-allow-headers", "*");
+		}
+		if (!headers.has("access-control-expose-headers")) {
+			headers.set("access-control-expose-headers", "*");
+		}
+	}
+
+	const entries: Array<[string, string]> = [];
+	headers.forEach((value, key) => {
+		entries.push([key, value]);
+	});
+	return JSON.stringify(entries);
+}
+
+async function streamResponseBody(
+	requestId: bigint,
+	response: Response,
+	pending: PendingProtocolRequest,
+) {
+	if (!response.body || NULL_BODY_STATUSES.has(response.status)) {
+		if (native) {
+			native.symbols.protocolFinishResponse(requestId);
+		}
+		return;
+	}
+
+	const reader = response.body.getReader();
+	pending.reader = reader;
+
+	try {
+		while (true) {
+			if (pending.controller.signal.aborted) {
+				await reader.cancel();
+				return;
+			}
+
+			const { done, value } = await reader.read();
+			if (done) {
+				break;
+			}
+
+			if (native && value && value.byteLength > 0) {
+				native.symbols.protocolWriteResponseChunk(requestId, ptr(value), BigInt(value.byteLength));
+			}
+		}
+
+		if (native) {
+			native.symbols.protocolFinishResponse(requestId);
+		}
+	} finally {
+		pending.reader = null;
+	}
+}
+
+async function dispatchProtocolRequest(
+	requestId: bigint,
+	_webviewId: number,
+	meta: ProtocolRequestMeta,
+) {
+	const pending: PendingProtocolRequest = {
+		controller: new AbortController(),
+		reader: null,
+	};
+	pendingRequests.set(requestId, pending);
+
+	try {
+		const url = new URL(meta.url);
+		const scheme = normalizeScheme(url.protocol);
+		const handler = protocolHandlers.get(scheme);
+
+		if (!handler) {
+			if (native) {
+				const body = textEncoder.encode("No handler registered for this protocol");
+				native.symbols.protocolStartResponse(
+					requestId,
+					404,
+					toCString("Not Found"),
+					toCString(JSON.stringify([["content-type", "text/plain; charset=utf-8"]])),
+				);
+				native.symbols.protocolWriteResponseChunk(requestId, ptr(body), BigInt(body.byteLength));
+				native.symbols.protocolFinishResponse(requestId);
+			}
+			return;
+		}
+
+		const body = meta.hasBody ? getRequestBody(requestId) : null;
+		const init: RequestInit & { duplex?: "half" } = {
+			method: meta.method,
+			headers: meta.headers,
+			signal: pending.controller.signal,
+		};
+
+		if (body && meta.method !== "GET" && meta.method !== "HEAD") {
+			init.body = body;
+		}
+
+		const request = new Request(meta.url, init);
+		const response = await handler(request);
+
+		if (native) {
+			native.symbols.protocolStartResponse(
+				requestId,
+				response.status,
+				toCString(response.statusText || "OK"),
+				toCString(serializeHeaders(response.headers, scheme)),
+			);
+		}
+
+		await streamResponseBody(requestId, response, pending);
+	} catch (error) {
+		if (native) {
+			native.symbols.protocolErrorResponse(
+				requestId,
+				toCString(error instanceof Error ? error.message : String(error)),
+			);
+		}
+	} finally {
+		pendingRequests.delete(requestId);
+	}
+}
+
+function ensureCallbacksInstalled() {
+	if (!native || callbacksInstalled) {
+		return;
+	}
+
+	protocolRequestCallback = new JSCallback(
+		(requestId: bigint, webviewId: number, requestJson: number) => {
+			const jsonPointer = requestJson as unknown as Pointer;
+			const json = new CString(jsonPointer).toString();
+			native?.symbols.freeProtocolBuffer(jsonPointer);
+			const meta = JSON.parse(json) as ProtocolRequestMeta;
+			void dispatchProtocolRequest(requestId, webviewId, meta);
+		},
+		{
+			args: [FFIType.u64, FFIType.u32, FFIType.cstring],
+			returns: FFIType.void,
+			threadsafe: true,
+		},
+	);
+
+	protocolCancelCallback = new JSCallback(
+		(requestId: bigint) => {
+			const pending = pendingRequests.get(requestId);
+			if (!pending) {
+				return;
+			}
+			pending.controller.abort();
+			void pending.reader?.cancel();
+			pendingRequests.delete(requestId);
+		},
+		{
+			args: [FFIType.u64],
+			returns: FFIType.void,
+			threadsafe: true,
+		},
+	);
+
+	native.symbols.setCustomProtocolHandlers(protocolRequestCallback, protocolCancelCallback);
+	callbacksInstalled = true;
+}
+
+export const Protocol = {
+	async handle(scheme: string, handler: ProtocolHandler): Promise<void> {
+		await ensureSchemesLoaded();
+
+		const normalizedScheme = normalizeScheme(scheme);
+		assertValidScheme(normalizedScheme);
+
+		if (schemesLoadedFromConfig && !declaredSchemes.has(normalizedScheme)) {
+			const declared = [...declaredSchemes.keys()];
+			throw new Error(
+				`Protocol scheme '${normalizedScheme}' is not declared in electrobun.config.ts. ` +
+				`Declared schemes: [${declared.length ? declared.join(", ") : "none"}]`,
+			);
+		}
+
+		if (protocolHandlers.has(normalizedScheme)) {
+			console.warn(
+				`[Protocol] handler for '${normalizedScheme}' is being replaced. ` +
+				`Call Protocol.unhandle('${normalizedScheme}') first if this is intentional.`,
+			);
+		}
+
+		protocolHandlers.set(normalizedScheme, handler);
+		ensureCallbacksInstalled();
+	},
+	unhandle(scheme: string): boolean {
+		return protocolHandlers.delete(normalizeScheme(scheme));
+	},
+	isHandled(scheme: string): boolean {
+		return protocolHandlers.has(normalizeScheme(scheme));
+	},
+	getRegisteredSchemes(): CustomScheme[] {
+		return [...declaredSchemes.values()];
+	},
+	getHandledSchemes(): string[] {
+		return [...protocolHandlers.keys()];
+	},
+};

--- a/package/src/bun/index.ts
+++ b/package/src/bun/index.ts
@@ -44,6 +44,8 @@ import type {
 	ApplicationMenuItemConfig,
 } from "./proc/native";
 import { BuildConfig, type BuildConfigType } from "./core/BuildConfig";
+import { Protocol } from "./core/Protocol";
+import type { CustomScheme, CustomSchemePrivileges, ProtocolHandler } from "../shared/protocol";
 import { bridge, hasFFI } from "./proc/native";
 
 // Carrot boot state — populated from __bunnyCarrotBootstrap injected by Bunny Ears
@@ -189,6 +191,9 @@ export {
 	type ElectrobunEvent,
 	type ElectrobunConfig,
 	type BuildConfigType,
+	type CustomScheme,
+	type CustomSchemePrivileges,
+	type ProtocolHandler,
 	type WindowOptionsType,
 	type BrowserViewOptions,
 	type GpuWindowOptionsType,
@@ -230,6 +235,7 @@ export {
 	Session,
 	WGPUBridge,
 	BuildConfig,
+	Protocol,
 };
 
 // Default Export
@@ -248,6 +254,7 @@ const Electrobun = {
 	Session,
 	WGPUBridge,
 	BuildConfig,
+	Protocol,
 	events: electobunEventEmmitter,
 	PATHS,
 	Socket,

--- a/package/src/bun/proc/native.ts
+++ b/package/src/bun/proc/native.ts
@@ -668,6 +668,38 @@ export const native = (() => {
 				],
 				returns: FFIType.void,
 			},
+			setCustomProtocolConfig: {
+				args: [FFIType.cstring],
+				returns: FFIType.void,
+			},
+			setCustomProtocolHandlers: {
+				args: [FFIType.function, FFIType.function],
+				returns: FFIType.void,
+			},
+			protocolGetRequestBody: {
+				args: [FFIType.u64, FFIType.ptr],
+				returns: FFIType.ptr,
+			},
+			freeProtocolBuffer: {
+				args: [FFIType.ptr],
+				returns: FFIType.void,
+			},
+			protocolStartResponse: {
+				args: [FFIType.u64, FFIType.i32, FFIType.cstring, FFIType.cstring],
+				returns: FFIType.void,
+			},
+			protocolWriteResponseChunk: {
+				args: [FFIType.u64, FFIType.ptr, FFIType.u64],
+				returns: FFIType.void,
+			},
+			protocolFinishResponse: {
+				args: [FFIType.u64],
+				returns: FFIType.void,
+			},
+			protocolErrorResponse: {
+				args: [FFIType.u64, FFIType.cstring],
+				returns: FFIType.void,
+			},
 			setWindowIcon: {
 				args: [
 					FFIType.ptr, // window pointer

--- a/package/src/cli/index.ts
+++ b/package/src/cli/index.ts
@@ -1471,7 +1471,13 @@ const defaultConfig = {
 		version: "0.1.0",
 		description: "" as string | undefined,
 		urlSchemes: undefined as string[] | undefined,
-	},
+		protocols: undefined as
+			| Array<{
+					scheme: string;
+					privileges?: Record<string, boolean>;
+			  }>
+			| undefined,
+	}, 
 	build: {
 		buildFolder: "build",
 		artifactFolder: "artifacts",
@@ -3367,6 +3373,7 @@ Categories=Utility;Application;
 		const buildJsonObj: Record<string, unknown> = {
 			defaultRenderer: platformConfig?.defaultRenderer ?? "native",
 			availableRenderers: bundlesCEF ? ["native", "cef"] : ["native"],
+				protocols: config.app?.protocols ?? [],
 			runtime: config.runtime ?? {},
 			...(bundlesCEF
 				? { cefVersion: config.build?.cefVersion ?? DEFAULT_CEF_VERSION_STRING }

--- a/package/src/native/linux/cef_process_helper_linux.cpp
+++ b/package/src/native/linux/cef_process_helper_linux.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <map>
 #include <mutex>
+#include "../shared/protocol_config.h"
 #include "include/cef_app.h"
 #include "include/cef_client.h"
 #include "include/cef_v8.h"
@@ -12,12 +13,29 @@ public:
 
     // CefApp methods:
     virtual void OnRegisterCustomSchemes(CefRawPtr<CefSchemeRegistrar> registrar) override {
+        CefRefPtr<CefCommandLine> command_line = CefCommandLine::GetGlobalCommandLine();
+        if (command_line && command_line->HasSwitch("electrobun-custom-protocols")) {
+            electrobun::setProtocolConfigJson(command_line->GetSwitchValue("electrobun-custom-protocols").ToString());
+        }
         registrar->AddCustomScheme("views",
             CEF_SCHEME_OPTION_STANDARD |
             CEF_SCHEME_OPTION_CORS_ENABLED |
             CEF_SCHEME_OPTION_SECURE | // treat it like https
             CEF_SCHEME_OPTION_CSP_BYPASSING | // allow things like crypto.subtle
             CEF_SCHEME_OPTION_FETCH_ENABLED);
+
+        electrobun::forEachProtocolRegistration([&](const electrobun::ProtocolRegistration& registration) {
+            int options = 0;
+            if (registration.privileges.standard) options |= CEF_SCHEME_OPTION_STANDARD;
+            if (registration.privileges.secure) options |= CEF_SCHEME_OPTION_SECURE;
+            if (registration.privileges.corsEnabled) options |= CEF_SCHEME_OPTION_CORS_ENABLED;
+            if (registration.privileges.bypassCSP) options |= CEF_SCHEME_OPTION_CSP_BYPASSING;
+            if (registration.privileges.supportFetchAPI) options |= CEF_SCHEME_OPTION_FETCH_ENABLED;
+            if (registration.privileges.stream) options |= CEF_SCHEME_OPTION_STREAMING;
+            if (registration.privileges.codeCache) options |= CEF_SCHEME_OPTION_CODE_CACHE_ENABLED;
+            if (registration.privileges.allowServiceWorkers) options |= CEF_SCHEME_OPTION_SERVICE_WORKERS_ALLOWED;
+            registrar->AddCustomScheme(registration.scheme, options);
+        });
     }
 
     virtual CefRefPtr<CefRenderProcessHandler> GetRenderProcessHandler() override {

--- a/package/src/native/linux/nativeWrapper.cpp
+++ b/package/src/native/linux/nativeWrapper.cpp
@@ -17,6 +17,7 @@
 #include <memory>
 #include <pthread.h>
 #include <map>
+#include <unordered_map>
 #include <iostream>
 #include <cstring>
 #include <dlfcn.h>
@@ -37,6 +38,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <fstream>
+#include <deque>
 #include <set>
 #include <cstdarg>
 #include "dawn/webgpu.h"
@@ -59,6 +61,7 @@
 #include "../shared/app_paths.h"
 #include "../shared/accelerator_parser.h"
 #include "../shared/chromium_flags.h"
+#include "../shared/protocol_config.h"
 
 using namespace electrobun;
 
@@ -143,6 +146,7 @@ typedef void (*WindowBlurCallback)(uint32_t windowId);
 
 // Forward declaration for WebKit scheme handler
 static void handleViewsURIScheme(WebKitURISchemeRequest* request, gpointer user_data);
+static void handleCustomProtocolURIScheme(WebKitURISchemeRequest* request, gpointer user_data);
 
 // Forward declaration for partition context management
 static WebKitWebContext* getContextForPartition(const char* partitionIdentifier);
@@ -176,6 +180,24 @@ static std::mutex webviewHTMLMutex;
 // Global variables for CEF cache path isolation
 static std::string g_electrobunChannel = "";
 static std::string g_electrobunIdentifier = "";
+static ProtocolRequestHandler g_protocolRequestHandler = nullptr;
+static ProtocolRequestCancelledHandler g_protocolRequestCancelledHandler = nullptr;
+static std::atomic<uint64_t> g_nextProtocolRequestId{1};
+static std::mutex g_protocolRequestMutex;
+static std::unordered_map<uint64_t, std::vector<uint8_t>> g_protocolRequestBodies;
+static std::unordered_map<uint64_t, WebKitURISchemeRequest*> g_pendingWebKitProtocolRequests;
+
+struct PendingWebKitProtocolResponseState {
+    int statusCode = 200;
+    std::string statusText = "OK";
+    std::string headersJson = "[]";
+    std::vector<uint8_t> body;
+};
+
+static std::unordered_map<uint64_t, PendingWebKitProtocolResponseState> g_pendingWebKitResponseStates;
+
+class ViewsResourceHandler;
+static std::unordered_map<uint64_t, ViewsResourceHandler*> g_pendingCEFProtocolHandlers;
 
 // Forward declarations for HTML content management
 extern "C" ELECTROBUN_EXPORT const char* getWebviewHTMLContent(uint32_t webviewId);
@@ -204,6 +226,216 @@ GtkWidget* createMenuFromParsedItems(const std::vector<MenuJsonValue>& items, Zi
 GtkWidget* createApplicationMenuBar(const std::vector<MenuJsonValue>& items, ZigStatusItemHandler clickHandler);
 void applyApplicationMenuToWindow(GtkWidget* window);
 void initializeGTK();
+void dispatchProtocolRequestSync(std::function<void()> callback);
+
+static std::string escapeProtocolJSONString(const std::string& value) {
+    std::string output;
+    output.reserve(value.size() + 16);
+
+    for (char c : value) {
+        switch (c) {
+            case '"': output += "\\\""; break;
+            case '\\': output += "\\\\"; break;
+            case '\n': output += "\\n"; break;
+            case '\r': output += "\\r"; break;
+            case '\t': output += "\\t"; break;
+            default: output += c; break;
+        }
+    }
+
+    return output;
+}
+
+static std::string extractProtocolScheme(const std::string& url) {
+    size_t schemeSeparator = url.find(':');
+    if (schemeSeparator == std::string::npos) {
+        return "";
+    }
+    return normalizeProtocolScheme(url.substr(0, schemeSeparator));
+}
+
+static std::vector<std::pair<std::string, std::string>> parseProtocolHeaderPairs(const std::string& headersJson) {
+    std::vector<std::pair<std::string, std::string>> headers;
+    size_t pos = 0;
+
+    auto skipWhitespace = [&]() {
+        while (pos < headersJson.size() && std::isspace(static_cast<unsigned char>(headersJson[pos]))) {
+            pos++;
+        }
+    };
+
+    auto parseString = [&]() -> std::string {
+        if (pos >= headersJson.size() || headersJson[pos] != '"') {
+            return "";
+        }
+
+        pos++;
+        std::string result;
+        while (pos < headersJson.size()) {
+            char c = headersJson[pos++];
+            if (c == '\\' && pos < headersJson.size()) {
+                char escaped = headersJson[pos++];
+                switch (escaped) {
+                    case 'n': result += '\n'; break;
+                    case 'r': result += '\r'; break;
+                    case 't': result += '\t'; break;
+                    case '\\': result += '\\'; break;
+                    case '"': result += '"'; break;
+                    default: result += escaped; break;
+                }
+                continue;
+            }
+
+            if (c == '"') {
+                break;
+            }
+
+            result += c;
+        }
+
+        return result;
+    };
+
+    skipWhitespace();
+    if (pos >= headersJson.size() || headersJson[pos] != '[') {
+        return headers;
+    }
+
+    pos++;
+    while (pos < headersJson.size()) {
+        skipWhitespace();
+        if (pos < headersJson.size() && headersJson[pos] == ']') {
+            break;
+        }
+
+        if (pos >= headersJson.size() || headersJson[pos] != '[') {
+            break;
+        }
+
+        pos++;
+        skipWhitespace();
+        std::string key = parseString();
+        skipWhitespace();
+        if (pos < headersJson.size() && headersJson[pos] == ',') {
+            pos++;
+        }
+        skipWhitespace();
+        std::string value = parseString();
+        skipWhitespace();
+        if (pos < headersJson.size() && headersJson[pos] == ']') {
+            pos++;
+        }
+
+        headers.emplace_back(std::move(key), std::move(value));
+
+        skipWhitespace();
+        if (pos < headersJson.size() && headersJson[pos] == ',') {
+            pos++;
+        }
+    }
+
+    return headers;
+}
+
+static std::string buildProtocolHeadersJSON(const CefRequest::HeaderMap& headerMap) {
+    std::string json = "[";
+    bool firstHeader = true;
+    for (const auto& header : headerMap) {
+        if (!firstHeader) {
+            json += ",";
+        }
+        firstHeader = false;
+        json += "[\"" + escapeProtocolJSONString(header.first.ToString()) + "\",\"" +
+                escapeProtocolJSONString(header.second.ToString()) + "\"]";
+    }
+    json += "]";
+    return json;
+}
+
+static std::string buildProtocolHeadersJSON(SoupMessageHeaders* headers) {
+    if (!headers) {
+        return "[]";
+    }
+
+    std::string json = "[";
+    bool firstHeader = true;
+    struct Context {
+        std::string* json;
+        bool* firstHeader;
+    } context{&json, &firstHeader};
+
+    soup_message_headers_foreach(
+        headers,
+        [](const char* name, const char* value, gpointer user_data) {
+            auto* context = static_cast<Context*>(user_data);
+            if (!*context->firstHeader) {
+                *context->json += ",";
+            }
+            *context->firstHeader = false;
+            *context->json += "[\"" + escapeProtocolJSONString(name ? name : "") + "\",\"" +
+                              escapeProtocolJSONString(value ? value : "") + "\"]";
+        },
+        &context);
+
+    json += "]";
+    return json;
+}
+
+static std::vector<uint8_t> readProtocolRequestBody(CefRefPtr<CefPostData> postData) {
+    std::vector<uint8_t> body;
+    if (!postData || postData->GetElementCount() == 0) {
+        return body;
+    }
+
+    CefPostData::ElementVector elements;
+    postData->GetElements(elements);
+    for (auto& element : elements) {
+        if (element->GetType() != PDE_TYPE_BYTES) {
+            continue;
+        }
+
+        size_t size = element->GetBytesCount();
+        if (size == 0) {
+            continue;
+        }
+
+        size_t start = body.size();
+        body.resize(start + size);
+        element->GetBytes(size, body.data() + start);
+    }
+
+    return body;
+}
+
+static std::vector<uint8_t> readProtocolRequestBody(GInputStream* stream) {
+    std::vector<uint8_t> body;
+    if (!stream) {
+        return body;
+    }
+
+    uint8_t buffer[4096];
+    GError* error = nullptr;
+    gssize bytesRead = 0;
+    while ((bytesRead = g_input_stream_read(stream, buffer, sizeof(buffer), nullptr, &error)) > 0) {
+        body.insert(body.end(), buffer, buffer + bytesRead);
+    }
+
+    if (error) {
+        g_error_free(error);
+    }
+
+    return body;
+}
+
+static std::string buildProtocolRequestJson(const std::string& url,
+                                            const std::string& method,
+                                            const std::string& headersJson,
+                                            bool hasBody) {
+    return std::string("{\"url\":\"") + escapeProtocolJSONString(url) +
+           "\",\"method\":\"" + escapeProtocolJSONString(method) +
+           "\",\"headers\":" + headersJson +
+           ",\"hasBody\":" + (hasBody ? "true" : "false") + "}";
+}
 
 // X11 Window structure to replace GTK windows
 struct X11Window {
@@ -527,141 +759,220 @@ public:
 // CEF views:// scheme handler implementation
 class ViewsResourceHandler : public CefResourceHandler {
 public:
-    explicit ViewsResourceHandler(uint32_t webviewId) : offset_(0), webviewId_(webviewId) {}
+    explicit ViewsResourceHandler(uint32_t webviewId)
+        : hasResponse_(false), offset_(0), webviewId_(webviewId), requestId_(0), statusCode_(200), headerReady_(false), finished_(false), failed_(false) {}
+
+    void OnProtocolResponseStart(int statusCode, const std::string& statusText, const std::string& headersJson);
+    void OnProtocolResponseChunk(const uint8_t* chunk, size_t size);
+    void OnProtocolResponseFinish();
+    void OnProtocolResponseError(const std::string& message);
     
     bool Open(CefRefPtr<CefRequest> request, bool& handle_request, CefRefPtr<CefCallback> callback) override {
-        std::string url = request->GetURL();
-        
-        // Parse the URI to get everything after views://
-        std::string fullPath = "index.html"; // default
+        handle_request = true;
+
+        std::string url = request->GetURL().ToString();
+        std::string scheme = extractProtocolScheme(url);
+        data_.clear();
+        mimeType_.clear();
+        hasResponse_ = false;
+        offset_ = 0;
+        requestId_ = 0;
+        statusCode_ = 200;
+        statusText_ = "OK";
+        headerReady_ = false;
+        finished_ = false;
+        failed_ = false;
+        errorMessage_.clear();
+        responseHeaders_.clear();
+        headerMap_.clear();
+        chunks_.clear();
+        chunkOffset_ = 0;
+
         if (url.find("views://") == 0) {
-            fullPath = url.substr(8); // Skip "views://"
-        }
-        
-        // Check if this is the internal HTML request
-        if (fullPath == "internal/index.html") {
-            // Use stored HTML content for this specific webview
-            const char* htmlContent = getWebviewHTMLContent(webviewId_);
-            if (htmlContent) {
-                data_ = std::string(htmlContent);
-                mimeType_ = "text/html";
-                free((void*)htmlContent); // Free the strdup'd memory
-                handle_request = true;
-                return true;
-            } else {
+            std::string fullPath = url.substr(8);
+            if (fullPath.empty()) {
+                fullPath = "index.html";
+            }
+
+            if (fullPath == "internal/index.html") {
+                const char* htmlContent = getWebviewHTMLContent(webviewId_);
+                if (htmlContent) {
+                    data_ = std::string(htmlContent);
+                    mimeType_ = "text/html";
+                    free((void*)htmlContent);
+                    hasResponse_ = true;
+                    return true;
+                }
+
                 data_ = "<html><body>No content set</body></html>";
                 mimeType_ = "text/html";
-                handle_request = true;
+                hasResponse_ = true;
                 return true;
             }
-        }
-        
-        // Build paths relative to current directory (bin)
-        char* cwd = g_get_current_dir();
-        gchar* resourcesDir = g_build_filename(cwd, "..", "Resources", nullptr);
-        gchar* asarPath = g_build_filename(resourcesDir, "app.asar", nullptr);
 
-        // Check if ASAR archive exists
-        if (g_file_test(asarPath, G_FILE_TEST_EXISTS)) {
-            // Thread-safe lazy-load ASAR archive on first use
-            std::call_once(g_asarArchiveInitFlag, [asarPath]() {
-                g_asarArchive = asar_open(asarPath);
-                if (!g_asarArchive) {
-                    printf("ERROR CEF loadViewsFile: Failed to open ASAR archive at %s\n", asarPath);
-                }
-            });
+            char* cwd = g_get_current_dir();
+            gchar* resourcesDir = g_build_filename(cwd, "..", "Resources", nullptr);
+            gchar* asarPath = g_build_filename(resourcesDir, "app.asar", nullptr);
 
-            // If ASAR archive is loaded, try to read from it
-            if (g_asarArchive) {
-                // The ASAR contains the entire app directory, so prepend "views/" to the path
-                std::string asarFilePath = "views/" + fullPath;
+            if (g_file_test(asarPath, G_FILE_TEST_EXISTS)) {
+                std::call_once(g_asarArchiveInitFlag, [asarPath]() {
+                    g_asarArchive = asar_open(asarPath);
+                    if (!g_asarArchive) {
+                        printf("ERROR CEF loadViewsFile: Failed to open ASAR archive at %s\n", asarPath);
+                    }
+                });
 
-                size_t fileSize = 0;
-                const uint8_t* fileData = nullptr;
-                
-                // Protect ASAR read operations with mutex
-                {
-                    std::lock_guard<std::mutex> lock(g_asarReadMutex);
-                    fileData = asar_read_file(g_asarArchive, asarFilePath.c_str(), &fileSize);
-                    
-                    if (fileData && fileSize > 0) {
-                        // Create std::string that copies the buffer while holding the lock
-                        data_ = std::string(reinterpret_cast<const char*>(fileData), fileSize);
-                        // Free the ASAR buffer before releasing the lock
-                        asar_free_buffer(fileData, fileSize);
+                if (g_asarArchive) {
+                    std::string asarFilePath = "views/" + fullPath;
+                    size_t fileSize = 0;
+                    const uint8_t* fileData = nullptr;
+
+                    {
+                        std::lock_guard<std::mutex> lock(g_asarReadMutex);
+                        fileData = asar_read_file(g_asarArchive, asarFilePath.c_str(), &fileSize);
+                        if (fileData && fileSize > 0) {
+                            data_ = std::string(reinterpret_cast<const char*>(fileData), fileSize);
+                            asar_free_buffer(fileData, fileSize);
+                        }
+                    }
+
+                    if (!data_.empty()) {
+                        std::string mimeType = "application/octet-stream";
+                        if (fullPath.find(".html") != std::string::npos) mimeType = "text/html";
+                        else if (fullPath.find(".css") != std::string::npos) mimeType = "text/css";
+                        else if (fullPath.find(".js") != std::string::npos) mimeType = "text/javascript";
+                        else if (fullPath.find(".json") != std::string::npos) mimeType = "application/json";
+                        else if (fullPath.find(".png") != std::string::npos) mimeType = "image/png";
+                        else if (fullPath.find(".jpg") != std::string::npos || fullPath.find(".jpeg") != std::string::npos) mimeType = "image/jpeg";
+                        else if (fullPath.find(".svg") != std::string::npos) mimeType = "image/svg+xml";
+                        else if (fullPath.find(".woff") != std::string::npos) mimeType = "font/woff";
+                        else if (fullPath.find(".woff2") != std::string::npos) mimeType = "font/woff2";
+                        else if (fullPath.find(".ttf") != std::string::npos) mimeType = "font/ttf";
+                        mimeType_ = mimeType;
+
+                        g_free(cwd);
+                        g_free(resourcesDir);
+                        g_free(asarPath);
+
+                        hasResponse_ = true;
+                        return true;
                     }
                 }
+            }
 
-                if (!data_.empty()) {
+            gchar* viewsDir = g_build_filename(resourcesDir, "app", "views", nullptr);
+            gchar* filePath = g_build_filename(viewsDir, fullPath.c_str(), nullptr);
 
-                    // Determine MIME type
-                    std::string mimeType = "application/octet-stream";
-                    if (fullPath.find(".html") != std::string::npos) mimeType = "text/html";
-                    else if (fullPath.find(".css") != std::string::npos) mimeType = "text/css";
-                    else if (fullPath.find(".js") != std::string::npos) mimeType = "text/javascript";
-                    else if (fullPath.find(".json") != std::string::npos) mimeType = "application/json";
-                    else if (fullPath.find(".png") != std::string::npos) mimeType = "image/png";
-                    else if (fullPath.find(".jpg") != std::string::npos || fullPath.find(".jpeg") != std::string::npos) mimeType = "image/jpeg";
-                    else if (fullPath.find(".svg") != std::string::npos) mimeType = "image/svg+xml";
-                    else if (fullPath.find(".woff") != std::string::npos) mimeType = "font/woff";
-                    else if (fullPath.find(".woff2") != std::string::npos) mimeType = "font/woff2";
-                    else if (fullPath.find(".ttf") != std::string::npos) mimeType = "font/ttf";
-                    mimeType_ = mimeType;
+            if (g_file_test(filePath, G_FILE_TEST_EXISTS)) {
+                gsize fileSize;
+                gchar* fileContent;
+                GError* error = nullptr;
+
+                if (g_file_get_contents(filePath, &fileContent, &fileSize, &error)) {
+                    data_ = std::string(fileContent, fileSize);
+                    g_free(fileContent);
+                    mimeType_ = getMimeTypeFromUrl(fullPath);
 
                     g_free(cwd);
                     g_free(resourcesDir);
                     g_free(asarPath);
+                    g_free(viewsDir);
+                    g_free(filePath);
 
-                    handle_request = true;
+                    hasResponse_ = true;
                     return true;
-                } else {
-                    // Fall through to flat file reading
                 }
-            }
-        }
 
-        // Fallback: Read from flat file system (for non-ASAR builds or missing files)
-        gchar* viewsDir = g_build_filename(resourcesDir, "app", "views", nullptr);
-        gchar* filePath = g_build_filename(viewsDir, fullPath.c_str(), nullptr);
-
-
-        // Check if file exists and read it
-        if (g_file_test(filePath, G_FILE_TEST_EXISTS)) {
-            gsize fileSize;
-            gchar* fileContent;
-            GError* error = nullptr;
-
-            if (g_file_get_contents(filePath, &fileContent, &fileSize, &error)) {
-                data_ = std::string(fileContent, fileSize);
-                g_free(fileContent);
-                
-                // Determine MIME type using shared function
-                mimeType_ = getMimeTypeFromUrl(fullPath);
-                
-                
-                g_free(cwd);
-                g_free(viewsDir);
-                g_free(filePath);
-                
-                handle_request = true;
-                return true;
-            } else {
                 printf("CEF views:// failed to read file: %s\n", error ? error->message : "unknown error");
                 if (error) g_error_free(error);
+            } else {
+                printf("CEF views:// file not found: %s\n", filePath);
             }
-        } else {
-            printf("CEF views:// file not found: %s\n", filePath);
+
+            g_free(cwd);
+            g_free(resourcesDir);
+            g_free(asarPath);
+            g_free(viewsDir);
+            g_free(filePath);
+            hasResponse_ = false;
+            return false;
         }
-        
-        g_free(cwd);
-        g_free(viewsDir);
-        g_free(filePath);
-        
-        handle_request = false;
+
+        if (hasProtocolRegistration(scheme)) {
+            requestId_ = g_nextProtocolRequestId.fetch_add(1);
+            hasResponse_ = true;
+            offset_ = 0;
+
+            std::string method = request->GetMethod().ToString();
+            CefRequest::HeaderMap headerMap;
+            request->GetHeaderMap(headerMap);
+            std::string headersJson = buildProtocolHeadersJSON(headerMap);
+
+            std::vector<uint8_t> body = readProtocolRequestBody(request->GetPostData());
+            bool hasBody = !body.empty();
+            if (hasBody) {
+                std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+                g_protocolRequestBodies[requestId_] = std::move(body);
+            }
+
+            std::string requestJson = buildProtocolRequestJson(url, method, headersJson, hasBody);
+
+            {
+                std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+                g_pendingCEFProtocolHandlers[requestId_] = this;
+            }
+
+            if (g_protocolRequestHandler) {
+                uint64_t requestId = requestId_;
+                uint32_t webviewId = webviewId_;
+                dispatchProtocolRequestSync([requestId, webviewId, requestJson]() {
+                    char* requestJsonCopy = strdup(requestJson.c_str());
+                    g_protocolRequestHandler(requestId, webviewId, requestJsonCopy);
+                });
+                return true;
+            }
+
+            {
+                std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+                g_pendingCEFProtocolHandlers.erase(requestId_);
+                g_protocolRequestBodies.erase(requestId_);
+            }
+            requestId_ = 0;
+            hasResponse_ = false;
+            return false;
+        }
+
+        hasResponse_ = false;
         return false;
     }
     
     void GetResponseHeaders(CefRefPtr<CefResponse> response, int64_t& response_length, CefString& redirectUrl) override {
+        if (requestId_ != 0) {
+            std::unique_lock<std::mutex> lock(mutex_);
+            condition_.wait(lock, [&] { return headerReady_ || failed_; });
+            if (failed_) {
+                response->SetStatus(500);
+                response_length = 0;
+                return;
+            }
+
+            response->SetStatus(statusCode_);
+            response->SetStatusText(statusText_);
+            response->SetHeaderMap(headerMap_);
+            auto contentType = responseHeaders_.find("content-type");
+            if (contentType != responseHeaders_.end()) {
+                response->SetMimeType(contentType->second);
+            }
+            response_length = -1;
+            return;
+        }
+
+        if (!hasResponse_) {
+            response->SetStatus(404);
+            response_length = 0;
+            return;
+        }
+
         response->SetStatus(200);
         response->SetMimeType(mimeType_);
         response->SetStatusText("OK");
@@ -669,32 +980,126 @@ public:
     }
     
     bool Read(void* data_out, int bytes_to_read, int& bytes_read, CefRefPtr<CefResourceReadCallback> callback) override {
-        bool has_data = false;
         bytes_read = 0;
-        
-        if (offset_ < data_.length()) {
-            int transfer_size = std::min(bytes_to_read, static_cast<int>(data_.length() - offset_));
-            memcpy(data_out, data_.c_str() + offset_, transfer_size);
-            offset_ += transfer_size;
-            bytes_read = transfer_size;
-            has_data = true;
+
+        if (requestId_ != 0) {
+            std::unique_lock<std::mutex> lock(mutex_);
+            condition_.wait(lock, [&] {
+                return failed_ || !chunks_.empty() || finished_;
+            });
+
+            if (failed_) {
+                return false;
+            }
+
+            if (chunks_.empty()) {
+                return false;
+            }
+
+            std::vector<uint8_t>& chunk = chunks_.front();
+            size_t remaining = chunk.size() - chunkOffset_;
+            bytes_read = std::min(bytes_to_read, static_cast<int>(remaining));
+            memcpy(data_out, chunk.data() + chunkOffset_, bytes_read);
+            chunkOffset_ += bytes_read;
+            if (chunkOffset_ >= chunk.size()) {
+                chunks_.pop_front();
+                chunkOffset_ = 0;
+            }
+            return true;
         }
-        
-        return has_data;
+
+        if (offset_ >= data_.length()) {
+            return false;
+        }
+
+        int transfer_size = std::min(bytes_to_read, static_cast<int>(data_.length() - offset_));
+        memcpy(data_out, data_.c_str() + offset_, transfer_size);
+        offset_ += transfer_size;
+        bytes_read = transfer_size;
+        return true;
     }
     
     void Cancel() override {
-        // Nothing to cancel
+        if (requestId_ != 0) {
+            if (g_protocolRequestCancelledHandler) {
+                g_protocolRequestCancelledHandler(requestId_);
+            }
+            {
+                std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+                g_pendingCEFProtocolHandlers.erase(requestId_);
+                g_protocolRequestBodies.erase(requestId_);
+            }
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                failed_ = true;
+            }
+            condition_.notify_all();
+        }
     }
     
 private:
     std::string data_;
     std::string mimeType_;
+    bool hasResponse_;
     size_t offset_;
     uint32_t webviewId_;
+    uint64_t requestId_;
+    int statusCode_;
+    std::string statusText_;
+    bool headerReady_;
+    bool finished_;
+    bool failed_;
+    std::string errorMessage_;
+    std::map<std::string, std::string> responseHeaders_;
+    CefResponse::HeaderMap headerMap_;
+    std::mutex mutex_;
+    std::condition_variable condition_;
+    std::deque<std::vector<uint8_t>> chunks_;
+    size_t chunkOffset_ = 0;
     
     IMPLEMENT_REFCOUNTING(ViewsResourceHandler);
 };
+
+void ViewsResourceHandler::OnProtocolResponseStart(int statusCode,
+                                                   const std::string& statusText,
+                                                   const std::string& headersJson) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    statusCode_ = statusCode;
+    statusText_ = statusText.empty() ? "OK" : statusText;
+    headerReady_ = true;
+    headerMap_.clear();
+    responseHeaders_.clear();
+
+    for (const auto& header : parseProtocolHeaderPairs(headersJson)) {
+        std::string normalizedKey = header.first;
+        std::transform(normalizedKey.begin(), normalizedKey.end(), normalizedKey.begin(), [](unsigned char c) {
+            return static_cast<char>(std::tolower(c));
+        });
+        responseHeaders_[normalizedKey] = header.second;
+        headerMap_.insert(std::make_pair(header.first, header.second));
+    }
+
+    condition_.notify_all();
+}
+
+void ViewsResourceHandler::OnProtocolResponseChunk(const uint8_t* chunk, size_t size) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    chunks_.emplace_back(chunk, chunk + size);
+    condition_.notify_all();
+}
+
+void ViewsResourceHandler::OnProtocolResponseFinish() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    finished_ = true;
+    condition_.notify_all();
+}
+
+void ViewsResourceHandler::OnProtocolResponseError(const std::string& message) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    failed_ = true;
+    errorMessage_ = message;
+    condition_.notify_all();
+}
 
 // CEF views:// scheme handler factory
 class ViewsSchemeHandlerFactory : public CefSchemeHandlerFactory {
@@ -756,6 +1161,13 @@ public:
     
     void OnBeforeCommandLineProcessing(const CefString& process_type, CefRefPtr<CefCommandLine> command_line) override {
         command_line->AppendSwitchWithValue("custom-scheme", "views");
+        forEachProtocolRegistration([&](const ProtocolRegistration& registration) {
+            command_line->AppendSwitchWithValue("custom-scheme", registration.scheme);
+        });
+        std::string protocolConfigJson = getProtocolConfigJson();
+        if (!protocolConfigJson.empty()) {
+            command_line->AppendSwitchWithValue("electrobun-custom-protocols", protocolConfigJson);
+        }
 
         // Linux default flags — can be overridden via chromiumFlags in config
         // GPU acceleration disabled by default for VM compatibility;
@@ -792,6 +1204,16 @@ public:
             CEF_SCHEME_OPTION_SECURE |
             CEF_SCHEME_OPTION_CSP_BYPASSING |
             CEF_SCHEME_OPTION_FETCH_ENABLED);
+
+        forEachProtocolRegistration([&](const ProtocolRegistration& registration) {
+            int options = 0;
+            if (registration.privileges.standard) options |= CEF_SCHEME_OPTION_STANDARD;
+            if (registration.privileges.secure) options |= CEF_SCHEME_OPTION_SECURE;
+            if (registration.privileges.corsEnabled) options |= CEF_SCHEME_OPTION_CORS_ENABLED;
+            if (registration.privileges.bypassCSP) options |= CEF_SCHEME_OPTION_CSP_BYPASSING;
+            if (registration.privileges.supportFetchAPI) options |= CEF_SCHEME_OPTION_FETCH_ENABLED;
+            registrar->AddCustomScheme(registration.scheme, options);
+        });
     }
     
     CefRefPtr<CefBrowserProcessHandler> GetBrowserProcessHandler() override {
@@ -802,10 +1224,21 @@ public:
         // In multi-process mode, return nullptr so render process uses the helper
         return nullptr;
     }
+
+    void OnBeforeChildProcessLaunch(CefRefPtr<CefCommandLine> command_line) override {
+        std::string protocolConfigJson = getProtocolConfigJson();
+        if (!protocolConfigJson.empty()) {
+            command_line->AppendSwitchWithValue("electrobun-custom-protocols", protocolConfigJson);
+        }
+    }
     
     
     void OnContextInitialized() override {
-        CefRegisterSchemeHandlerFactory("views", "", new ViewsSchemeHandlerFactory());
+        CefRefPtr<ViewsSchemeHandlerFactory> schemeFactory = new ViewsSchemeHandlerFactory();
+        CefRegisterSchemeHandlerFactory("views", "", schemeFactory);
+        forEachProtocolRegistration([&](const ProtocolRegistration& registration) {
+            CefRegisterSchemeHandlerFactory(registration.scheme, "", schemeFactory);
+        });
     }
     
     // Render process handler methods
@@ -1120,6 +1553,11 @@ public:
         CefRefPtr<CefFrame> frame,
         CefRefPtr<CefRequest> request,
         CefRefPtr<CefResponse> response) override {
+        std::string requestUrl = request->GetURL().ToString();
+        std::string scheme = extractProtocolScheme(requestUrl);
+        if (!scheme.empty() && scheme != "views" && hasProtocolRegistration(scheme)) {
+            return nullptr;
+        }
         
         // Only inject scripts into HTML responses in main frame
         if (frame->IsMain() && 
@@ -2041,6 +2479,7 @@ bool initializeCEF() {
     std::string buildJsonContent = electrobun::readFileToString(buildJsonPath);
     if (!buildJsonContent.empty()) {
         g_userChromiumFlags = electrobun::parseChromiumFlags(buildJsonContent);
+        electrobun::loadProtocolConfigFromBuildJson(buildJsonContent);
     }
 
     CefSettings settings;
@@ -3611,6 +4050,10 @@ CefRefPtr<CefRequestContext> CreateRequestContextForPartition(const char* partit
     if (!registered) {
         fprintf(stderr, "WARNING: Failed to register views:// scheme handler for partition context\n");
     }
+
+    forEachProtocolRegistration([&](const ProtocolRegistration& registration) {
+        context->RegisterSchemeHandlerFactory(registration.scheme, "", schemeFactory);
+    });
     
     return context;
 }
@@ -5149,6 +5592,174 @@ void applyApplicationMenuToX11Window(X11Window* x11win) {
     fflush(stdout);
 }
 
+static uint32_t getWebviewIdForURISchemeRequest(WebKitURISchemeRequest* request) {
+    uint32_t webviewId = 0;
+    WebKitWebView* requestingWebView = webkit_uri_scheme_request_get_web_view(request);
+    if (!requestingWebView) {
+        return webviewId;
+    }
+
+    std::lock_guard<std::mutex> lock(g_webviewMapMutex);
+    for (auto& [id, view] : g_webviewMap) {
+        auto* wkImpl = dynamic_cast<WebKitWebViewImpl*>(view.get());
+        if (wkImpl && wkImpl->webview == GTK_WIDGET(requestingWebView)) {
+            webviewId = id;
+            break;
+        }
+    }
+
+    return webviewId;
+}
+
+static GInputStream* createMemoryInputStreamFromBytes(const std::vector<uint8_t>& data) {
+    if (data.empty()) {
+        return g_memory_input_stream_new();
+    }
+
+    gpointer bytes = g_malloc(data.size());
+    memcpy(bytes, data.data(), data.size());
+    return g_memory_input_stream_new_from_data(bytes, data.size(), g_free);
+}
+
+static void cleanupPendingWebKitProtocolRequestLocked(uint64_t requestId) {
+    auto requestIt = g_pendingWebKitProtocolRequests.find(requestId);
+    if (requestIt != g_pendingWebKitProtocolRequests.end()) {
+        g_object_unref(requestIt->second);
+        g_pendingWebKitProtocolRequests.erase(requestIt);
+    }
+    g_pendingWebKitResponseStates.erase(requestId);
+    g_protocolRequestBodies.erase(requestId);
+}
+
+static void completePendingWebKitProtocolResponse(uint64_t requestId) {
+    WebKitURISchemeRequest* request = nullptr;
+    PendingWebKitProtocolResponseState state;
+
+    {
+        std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+        auto requestIt = g_pendingWebKitProtocolRequests.find(requestId);
+        if (requestIt == g_pendingWebKitProtocolRequests.end()) {
+            cleanupPendingWebKitProtocolRequestLocked(requestId);
+            return;
+        }
+
+        request = WEBKIT_URI_SCHEME_REQUEST(g_object_ref(requestIt->second));
+
+        auto stateIt = g_pendingWebKitResponseStates.find(requestId);
+        if (stateIt != g_pendingWebKitResponseStates.end()) {
+            state = stateIt->second;
+        }
+
+        cleanupPendingWebKitProtocolRequestLocked(requestId);
+    }
+
+    GInputStream* stream = createMemoryInputStreamFromBytes(state.body);
+
+#if WEBKIT_CHECK_VERSION(2, 36, 0)
+    WebKitURISchemeResponse* response = webkit_uri_scheme_response_new(stream, static_cast<gint64>(state.body.size()));
+    SoupMessageHeaders* responseHeaders = soup_message_headers_new(SOUP_MESSAGE_HEADERS_RESPONSE);
+    std::string contentType;
+    for (const auto& header : parseProtocolHeaderPairs(state.headersJson)) {
+        soup_message_headers_append(responseHeaders, header.first.c_str(), header.second.c_str());
+        std::string normalizedKey = header.first;
+        std::transform(normalizedKey.begin(), normalizedKey.end(), normalizedKey.begin(), [](unsigned char c) {
+            return static_cast<char>(std::tolower(c));
+        });
+        if (normalizedKey == "content-type") {
+            contentType = header.second;
+        }
+    }
+
+    webkit_uri_scheme_response_set_status(response, state.statusCode, state.statusText.empty() ? nullptr : state.statusText.c_str());
+    if (!contentType.empty()) {
+        webkit_uri_scheme_response_set_content_type(response, contentType.c_str());
+    }
+    webkit_uri_scheme_response_set_http_headers(response, responseHeaders);
+    webkit_uri_scheme_request_finish_with_response(request, response);
+    g_object_unref(response);
+#else
+    std::string contentType = "application/octet-stream";
+    for (const auto& header : parseProtocolHeaderPairs(state.headersJson)) {
+        std::string normalizedKey = header.first;
+        std::transform(normalizedKey.begin(), normalizedKey.end(), normalizedKey.begin(), [](unsigned char c) {
+            return static_cast<char>(std::tolower(c));
+        });
+        if (normalizedKey == "content-type") {
+            contentType = header.second;
+            break;
+        }
+    }
+
+    webkit_uri_scheme_request_finish(request, stream, static_cast<gint64>(state.body.size()), contentType.c_str());
+#endif
+
+    g_object_unref(stream);
+    g_object_unref(request);
+}
+
+static void completePendingWebKitProtocolError(uint64_t requestId, const std::string& message) {
+    WebKitURISchemeRequest* request = nullptr;
+
+    {
+        std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+        auto requestIt = g_pendingWebKitProtocolRequests.find(requestId);
+        if (requestIt == g_pendingWebKitProtocolRequests.end()) {
+            cleanupPendingWebKitProtocolRequestLocked(requestId);
+            return;
+        }
+
+        request = WEBKIT_URI_SCHEME_REQUEST(g_object_ref(requestIt->second));
+        cleanupPendingWebKitProtocolRequestLocked(requestId);
+    }
+
+    GError* error = g_error_new(G_IO_ERROR, G_IO_ERROR_FAILED, "%s", message.c_str());
+    webkit_uri_scheme_request_finish_error(request, error);
+    g_error_free(error);
+    g_object_unref(request);
+}
+
+static void handleCustomProtocolURIScheme(WebKitURISchemeRequest* request, gpointer user_data) {
+    const char* uri = webkit_uri_scheme_request_get_uri(request);
+    if (!uri) {
+        return;
+    }
+
+    uint32_t webviewId = getWebviewIdForURISchemeRequest(request);
+    std::string method = webkit_uri_scheme_request_get_http_method(request) ? webkit_uri_scheme_request_get_http_method(request) : "GET";
+    std::string headersJson = buildProtocolHeadersJSON(webkit_uri_scheme_request_get_http_headers(request));
+
+    std::vector<uint8_t> body;
+#if WEBKIT_CHECK_VERSION(2, 40, 0)
+    GInputStream* bodyStream = webkit_uri_scheme_request_get_http_body(request);
+    if (bodyStream) {
+        body = readProtocolRequestBody(bodyStream);
+        g_object_unref(bodyStream);
+    }
+#endif
+
+    bool hasBody = !body.empty();
+    std::string requestJson = buildProtocolRequestJson(uri, method, headersJson, hasBody);
+    uint64_t requestId = g_nextProtocolRequestId.fetch_add(1);
+
+    {
+        std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+        g_pendingWebKitProtocolRequests[requestId] = WEBKIT_URI_SCHEME_REQUEST(g_object_ref(request));
+        g_pendingWebKitResponseStates[requestId] = PendingWebKitProtocolResponseState();
+        if (hasBody) {
+            g_protocolRequestBodies[requestId] = std::move(body);
+        }
+    }
+
+    if (g_protocolRequestHandler) {
+        dispatchProtocolRequestSync([requestId, webviewId, requestJson]() {
+            char* requestJsonCopy = strdup(requestJson.c_str());
+            g_protocolRequestHandler(requestId, webviewId, requestJsonCopy);
+        });
+    } else {
+        completePendingWebKitProtocolError(requestId, "No protocol handler configured");
+    }
+}
+
 // views:// URI scheme handler callback
 static void handleViewsURIScheme(WebKitURISchemeRequest* request, gpointer user_data) {
     const char* uri = webkit_uri_scheme_request_get_uri(request);
@@ -5164,19 +5775,7 @@ static void handleViewsURIScheme(WebKitURISchemeRequest* request, gpointer user_
     if (strcmp(fullPath, "internal/index.html") == 0) {
         fflush(stdout);
         
-        // Resolve the webviewId by matching the requesting WebKitWebView to g_webviewMap
-        uint32_t webviewId = 0;
-        WebKitWebView* requestingWebView = webkit_uri_scheme_request_get_web_view(request);
-        if (requestingWebView) {
-            std::lock_guard<std::mutex> lock(g_webviewMapMutex);
-            for (auto& [id, view] : g_webviewMap) {
-                auto* wkImpl = dynamic_cast<WebKitWebViewImpl*>(view.get());
-                if (wkImpl && wkImpl->webview == GTK_WIDGET(requestingWebView)) {
-                    webviewId = id;
-                    break;
-                }
-            }
-        }
+        uint32_t webviewId = getWebviewIdForURISchemeRequest(request);
         
         // Use stored HTML content for this specific webview
         const char* htmlContent = getWebviewHTMLContent(webviewId);
@@ -5322,6 +5921,9 @@ void initializeGTK() {
             // Register the views:// URI scheme handler AFTER GTK is initialized
             WebKitWebContext* context = webkit_web_context_get_default();
             webkit_web_context_register_uri_scheme(context, "views", handleViewsURIScheme, nullptr, nullptr);
+            forEachProtocolRegistration([&](const ProtocolRegistration& registration) {
+                webkit_web_context_register_uri_scheme(context, registration.scheme.c_str(), handleCustomProtocolURIScheme, nullptr, nullptr);
+            });
         }
     }
     // Notify all waiting threads that GTK is initialized
@@ -5461,6 +6063,12 @@ dispatch_sync_main_void(Func&& func) {
     }
 }
 
+void dispatchProtocolRequestSync(std::function<void()> callback) {
+    dispatch_sync_main_void([callback = std::move(callback)]() {
+        callback();
+    });
+}
+
 // Store for partition-specific contexts (for session storage synchronization)
 static std::map<std::string, WebKitWebContext*> g_partitionContexts;
 
@@ -5589,9 +6197,12 @@ static WebKitWebContext* getContextForPartition(const char* partitionIdentifier)
             context = webkit_web_context_new_with_website_data_manager(dataManager);
             g_object_unref(dataManager);
         }
-
+        
         // Register views:// scheme handler for this partition context
         webkit_web_context_register_uri_scheme(context, "views", handleViewsURIScheme, nullptr, nullptr);
+        forEachProtocolRegistration([&](const ProtocolRegistration& registration) {
+            webkit_web_context_register_uri_scheme(context, registration.scheme.c_str(), handleCustomProtocolURIScheme, nullptr, nullptr);
+        });
         
         g_partitionContexts[partition] = context;
     }
@@ -10888,6 +11499,145 @@ ELECTROBUN_EXPORT void setDockIconVisible(bool visible) {
 ELECTROBUN_EXPORT bool isDockIconVisible() {
     // Not supported on Linux
     return true;
+}
+
+ELECTROBUN_EXPORT void setCustomProtocolConfig(const char* protocolConfigJson) {
+    setProtocolConfigJson(protocolConfigJson ? protocolConfigJson : "[]");
+}
+
+ELECTROBUN_EXPORT void setCustomProtocolHandlers(ProtocolRequestHandler requestHandler,
+                                                 ProtocolRequestCancelledHandler cancelHandler) {
+    g_protocolRequestHandler = requestHandler;
+    g_protocolRequestCancelledHandler = cancelHandler;
+}
+
+ELECTROBUN_EXPORT const uint8_t* protocolGetRequestBody(uint64_t requestId, uint64_t* outSize) {
+    std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+    auto it = g_protocolRequestBodies.find(requestId);
+    if (it == g_protocolRequestBodies.end()) {
+        if (outSize) {
+            *outSize = 0;
+        }
+        return nullptr;
+    }
+
+    const auto& body = it->second;
+    if (outSize) {
+        *outSize = body.size();
+    }
+
+    if (body.empty()) {
+        g_protocolRequestBodies.erase(it);
+        return nullptr;
+    }
+
+    uint8_t* result = static_cast<uint8_t*>(malloc(body.size()));
+    if (!result) {
+        if (outSize) {
+            *outSize = 0;
+        }
+        g_protocolRequestBodies.erase(it);
+        return nullptr;
+    }
+    memcpy(result, body.data(), body.size());
+    g_protocolRequestBodies.erase(it);
+    return result;
+}
+
+ELECTROBUN_EXPORT void freeProtocolBuffer(const uint8_t* buffer) {
+    if (buffer) {
+        free((void*)buffer);
+    }
+}
+
+ELECTROBUN_EXPORT void protocolStartResponse(uint64_t requestId,
+                                             int statusCode,
+                                             const char* statusText,
+                                             const char* headersJson) {
+    std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+    auto cefIt = g_pendingCEFProtocolHandlers.find(requestId);
+    if (cefIt != g_pendingCEFProtocolHandlers.end()) {
+        cefIt->second->OnProtocolResponseStart(statusCode, statusText ? statusText : "OK", headersJson ? headersJson : "[]");
+        return;
+    }
+
+    if (g_pendingWebKitProtocolRequests.find(requestId) == g_pendingWebKitProtocolRequests.end()) {
+        return;
+    }
+
+    auto stateIt = g_pendingWebKitResponseStates.find(requestId);
+    if (stateIt == g_pendingWebKitResponseStates.end()) {
+        return;
+    }
+
+    auto& state = stateIt->second;
+    state.statusCode = statusCode;
+    state.statusText = statusText ? statusText : "OK";
+    state.headersJson = headersJson ? headersJson : "[]";
+}
+
+ELECTROBUN_EXPORT void protocolWriteResponseChunk(uint64_t requestId, const uint8_t* chunk, uint64_t size) {
+    if (!chunk || size == 0) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+    auto cefIt = g_pendingCEFProtocolHandlers.find(requestId);
+    if (cefIt != g_pendingCEFProtocolHandlers.end()) {
+        cefIt->second->OnProtocolResponseChunk(chunk, static_cast<size_t>(size));
+        return;
+    }
+
+    if (g_pendingWebKitProtocolRequests.find(requestId) == g_pendingWebKitProtocolRequests.end()) {
+        return;
+    }
+
+    auto stateIt = g_pendingWebKitResponseStates.find(requestId);
+    if (stateIt == g_pendingWebKitResponseStates.end()) {
+        return;
+    }
+
+    // WebKitGTK requires the complete GInputStream when
+    // webkit_uri_scheme_request_finish_with_response()/finish() is called, so
+    // we buffer chunks here and create the input stream in protocolFinishResponse.
+    auto& body = stateIt->second.body;
+    body.insert(body.end(), chunk, chunk + size);
+}
+
+ELECTROBUN_EXPORT void protocolFinishResponse(uint64_t requestId) {
+    {
+        std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+        auto cefIt = g_pendingCEFProtocolHandlers.find(requestId);
+        if (cefIt != g_pendingCEFProtocolHandlers.end()) {
+            cefIt->second->OnProtocolResponseFinish();
+            g_pendingCEFProtocolHandlers.erase(cefIt);
+            g_protocolRequestBodies.erase(requestId);
+            return;
+        }
+    }
+
+    dispatch_sync_main_void([requestId]() {
+        completePendingWebKitProtocolResponse(requestId);
+    });
+}
+
+ELECTROBUN_EXPORT void protocolErrorResponse(uint64_t requestId, const char* message) {
+    std::string errorMessage = message ? message : "Protocol request failed";
+
+    {
+        std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+        auto cefIt = g_pendingCEFProtocolHandlers.find(requestId);
+        if (cefIt != g_pendingCEFProtocolHandlers.end()) {
+            cefIt->second->OnProtocolResponseError(errorMessage);
+            g_pendingCEFProtocolHandlers.erase(cefIt);
+            g_protocolRequestBodies.erase(requestId);
+            return;
+        }
+    }
+
+    dispatch_sync_main_void([requestId, errorMessage]() {
+        completePendingWebKitProtocolError(requestId, errorMessage);
+    });
 }
 
 // Graceful shutdown function to coordinate cleanup

--- a/package/src/native/macos/cef_process_helper_mac.cc
+++ b/package/src/native/macos/cef_process_helper_mac.cc
@@ -1,6 +1,7 @@
 #include "include/cef_app.h"
 #include "include/cef_v8.h"
 #include "include/wrapper/cef_library_loader.h"
+#include "../shared/protocol_config.h"
 #include <map>
 #include <mutex>
 
@@ -12,12 +13,29 @@ class HelperApp : public CefApp, public CefRenderProcessHandler {
 public:
     // CefApp methods:
     virtual void OnRegisterCustomSchemes(CefRawPtr<CefSchemeRegistrar> registrar) override {
+        CefRefPtr<CefCommandLine> command_line = CefCommandLine::GetGlobalCommandLine();
+        if (command_line && command_line->HasSwitch("electrobun-custom-protocols")) {
+            electrobun::setProtocolConfigJson(command_line->GetSwitchValue("electrobun-custom-protocols").ToString());
+        }
         registrar->AddCustomScheme("views",
             CEF_SCHEME_OPTION_STANDARD |
             CEF_SCHEME_OPTION_CORS_ENABLED |
             CEF_SCHEME_OPTION_SECURE | // treat it like https
             CEF_SCHEME_OPTION_CSP_BYPASSING | // allow things like crypto.subtle
             CEF_SCHEME_OPTION_FETCH_ENABLED);
+
+        electrobun::forEachProtocolRegistration([&](const electrobun::ProtocolRegistration& registration) {
+            int options = 0;
+            if (registration.privileges.standard) options |= CEF_SCHEME_OPTION_STANDARD;
+            if (registration.privileges.secure) options |= CEF_SCHEME_OPTION_SECURE;
+            if (registration.privileges.corsEnabled) options |= CEF_SCHEME_OPTION_CORS_ENABLED;
+            if (registration.privileges.bypassCSP) options |= CEF_SCHEME_OPTION_CSP_BYPASSING;
+            if (registration.privileges.supportFetchAPI) options |= CEF_SCHEME_OPTION_FETCH_ENABLED;
+            if (registration.privileges.stream) options |= CEF_SCHEME_OPTION_STREAMING;
+            if (registration.privileges.codeCache) options |= CEF_SCHEME_OPTION_CODE_CACHE_ENABLED;
+            if (registration.privileges.allowServiceWorkers) options |= CEF_SCHEME_OPTION_SERVICE_WORKERS_ALLOWED;
+            registrar->AddCustomScheme(registration.scheme, options);
+        });
     }
 
     virtual CefRefPtr<CefRenderProcessHandler> GetRenderProcessHandler() override {

--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -30,6 +30,8 @@ static bool wgpuDebugEnabled() {
 #include <unistd.h>
 #include <signal.h>
 #include <atomic>
+#include <condition_variable>
+#include <deque>
 #include <mutex>
 #include "../shared/pending_resize_queue.h"
 
@@ -57,6 +59,7 @@ static bool wgpuDebugEnabled() {
 #include <cstdint>
 #include <chrono>
 #include <map>
+#include <unordered_map>
 #include <mutex>
 #include <atomic>
 
@@ -77,6 +80,7 @@ static bool wgpuDebugEnabled() {
 #include "../shared/app_paths.h"
 #include "../shared/accelerator_parser.h"
 #include "../shared/chromium_flags.h"
+#include "../shared/protocol_config.h"
 
 using namespace electrobun;
 
@@ -104,6 +108,19 @@ static id mouseDraggedMonitor = nil;
 static id mouseUpMonitor = nil;
 
 static int g_remoteDebugPort = 9222;
+// Protocol handlers are installed during startup via setCustomProtocolHandlers()
+// before any WKWebView/CEF browser is created, so request-path reads use atomic
+// loads without introducing additional locking on every request.
+static std::atomic<ProtocolRequestHandler> g_protocolRequestHandler{nullptr};
+static std::atomic<ProtocolRequestCancelledHandler> g_protocolRequestCancelledHandler{nullptr};
+static std::atomic<uint64_t> g_nextProtocolRequestId{1};
+static std::mutex g_protocolRequestMutex;
+static std::unordered_map<uint64_t, std::vector<uint8_t>> g_protocolRequestBodies;
+static std::unordered_map<uint64_t, id<WKURLSchemeTask>> g_pendingWKProtocolTasks;
+static std::unordered_map<void*, uint64_t> g_pendingWKTaskIds;
+
+class ElectrobunSchemeHandler;
+static std::unordered_map<uint64_t, ElectrobunSchemeHandler*> g_pendingCEFProtocolHandlers;
 
 // Menu role to selector mapping
 // This maps Electrobun role strings to their corresponding Objective-C selectors.
@@ -709,6 +726,99 @@ void retainObjCObject(id objcObject) {
 }
 void releaseObjCObject(id objcObject) {
     CFRelease((__bridge CFTypeRef)objcObject);
+}
+
+static std::string escapeProtocolJSONString(NSString *value) {
+    if (!value) {
+        return "";
+    }
+
+    const char* utf8 = value ? [value UTF8String] : nullptr;
+    std::string input = utf8 ? utf8 : "";
+    std::string output;
+    output.reserve(input.size() + 16);
+
+    for (char c : input) {
+        switch (c) {
+            case '"': output += "\\\""; break;
+            case '\\': output += "\\\\"; break;
+            case '\n': output += "\\n"; break;
+            case '\r': output += "\\r"; break;
+            case '\t': output += "\\t"; break;
+            default: output += c; break;
+        }
+    }
+
+    return output;
+}
+
+static std::string escapeProtocolJSONString(const std::string& input) {
+    std::string output;
+    output.reserve(input.size() + 16);
+    for (char c : input) {
+        switch (c) {
+            case '"': output += "\\\""; break;
+            case '\\': output += "\\\\"; break;
+            case '\n': output += "\\n"; break;
+            case '\r': output += "\\r"; break;
+            case '\t': output += "\\t"; break;
+            default: output += c; break;
+        }
+    }
+    return output;
+}
+
+static NSData *readProtocolRequestBody(NSURLRequest *request) {
+    if (request.HTTPBody) {
+        return request.HTTPBody;
+    }
+
+    NSInputStream *bodyStream = request.HTTPBodyStream;
+    if (!bodyStream) {
+        return nil;
+    }
+
+    NSMutableData *data = [NSMutableData data];
+    [bodyStream open];
+
+    uint8_t buffer[4096];
+    NSInteger bytesRead = 0;
+    while ((bytesRead = [bodyStream read:buffer maxLength:sizeof(buffer)]) > 0) {
+        [data appendBytes:buffer length:(NSUInteger)bytesRead];
+    }
+
+    if (bytesRead < 0) {
+        [bodyStream close];
+        return nil;
+    }
+
+    [bodyStream close];
+    return data;
+}
+
+static std::string buildProtocolHeadersJSON(NSDictionary<NSString *, NSString *> *headers) {
+    std::string json = "[";
+    bool first = true;
+    for (NSString *key in headers) {
+        if (!first) {
+            json += ",";
+        }
+        first = false;
+        json += "[\"" + escapeProtocolJSONString(key) + "\",\"" + escapeProtocolJSONString(headers[key]) + "\"]";
+    }
+    json += "]";
+    return json;
+}
+
+// Caller must hold g_protocolRequestMutex.
+static void cleanupPendingProtocolTask(uint64_t requestId) {
+    auto taskIt = g_pendingWKProtocolTasks.find(requestId);
+    if (taskIt != g_pendingWKProtocolTasks.end()) {
+        releaseObjCObject(taskIt->second);
+        g_pendingWKTaskIds.erase((__bridge void *)taskIt->second);
+        g_pendingWKProtocolTasks.erase(taskIt);
+    }
+    g_protocolRequestBodies.erase(requestId);
 }
 
 /*
@@ -1912,6 +2022,7 @@ static void schedulePendingResizeDrain() {
         const char *contentPtr = NULL;
         
         NSString *urlString = url.absoluteString;
+        NSString *scheme = url.scheme.lowercaseString;
         
         if ([urlString hasPrefix:@"views://"]) {
             NSString *relativePath = normalizeViewsRelativePath(urlString);
@@ -1943,6 +2054,54 @@ static void schedulePendingResizeDrain() {
                     contentLength = data.length;
                 }
             } 
+        } else if (scheme.length > 0 && hasProtocolRegistration([scheme UTF8String])) {
+            uint64_t requestId = g_nextProtocolRequestId.fetch_add(1);
+            NSData *requestBody = readProtocolRequestBody(urlSchemeTask.request);
+            std::string headersJson = buildProtocolHeadersJSON(urlSchemeTask.request.allHTTPHeaderFields ?: @{});
+            std::string requestJson = std::string("{\"url\":\"") +
+                escapeProtocolJSONString(urlString) +
+                "\",\"method\":\"" +
+                escapeProtocolJSONString(urlSchemeTask.request.HTTPMethod ?: @"GET") +
+                "\",\"headers\":" + headersJson +
+                ",\"hasBody\":" + (requestBody.length > 0 ? "true" : "false") + "}";
+
+            {
+                std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+                retainObjCObject(urlSchemeTask);
+                g_pendingWKProtocolTasks[requestId] = urlSchemeTask;
+                g_pendingWKTaskIds[(__bridge void *)urlSchemeTask] = requestId;
+                if (requestBody.length > 0) {
+                    const uint8_t *bytes = static_cast<const uint8_t *>(requestBody.bytes);
+                    g_protocolRequestBodies[requestId] = std::vector<uint8_t>(bytes, bytes + requestBody.length);
+                }
+            }
+
+            auto handler = g_protocolRequestHandler.load();
+            if (handler) {
+                char *requestJsonCopy = strdup(requestJson.c_str());
+                handler(requestId, self.webviewId, requestJsonCopy);
+            } else {
+                NSError *error = [NSError errorWithDomain:@"ElectrobunProtocol"
+                                                     code:500
+                                                 userInfo:@{NSLocalizedDescriptionKey: @"No protocol handler configured"}];
+                id<WKURLSchemeTask> taskToFail = nil;
+                {
+                    std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+                    auto taskIt = g_pendingWKProtocolTasks.find(requestId);
+                    if (taskIt != g_pendingWKProtocolTasks.end()) {
+                        taskToFail = taskIt->second;
+                        g_pendingWKTaskIds.erase((__bridge void *)taskIt->second);
+                        g_pendingWKProtocolTasks.erase(taskIt);
+                    }
+                    g_protocolRequestBodies.erase(requestId);
+                }
+                id<WKURLSchemeTask> activeTask = taskToFail ? taskToFail : urlSchemeTask;
+                [activeTask didFailWithError:error];
+                if (taskToFail) {
+                    releaseObjCObject(taskToFail);
+                }
+            }
+            return;
         } else {
             NSLog(@"Unknown URL format: %@", urlString);
         }
@@ -1988,6 +2147,18 @@ static void schedulePendingResizeDrain() {
        
     }
     - (void)webView:(WKWebView *)webView stopURLSchemeTask:(id<WKURLSchemeTask>)urlSchemeTask {
+        std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+        auto requestIt = g_pendingWKTaskIds.find((__bridge void *)urlSchemeTask);
+        if (requestIt == g_pendingWKTaskIds.end()) {
+            return;
+        }
+
+        uint64_t requestId = requestIt->second;
+        auto cancelledHandler = g_protocolRequestCancelledHandler.load();
+        if (cancelledHandler) {
+            cancelledHandler(requestId);
+        }
+        cleanupPendingProtocolTask(requestId);
     }
 @end
 
@@ -2450,6 +2621,14 @@ runOpenPanelWithParameters:(WKOpenPanelParameters *)parameters
                 assetSchemeHandler.webviewId = webviewId;
                 assetSchemeHandler.viewsRoot = viewsRootString;
                 [configuration setURLSchemeHandler:assetSchemeHandler forURLScheme:@"views"];
+
+                for (const auto& protocolRegistration : getProtocolRegistrations()) {
+                    MyURLSchemeHandler *protocolHandler = [[MyURLSchemeHandler alloc] init];
+                    protocolHandler.webviewId = webviewId;
+                    protocolHandler.viewsRoot = viewsRootString;
+                    NSString *schemeName = [NSString stringWithUTF8String:protocolRegistration.scheme.c_str()];
+                    [configuration setURLSchemeHandler:protocolHandler forURLScheme:schemeName];
+                }
                 
                 // create WKWebView
                 self.webView = [[WKWebView alloc] initWithFrame:frame configuration:configuration];
@@ -4120,6 +4299,13 @@ public:
     }
     void OnBeforeCommandLineProcessing(const CefString& process_type, CefRefPtr<CefCommandLine> command_line) override {
         command_line->AppendSwitchWithValue("custom-scheme", "views");
+        forEachProtocolRegistration([&](const ProtocolRegistration& registration) {
+            command_line->AppendSwitchWithValue("custom-scheme", registration.scheme);
+        });
+        std::string protocolConfigJson = getProtocolConfigJson();
+        if (!protocolConfigJson.empty()) {
+            command_line->AppendSwitchWithValue("electrobun-custom-protocols", protocolConfigJson);
+        }
 
         // macOS default flags — can be overridden via chromiumFlags in config
         static const std::vector<electrobun::DefaultFlag> defaults = {
@@ -4141,7 +4327,16 @@ public:
             CEF_SCHEME_OPTION_SECURE | // treat it like https
             CEF_SCHEME_OPTION_CSP_BYPASSING | // allow things like crypto.subtle
             CEF_SCHEME_OPTION_FETCH_ENABLED);
-            
+
+        forEachProtocolRegistration([&](const ProtocolRegistration& registration) {
+            int options = 0;
+            if (registration.privileges.standard) options |= CEF_SCHEME_OPTION_STANDARD;
+            if (registration.privileges.secure) options |= CEF_SCHEME_OPTION_SECURE;
+            if (registration.privileges.corsEnabled) options |= CEF_SCHEME_OPTION_CORS_ENABLED;
+            if (registration.privileges.bypassCSP) options |= CEF_SCHEME_OPTION_CSP_BYPASSING;
+            if (registration.privileges.supportFetchAPI) options |= CEF_SCHEME_OPTION_FETCH_ENABLED;
+            registrar->AddCustomScheme(registration.scheme, options);
+        });
     }
     
     CefRefPtr<CefBrowserProcessHandler> GetBrowserProcessHandler() override {
@@ -4153,6 +4348,11 @@ public:
     virtual void OnBeforeChildProcessLaunch(CefRefPtr<CefCommandLine> command_line) override {        
         std::vector<CefString> args;
         command_line->GetArguments(args); 
+
+        std::string protocolConfigJson = getProtocolConfigJson();
+        if (!protocolConfigJson.empty()) {
+            command_line->AppendSwitchWithValue("electrobun-custom-protocols", protocolConfigJson);
+        }
 
         // Log the CEF process_helper path
         // NSLog(@"CEF helper process path: %s", command_line->GetProgram().ToString().c_str());
@@ -4903,7 +5103,21 @@ public:
         CefRefPtr<CefRequest> request,
         CefRefPtr<CefResponse> response) override {
         
-        // Only filter main frame HTML responses
+        // Only filter main frame HTML responses from views:// — not from custom user protocols.
+        // User-defined custom protocol responses are served via ElectrobunSchemeHandler with
+        // requestId_ > 0 and should not have preload scripts injected unless explicitly requested.
+        std::string requestUrl = request->GetURL().ToString();
+        size_t schemeSep = requestUrl.find("://");
+        if (schemeSep != std::string::npos) {
+            std::string scheme = requestUrl.substr(0, schemeSep);
+            std::transform(scheme.begin(), scheme.end(), scheme.begin(), [](unsigned char c) {
+                return static_cast<char>(std::tolower(c));
+            });
+            if (scheme != "views" && hasProtocolRegistration(scheme)) {
+                return nullptr;
+            }
+        }
+
         if (frame->IsMain() && 
             response->GetMimeType().ToString().find("html") != std::string::npos) {
             NSLog(@"Creating response filter for HTML content");
@@ -5504,6 +5718,7 @@ bool initializeCEF() {
     if (buildJsonPath) {
         std::string buildJsonContent = electrobun::readFileToString([buildJsonPath UTF8String]);
         g_userChromiumFlags = electrobun::parseChromiumFlags(buildJsonContent);
+        electrobun::loadProtocolConfigFromBuildJson(buildJsonContent);
     }
 
     CefSettings settings;
@@ -5600,87 +5815,155 @@ bool initializeCEF() {
 // The main scheme handler class
 class ElectrobunSchemeHandler : public CefResourceHandler {
 public:
-     ElectrobunSchemeHandler(uint32_t webviewId)
-    : webviewId_(webviewId), hasResponse_(false), offset_(0) {}
+      ElectrobunSchemeHandler(uint32_t webviewId)
+    : webviewId_(webviewId), hasResponse_(false), offset_(0), requestId_(0), statusCode_(200), headerReady_(false), finished_(false), failed_(false) {}
+
+    void OnProtocolResponseStart(int statusCode, const std::string& statusText, const std::string& headersJson);
+    void OnProtocolResponseChunk(const uint8_t* chunk, size_t size);
+    void OnProtocolResponseFinish();
+    void OnProtocolResponseError(const std::string& message);
 
   bool Open(CefRefPtr<CefRequest> request,
             bool& handle_request,
             CefRefPtr<CefCallback> callback) override {
 
         std::string urlStr = request->GetURL().ToString();
+        std::string scheme;
+        size_t schemeSeparator = urlStr.find("://");
+        if (schemeSeparator != std::string::npos) {
+            scheme = urlStr.substr(0, schemeSeparator);
+            std::transform(scheme.begin(), scheme.end(), scheme.begin(), [](unsigned char c) {
+                return static_cast<char>(std::tolower(c));
+            });
+        }
         
-        // CEF calls Open from a worker thread, so we need to handle this on the main thread
-        // to avoid threading issues with Bun's JS runtime
-        __block std::string responseDataBlock;
-        __block std::string mimeTypeBlock;
-        __block bool hasResponseBlock = false;
-        
-        dispatch_sync(dispatch_get_main_queue(), ^{
-            responseData_.clear();
-            hasResponse_ = false;
-            offset_ = 0;
-            
-            // If the URL starts with "views://"
-            if (urlStr.find("views://") == 0) {
-                NSLog(@"DEBUG CEF: Processing views:// URL: %s", urlStr.c_str());
-                // Remove the prefix (8 characters for "views://") - FIXED VERSION v2
-                std::string relativePath = urlStr.substr(8);
-                NSLog(@"DEBUG CEF FIXED: relativePath = '%s'", relativePath.c_str());
-                
-                // Check if this is the internal HTML request.
-                NSLog(@"DEBUG CEF: Comparing relativePath '%s' with 'internal/index.html'", relativePath.c_str());
-                if (relativePath == "internal/index.html") {
-                    NSLog(@"DEBUG CEF: Handling views://internal/index.html for webview %u", webviewId_);
-                    // Use stored HTML content instead of JSCallback
-                    const char* htmlContent = getWebviewHTMLContent(webviewId_);
-                    if (!htmlContent) {
-                        // Fallback to default if no content set
-                        NSLog(@"DEBUG CEF: No HTML content found for webview %u, using fallback", webviewId_);
-                        htmlContent = strdup("<html><body>No content set</body></html>");
-                    } else {
-                        NSLog(@"DEBUG CEF: Retrieved HTML content for webview %u", webviewId_);
-                    }
-                    
-                    if (htmlContent) {
-                        size_t len = strlen(htmlContent);
-                        NSLog(@"DEBUG CEF: HTML content length: %zu, content preview: %.100s", len, htmlContent);
-                        mimeTypeBlock = "text/html";
-                        responseDataBlock.assign(htmlContent, htmlContent + len);
-                        hasResponseBlock = true;
-                        free((void*)htmlContent); // Free the strdup'd memory
-                    } else {
-                        NSLog(@"DEBUG CEF: No HTML content to load");
-                    }
-                } else {
-                    NSLog(@"DEBUG CEF: Attempting to read views file: %s", urlStr.c_str());
-                    NSData *data = readViewsFile(urlStr.c_str());
-                    if (data) {   
-                        NSLog(@"DEBUG CEF: Successfully read views file, length: %lu", (unsigned long)data.length);
-                        // Determine MIME type using shared function
-                        std::string mimeType = getMimeTypeFromUrl(relativePath);
-                        const char* mimeTypePtr = strdup(mimeType.c_str());
-                        NSLog(@"DEBUG CEF: Set MIME type '%s' for file: %s", mimeType.c_str(), relativePath.c_str());
-                        // REMOVED: jsUtils.getMimeType callback (now using file extension detection)
-                        
-                        if (mimeTypePtr) {
-                            mimeTypeBlock = std::string(mimeTypePtr);
-                            free((void*)mimeTypePtr); // Free the strdup'd memory
-                        } else {
-                            mimeTypeBlock = "text/html"; // Fallback
-                        }
+        // Open runs on CEF worker threads. The views:// file helpers and
+        // protocol FFI callback are already safe to invoke directly here, so
+        // avoid dispatch_sync on the main queue and blocking the IO path.
+        std::string responseDataBlock;
+        std::string mimeTypeBlock;
+        bool hasResponseBlock = false;
 
-                        responseDataBlock.assign((const char*)data.bytes,
-                                            (const char*)data.bytes + data.length);
-                        hasResponseBlock = true;
+        responseData_.clear();
+        hasResponse_ = false;
+        offset_ = 0;
+
+        // If the URL starts with "views://"
+        if (urlStr.find("views://") == 0) {
+            NSLog(@"DEBUG CEF: Processing views:// URL: %s", urlStr.c_str());
+            // Remove the prefix (8 characters for "views://") - FIXED VERSION v2
+            std::string relativePath = urlStr.substr(8);
+            NSLog(@"DEBUG CEF FIXED: relativePath = '%s'", relativePath.c_str());
+
+            // Check if this is the internal HTML request.
+            NSLog(@"DEBUG CEF: Comparing relativePath '%s' with 'internal/index.html'", relativePath.c_str());
+            if (relativePath == "internal/index.html") {
+                NSLog(@"DEBUG CEF: Handling views://internal/index.html for webview %u", webviewId_);
+                // Use stored HTML content instead of JSCallback
+                const char* htmlContent = getWebviewHTMLContent(webviewId_);
+                if (!htmlContent) {
+                    // Fallback to default if no content set
+                    NSLog(@"DEBUG CEF: No HTML content found for webview %u, using fallback", webviewId_);
+                    htmlContent = strdup("<html><body>No content set</body></html>");
+                } else {
+                    NSLog(@"DEBUG CEF: Retrieved HTML content for webview %u", webviewId_);
+                }
+
+                if (htmlContent) {
+                    size_t len = strlen(htmlContent);
+                    NSLog(@"DEBUG CEF: HTML content length: %zu, content preview: %.100s", len, htmlContent);
+                    mimeTypeBlock = "text/html";
+                    responseDataBlock.assign(htmlContent, htmlContent + len);
+                    hasResponseBlock = true;
+                    free((void*)htmlContent); // Free the strdup'd memory
+                } else {
+                    NSLog(@"DEBUG CEF: No HTML content to load");
+                }
+            } else {
+                NSLog(@"DEBUG CEF: Attempting to read views file: %s", urlStr.c_str());
+                NSData *data = readViewsFile(urlStr.c_str());
+                if (data) {
+                    NSLog(@"DEBUG CEF: Successfully read views file, length: %lu", (unsigned long)data.length);
+                    // Determine MIME type using shared function
+                    std::string mimeType = getMimeTypeFromUrl(relativePath);
+                    const char* mimeTypePtr = strdup(mimeType.c_str());
+                    NSLog(@"DEBUG CEF: Set MIME type '%s' for file: %s", mimeType.c_str(), relativePath.c_str());
+                    // REMOVED: jsUtils.getMimeType callback (now using file extension detection)
+
+                    if (mimeTypePtr) {
+                        mimeTypeBlock = std::string(mimeTypePtr);
+                        free((void*)mimeTypePtr); // Free the strdup'd memory
                     } else {
-                        NSLog(@"DEBUG CEF: Failed to read views file: %s", urlStr.c_str());
+                        mimeTypeBlock = "text/html"; // Fallback
                     }
+
+                    responseDataBlock.assign((const char*)data.bytes,
+                                        (const char*)data.bytes + data.length);
+                    hasResponseBlock = true;
+                } else {
+                    NSLog(@"DEBUG CEF: Failed to read views file: %s", urlStr.c_str());
                 }
             }
-            else {
-                NSLog(@"Unknown URL format: %s", urlStr.c_str());
+        }
+        else if (hasProtocolRegistration(scheme)) {
+            requestId_ = g_nextProtocolRequestId.fetch_add(1);
+            hasResponse_ = true;
+            offset_ = 0;
+
+            std::string method = request->GetMethod().ToString();
+            CefRequest::HeaderMap headerMap;
+            request->GetHeaderMap(headerMap);
+            std::string headersJson = "[";
+            bool firstHeader = true;
+            for (const auto& header : headerMap) {
+                if (!firstHeader) headersJson += ",";
+                firstHeader = false;
+                headersJson += "[\"" + escapeProtocolJSONString(header.first.ToString()) + "\",\"" + escapeProtocolJSONString(header.second.ToString()) + "\"]";
             }
-        });
+            headersJson += "]";
+
+            bool hasBody = false;
+            CefRefPtr<CefPostData> postData = request->GetPostData();
+            if (postData && postData->GetElementCount() > 0) {
+                CefPostData::ElementVector elements;
+                postData->GetElements(elements);
+                std::vector<uint8_t> body;
+                for (auto& element : elements) {
+                    if (element->GetType() == PDE_TYPE_BYTES) {
+                        size_t size = element->GetBytesCount();
+                        if (size > 0) {
+                            size_t start = body.size();
+                            body.resize(start + size);
+                            element->GetBytes(size, body.data() + start);
+                        }
+                    }
+                }
+                if (!body.empty()) {
+                    std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+                    g_protocolRequestBodies[requestId_] = std::move(body);
+                    hasBody = true;
+                }
+            }
+
+            std::string requestJson = std::string("{\"url\":\"") + escapeProtocolJSONString([NSString stringWithUTF8String:urlStr.c_str()]) +
+                "\",\"method\":\"" + escapeProtocolJSONString([NSString stringWithUTF8String:method.c_str()]) +
+                "\",\"headers\":" + headersJson +
+                ",\"hasBody\":" + (hasBody ? "true" : "false") + "}";
+
+            {
+                std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+                g_pendingCEFProtocolHandlers[requestId_] = this;
+            }
+
+            auto handler = g_protocolRequestHandler.load();
+            if (handler) {
+                char *requestJsonCopy = strdup(requestJson.c_str());
+                handler(requestId_, webviewId_, requestJsonCopy);
+                hasResponseBlock = true;
+            }
+        } else {
+            NSLog(@"Unknown URL format: %s", urlStr.c_str());
+        }
         
         // Copy the results back to the member variables
         mimeType_ = mimeTypeBlock;
@@ -5694,6 +5977,26 @@ public:
     void GetResponseHeaders(CefRefPtr<CefResponse> response,
                           int64_t& response_length,
                           CefString& redirectUrl) override {
+        if (requestId_ != 0) {
+            std::unique_lock<std::mutex> lock(mutex_);
+            condition_.wait(lock, [&] { return headerReady_ || failed_; });
+            if (failed_) {
+                response->SetStatus(500);
+                response_length = 0;
+                return;
+            }
+
+            response->SetStatus(statusCode_);
+            response->SetStatusText(statusText_);
+            response->SetHeaderMap(headerMap_);
+            auto contentType = responseHeaders_.find("content-type");
+            if (contentType != responseHeaders_.end()) {
+                response->SetMimeType(contentType->second);
+            }
+            response_length = -1;
+            return;
+        }
+
         if (!hasResponse_) {
         response->SetStatus(404);
         response_length = 0;
@@ -5714,6 +6017,32 @@ public:
                 int& bytes_read,
                 CefRefPtr<CefResourceReadCallback> callback) override {
         bytes_read = 0;
+        if (requestId_ != 0) {
+            std::unique_lock<std::mutex> lock(mutex_);
+            condition_.wait(lock, [&] {
+                return failed_ || !chunks_.empty() || finished_;
+            });
+
+            if (failed_) {
+                return false;
+            }
+
+            if (chunks_.empty()) {
+                return false;
+            }
+
+            std::vector<uint8_t>& chunk = chunks_.front();
+            size_t remaining = chunk.size() - chunkOffset_;
+            bytes_read = std::min(bytes_to_read, static_cast<int>(remaining));
+            memcpy(data_out, chunk.data() + chunkOffset_, bytes_read);
+            chunkOffset_ += bytes_read;
+            if (chunkOffset_ >= chunk.size()) {
+                chunks_.pop_front();
+                chunkOffset_ = 0;
+            }
+            return true;
+        }
+
         if (!hasResponse_ || offset_ >= responseData_.size()) {
         return false;
         }
@@ -5725,7 +6054,22 @@ public:
     }
 
     void Cancel() override {
-        // Optionally log cancellation.
+        if (requestId_ != 0) {
+            auto cancelledHandler = g_protocolRequestCancelledHandler.load();
+            if (cancelledHandler) {
+                cancelledHandler(requestId_);
+            }
+            {
+                std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+                g_pendingCEFProtocolHandlers.erase(requestId_);
+                g_protocolRequestBodies.erase(requestId_);
+            }
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                failed_ = true;
+            }
+            condition_.notify_all();
+        }
     }
 
     private:
@@ -5734,10 +6078,66 @@ public:
     std::vector<char> responseData_;
     bool hasResponse_;
     size_t offset_;
+    uint64_t requestId_;
+    int statusCode_;
+    std::string statusText_;
+    bool headerReady_;
+    bool finished_;
+    bool failed_;
+    std::string errorMessage_;
+    std::map<std::string, std::string> responseHeaders_;
+    CefResponse::HeaderMap headerMap_;
+    std::mutex mutex_;
+    std::condition_variable condition_;
+    std::deque<std::vector<uint8_t>> chunks_;
+    size_t chunkOffset_ = 0;
 
     IMPLEMENT_REFCOUNTING(ElectrobunSchemeHandler);
     DISALLOW_COPY_AND_ASSIGN(ElectrobunSchemeHandler);
 };
+
+void ElectrobunSchemeHandler::OnProtocolResponseStart(int statusCode,
+                                                      const std::string& statusText,
+                                                      const std::string& headersJson) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    statusCode_ = statusCode;
+    statusText_ = statusText;
+    headerReady_ = true;
+
+    NSData *jsonData = [NSData dataWithBytes:headersJson.data() length:headersJson.size()];
+    NSArray *pairs = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:nil];
+    if ([pairs isKindOfClass:[NSArray class]]) {
+        for (NSArray *pair in pairs) {
+            if ([pair isKindOfClass:[NSArray class]] && pair.count == 2) {
+                std::string key = [[pair[0] description] UTF8String];
+                std::string value = [[pair[1] description] UTF8String];
+                responseHeaders_[key] = value;
+                headerMap_.insert(std::make_pair(key, value));
+            }
+        }
+    }
+
+    condition_.notify_all();
+}
+
+void ElectrobunSchemeHandler::OnProtocolResponseChunk(const uint8_t* chunk, size_t size) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    chunks_.emplace_back(chunk, chunk + size);
+    condition_.notify_all();
+}
+
+void ElectrobunSchemeHandler::OnProtocolResponseFinish() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    finished_ = true;
+    condition_.notify_all();
+}
+
+void ElectrobunSchemeHandler::OnProtocolResponseError(const std::string& message) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    failed_ = true;
+    errorMessage_ = message;
+    condition_.notify_all();
+}
 
 
 // Global map to track browser to webview ID mapping
@@ -5827,6 +6227,10 @@ CefRefPtr<CefRequestContext> CreateRequestContextForPartition(const char* partit
   bool registered = context->RegisterSchemeHandlerFactory("views", "", schemeFactory);
   NSLog(@"DEBUG CEF: Registered scheme handler factory for partition '%s' - success: %s",
         partitionIdentifier ? partitionIdentifier : "(default)", registered ? "yes" : "no");
+
+  forEachProtocolRegistration([&](const ProtocolRegistration& registration) {
+    context->RegisterSchemeHandlerFactory(registration.scheme, "", schemeFactory);
+  });
 
   return context;
 }
@@ -8027,6 +8431,190 @@ extern "C" void setJSUtils(GetMimeType getMimeType, GetHTMLForWebviewSync getHTM
     dispatch_queue_attr_t attr = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_DEFAULT, 0);
     jsWorkerQueue = dispatch_queue_create("com.electrobun.jsworker", attr);    
 
+}
+
+extern "C" void setCustomProtocolConfig(const char* protocolConfigJson) {
+    std::string json = protocolConfigJson ? protocolConfigJson : "[]";
+    setProtocolConfigJson(json);
+}
+
+extern "C" void setCustomProtocolHandlers(ProtocolRequestHandler requestHandler,
+                                            ProtocolRequestCancelledHandler cancelHandler) {
+    g_protocolRequestHandler.store(requestHandler);
+    g_protocolRequestCancelledHandler.store(cancelHandler);
+}
+
+extern "C" const uint8_t* protocolGetRequestBody(uint64_t requestId, uint64_t* outSize) {
+    std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+    auto it = g_protocolRequestBodies.find(requestId);
+    if (it == g_protocolRequestBodies.end()) {
+        if (outSize) *outSize = 0;
+        return nullptr;
+    }
+
+    const auto& body = it->second;
+    if (outSize) {
+        *outSize = body.size();
+    }
+
+    if (body.empty()) {
+        g_protocolRequestBodies.erase(it);
+        return nullptr;
+    }
+
+    uint8_t* result = static_cast<uint8_t*>(malloc(body.size()));
+    if (!result) {
+        if (outSize) *outSize = 0;
+        g_protocolRequestBodies.erase(it);
+        return nullptr;
+    }
+    memcpy(result, body.data(), body.size());
+    g_protocolRequestBodies.erase(it);
+    return result;
+}
+
+extern "C" void freeProtocolBuffer(const uint8_t* buffer) {
+    if (buffer) {
+        free((void*)buffer);
+    }
+}
+
+static NSDictionary<NSString*, NSString*> *protocolHeadersFromJSONString(const char* headersJson) {
+    if (!headersJson || headersJson[0] == '\0') {
+        return @{};
+    }
+
+    NSData *jsonData = [NSData dataWithBytes:headersJson length:strlen(headersJson)];
+    NSArray *pairs = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:nil];
+    if (![pairs isKindOfClass:[NSArray class]]) {
+        return @{};
+    }
+
+    NSMutableDictionary<NSString*, NSString*> *headers = [NSMutableDictionary dictionary];
+    for (NSArray *pair in pairs) {
+        if ([pair isKindOfClass:[NSArray class]] && pair.count == 2) {
+            NSString *key = [pair[0] description];
+            NSString *value = [pair[1] description];
+            headers[key] = value;
+        }
+    }
+
+    return headers;
+}
+
+extern "C" void protocolStartResponse(uint64_t requestId,
+                                        int statusCode,
+                                        const char* statusText,
+                                        const char* headersJson) {
+    {
+        std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+        auto cefIt = g_pendingCEFProtocolHandlers.find(requestId);
+        if (cefIt != g_pendingCEFProtocolHandlers.end()) {
+            cefIt->second->OnProtocolResponseStart(statusCode, statusText ? statusText : "OK", headersJson ? headersJson : "[]");
+            return;
+        }
+    }
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+        auto it = g_pendingWKProtocolTasks.find(requestId);
+        if (it == g_pendingWKProtocolTasks.end()) {
+            return;
+        }
+
+        id<WKURLSchemeTask> task = it->second;
+        NSDictionary<NSString*, NSString*> *headers = protocolHeadersFromJSONString(headersJson);
+        NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:task.request.URL
+                                                                  statusCode:statusCode
+                                                                 HTTPVersion:@"HTTP/1.1"
+                                                                headerFields:headers];
+        if (!response) {
+            NSError *error = [NSError errorWithDomain:@"ElectrobunProtocol"
+                                                 code:500
+                                             userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithUTF8String:statusText ?: "Protocol response failed"]}];
+            [task didFailWithError:error];
+            cleanupPendingProtocolTask(requestId);
+            return;
+        }
+        [task didReceiveResponse:response];
+    });
+}
+
+extern "C" void protocolWriteResponseChunk(uint64_t requestId, const uint8_t* chunk, uint64_t size) {
+    if (!chunk || size == 0) {
+        return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+        auto cefIt = g_pendingCEFProtocolHandlers.find(requestId);
+        if (cefIt != g_pendingCEFProtocolHandlers.end()) {
+            cefIt->second->OnProtocolResponseChunk(chunk, (size_t)size);
+            return;
+        }
+    }
+
+    NSData *data = [NSData dataWithBytes:chunk length:(NSUInteger)size];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+        auto it = g_pendingWKProtocolTasks.find(requestId);
+        if (it == g_pendingWKProtocolTasks.end()) {
+            return;
+        }
+        [it->second didReceiveData:data];
+    });
+}
+
+extern "C" void protocolFinishResponse(uint64_t requestId) {
+    {
+        std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+        auto cefIt = g_pendingCEFProtocolHandlers.find(requestId);
+        if (cefIt != g_pendingCEFProtocolHandlers.end()) {
+            cefIt->second->OnProtocolResponseFinish();
+            g_pendingCEFProtocolHandlers.erase(cefIt);
+            g_protocolRequestBodies.erase(requestId);
+            return;
+        }
+    }
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+        auto it = g_pendingWKProtocolTasks.find(requestId);
+        if (it == g_pendingWKProtocolTasks.end()) {
+            return;
+        }
+
+        [it->second didFinish];
+        cleanupPendingProtocolTask(requestId);
+    });
+}
+
+extern "C" void protocolErrorResponse(uint64_t requestId, const char* message) {
+    {
+        std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+        auto cefIt = g_pendingCEFProtocolHandlers.find(requestId);
+        if (cefIt != g_pendingCEFProtocolHandlers.end()) {
+            cefIt->second->OnProtocolResponseError(message ? message : "Protocol request failed");
+            g_pendingCEFProtocolHandlers.erase(cefIt);
+            g_protocolRequestBodies.erase(requestId);
+            return;
+        }
+    }
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+        auto it = g_pendingWKProtocolTasks.find(requestId);
+        if (it == g_pendingWKProtocolTasks.end()) {
+            return;
+        }
+
+        NSString *messageText = [NSString stringWithUTF8String:message ?: "Protocol request failed"];
+        NSError *error = [NSError errorWithDomain:@"ElectrobunProtocol"
+                                             code:500
+                                         userInfo:@{NSLocalizedDescriptionKey: messageText}];
+        [it->second didFailWithError:error];
+        cleanupPendingProtocolTask(requestId);
+    });
 }
 
 // MARK: - Webview HTML Content Management (replaces JSCallback approach)

--- a/package/src/native/shared/callbacks.h
+++ b/package/src/native/shared/callbacks.h
@@ -48,6 +48,8 @@ typedef void (*QuitRequestedHandler)();
 // JS Utils callbacks (DEPRECATED: Now using map-based approach instead)
 typedef const char* (*GetMimeType)(const char* filePath);
 typedef const char* (*GetHTMLForWebviewSync)(uint32_t webviewId);
+typedef void (*ProtocolRequestHandler)(uint64_t requestId, uint32_t webviewId, const char* requestJSON);
+typedef void (*ProtocolRequestCancelledHandler)(uint64_t requestId);
 
 } // namespace electrobun
 

--- a/package/src/native/shared/protocol_config.h
+++ b/package/src/native/shared/protocol_config.h
@@ -1,0 +1,198 @@
+#ifndef ELECTROBUN_PROTOCOL_CONFIG_H
+#define ELECTROBUN_PROTOCOL_CONFIG_H
+
+#include <algorithm>
+#include <cctype>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace electrobun {
+
+struct ProtocolPrivileges {
+	bool standard = false;
+	bool secure = false;
+	bool bypassCSP = false;
+	bool allowServiceWorkers = false;
+	bool supportFetchAPI = false;
+	bool corsEnabled = false;
+	bool stream = false;
+	bool codeCache = false;
+};
+
+struct ProtocolRegistration {
+	std::string scheme;
+	ProtocolPrivileges privileges;
+};
+
+inline std::mutex& protocolConfigMutex() {
+	static std::mutex mutex;
+	return mutex;
+}
+
+inline std::vector<ProtocolRegistration>& protocolConfigStore() {
+	static std::vector<ProtocolRegistration> store;
+	return store;
+}
+
+// Stored alongside the parsed vector so it can be forwarded to CEF renderer
+// child processes verbatim via the --electrobun-custom-protocols command-line switch.
+inline std::string& protocolConfigRawJSON() {
+	static std::string raw;
+	return raw;
+}
+
+inline std::string normalizeProtocolScheme(const std::string& scheme) {
+	std::string normalized = scheme;
+	std::transform(normalized.begin(), normalized.end(), normalized.begin(), [](unsigned char ch) {
+		return static_cast<char>(std::tolower(ch));
+	});
+	return normalized;
+}
+
+inline bool readProtocolBoolean(const std::string& object, const std::string& key, bool fallback) {
+	std::string pattern = std::string("\"") + key + "\":";
+	size_t pos = object.find(pattern);
+	if (pos == std::string::npos) {
+		return fallback;
+	}
+	pos += pattern.size();
+	while (pos < object.size() && std::isspace(static_cast<unsigned char>(object[pos]))) {
+		pos++;
+	}
+	if (object.compare(pos, 4, "true") == 0) {
+		return true;
+	}
+	if (object.compare(pos, 5, "false") == 0) {
+		return false;
+	}
+	return fallback;
+}
+
+// Simple JSON scanner for well-formed output from JSON.stringify. Assumes no escaped
+// quotes in scheme names or privilege keys. For internal use only - input is trusted
+// output from the Bun side.
+inline std::vector<ProtocolRegistration> parseProtocolConfigJson(const std::string& json) {
+	std::vector<ProtocolRegistration> protocols;
+	size_t pos = 0;
+
+	while ((pos = json.find("\"scheme\"", pos)) != std::string::npos) {
+		size_t schemeStart = json.find('"', pos + 8);
+		if (schemeStart == std::string::npos) {
+			break;
+		}
+		schemeStart++;
+		size_t schemeEnd = json.find('"', schemeStart);
+		if (schemeEnd == std::string::npos) {
+			break;
+		}
+
+		std::string scheme = normalizeProtocolScheme(json.substr(schemeStart, schemeEnd - schemeStart));
+		size_t objectStart = json.rfind('{', pos);
+		size_t objectEnd = json.find('}', schemeEnd);
+		std::string object = objectStart != std::string::npos && objectEnd != std::string::npos
+			? json.substr(objectStart, objectEnd - objectStart + 1)
+			: json.substr(pos);
+
+		ProtocolRegistration registration;
+		registration.scheme = scheme;
+		registration.privileges.standard = readProtocolBoolean(object, "standard", true);
+		registration.privileges.secure = readProtocolBoolean(object, "secure", true);
+		registration.privileges.bypassCSP = readProtocolBoolean(object, "bypassCSP", false);
+		registration.privileges.allowServiceWorkers = readProtocolBoolean(object, "allowServiceWorkers", false);
+		registration.privileges.supportFetchAPI = readProtocolBoolean(object, "supportFetchAPI", true);
+		registration.privileges.corsEnabled = readProtocolBoolean(object, "corsEnabled", true);
+		registration.privileges.stream = readProtocolBoolean(object, "stream", true);
+		registration.privileges.codeCache = readProtocolBoolean(object, "codeCache", false);
+
+		if (!registration.scheme.empty() && registration.scheme != "views") {
+			protocols.push_back(registration);
+		}
+
+		pos = schemeEnd + 1;
+	}
+
+	return protocols;
+}
+
+inline std::string extractProtocolsJson(const std::string& buildJson) {
+	std::string key = "\"protocols\"";
+	size_t keyPos = buildJson.find(key);
+	if (keyPos == std::string::npos) {
+		return "[]";
+	}
+
+	size_t arrayStart = buildJson.find('[', keyPos + key.length());
+	if (arrayStart == std::string::npos) {
+		return "[]";
+	}
+
+	int depth = 1;
+	size_t arrayEnd = arrayStart + 1;
+	while (arrayEnd < buildJson.size() && depth > 0) {
+		if (buildJson[arrayEnd] == '[') depth++;
+		else if (buildJson[arrayEnd] == ']') depth--;
+		arrayEnd++;
+	}
+
+	if (depth != 0) {
+		return "[]";
+	}
+
+	return buildJson.substr(arrayStart, arrayEnd - arrayStart);
+}
+
+inline void setProtocolConfigJson(const std::string& json) {
+	std::lock_guard<std::mutex> lock(protocolConfigMutex());
+	protocolConfigRawJSON() = json;
+	protocolConfigStore() = parseProtocolConfigJson(json);
+}
+
+inline void loadProtocolConfigFromBuildJson(const std::string& buildJson) {
+	setProtocolConfigJson(extractProtocolsJson(buildJson));
+}
+
+inline std::string getProtocolConfigJson() {
+	std::lock_guard<std::mutex> lock(protocolConfigMutex());
+	return protocolConfigRawJSON();
+}
+
+inline std::vector<ProtocolRegistration> getProtocolRegistrations() {
+	std::lock_guard<std::mutex> lock(protocolConfigMutex());
+	return protocolConfigStore();
+}
+
+inline bool hasProtocolRegistration(const std::string& scheme) {
+	std::lock_guard<std::mutex> lock(protocolConfigMutex());
+	std::string normalized = normalizeProtocolScheme(scheme);
+	for (const auto& registration : protocolConfigStore()) {
+		if (registration.scheme == normalized) {
+			return true;
+		}
+	}
+	return false;
+}
+
+inline std::optional<ProtocolRegistration> findProtocolRegistration(const std::string& scheme) {
+	std::lock_guard<std::mutex> lock(protocolConfigMutex());
+	std::string normalized = normalizeProtocolScheme(scheme);
+	for (const auto& registration : protocolConfigStore()) {
+		if (registration.scheme == normalized) {
+			return registration;
+		}
+	}
+	return std::nullopt;
+}
+
+template <typename RegistrarFn>
+inline void forEachProtocolRegistration(RegistrarFn&& fn) {
+	std::lock_guard<std::mutex> lock(protocolConfigMutex());
+	for (const auto& registration : protocolConfigStore()) {
+		fn(registration);
+	}
+}
+
+}
+
+#endif

--- a/package/src/native/win/cef_process_helper_win.cpp
+++ b/package/src/native/win/cef_process_helper_win.cpp
@@ -1,5 +1,6 @@
 #include "include/cef_app.h"
 #include "include/cef_v8.h"
+#include "../shared/protocol_config.h"
 #include <map>
 #include <mutex>
 
@@ -7,12 +8,29 @@ class HelperApp : public CefApp, public CefRenderProcessHandler {
 public:
     // CefApp methods:
     virtual void OnRegisterCustomSchemes(CefRawPtr<CefSchemeRegistrar> registrar) override {
+        CefRefPtr<CefCommandLine> command_line = CefCommandLine::GetGlobalCommandLine();
+        if (command_line && command_line->HasSwitch("electrobun-custom-protocols")) {
+            electrobun::setProtocolConfigJson(command_line->GetSwitchValue("electrobun-custom-protocols").ToString());
+        }
         registrar->AddCustomScheme("views",
             CEF_SCHEME_OPTION_STANDARD |
             CEF_SCHEME_OPTION_CORS_ENABLED |
             CEF_SCHEME_OPTION_SECURE | // treat it like https
             CEF_SCHEME_OPTION_CSP_BYPASSING | // allow things like crypto.subtle
             CEF_SCHEME_OPTION_FETCH_ENABLED);
+
+        electrobun::forEachProtocolRegistration([&](const electrobun::ProtocolRegistration& registration) {
+            int options = 0;
+            if (registration.privileges.standard) options |= CEF_SCHEME_OPTION_STANDARD;
+            if (registration.privileges.secure) options |= CEF_SCHEME_OPTION_SECURE;
+            if (registration.privileges.corsEnabled) options |= CEF_SCHEME_OPTION_CORS_ENABLED;
+            if (registration.privileges.bypassCSP) options |= CEF_SCHEME_OPTION_CSP_BYPASSING;
+            if (registration.privileges.supportFetchAPI) options |= CEF_SCHEME_OPTION_FETCH_ENABLED;
+            if (registration.privileges.stream) options |= CEF_SCHEME_OPTION_STREAMING;
+            if (registration.privileges.codeCache) options |= CEF_SCHEME_OPTION_CODE_CACHE_ENABLED;
+            if (registration.privileges.allowServiceWorkers) options |= CEF_SCHEME_OPTION_SERVICE_WORKERS_ALLOWED;
+            registrar->AddCustomScheme(registration.scheme, options);
+        });
     }
 
     virtual CefRefPtr<CefRenderProcessHandler> GetRenderProcessHandler() override {

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -23,13 +23,16 @@
 #include <WebView2.h>
 #include <WebView2EnvironmentOptions.h>
 #include <map>
+#include <unordered_map>
 #include <algorithm>
 #include <stdint.h>
 #include <shellapi.h>
 #include <commctrl.h>
 #include <mutex>
 #include <atomic>
+#include <condition_variable>
 #include <cstdarg>
+#include <deque>
 #include <winrt/Windows.Data.Json.h>
 #include <winrt/base.h>
 #include <shobjidl.h>  // For IFileOpenDialog
@@ -60,6 +63,7 @@
 #include "../shared/app_paths.h"
 #include "../shared/accelerator_parser.h"
 #include "../shared/chromium_flags.h"
+#include "../shared/protocol_config.h"
 
 using namespace electrobun;
 
@@ -484,6 +488,26 @@ static const int OFFSCREEN_OFFSET = -20000;
 
 // Remote DevTools port
 static int g_remoteDebugPort = 9222;
+static ProtocolRequestHandler g_protocolRequestHandler = nullptr;
+static ProtocolRequestCancelledHandler g_protocolRequestCancelledHandler = nullptr;
+static std::atomic<uint64_t> g_nextProtocolRequestId{1};
+static std::mutex g_protocolRequestMutex;
+static std::unordered_map<uint64_t, std::vector<uint8_t>> g_protocolRequestBodies;
+static std::unordered_map<uint64_t, ComPtr<ICoreWebView2Deferral>> g_pendingWebView2Deferrals;
+static std::unordered_map<uint64_t, ComPtr<ICoreWebView2WebResourceRequestedEventArgs>> g_pendingWebView2Responses;
+static std::unordered_map<uint64_t, ComPtr<ICoreWebView2Environment>> g_pendingWebView2Environments;
+
+struct PendingWebView2ProtocolResponseState {
+    int statusCode = 200;
+    std::string statusText = "OK";
+    std::string headersJson = "[]";
+    std::vector<uint8_t> body;
+};
+
+static std::unordered_map<uint64_t, PendingWebView2ProtocolResponseState> g_pendingWebView2ResponseStates;
+
+class ElectrobunSchemeHandler;
+static std::unordered_map<uint64_t, ElectrobunSchemeHandler*> g_pendingCEFProtocolHandlers;
 
 static bool IsPortAvailable(int port) {
     WSADATA wsaData;
@@ -557,6 +581,15 @@ public:
     }
 
     void OnBeforeCommandLineProcessing(const CefString& process_type, CefRefPtr<CefCommandLine> command_line) override {
+        command_line->AppendSwitchWithValue("custom-scheme", "views");
+        forEachProtocolRegistration([&](const ProtocolRegistration& registration) {
+            command_line->AppendSwitchWithValue("custom-scheme", registration.scheme);
+        });
+        std::string protocolConfigJson = getProtocolConfigJson();
+        if (!protocolConfigJson.empty()) {
+            command_line->AppendSwitchWithValue("electrobun-custom-protocols", protocolConfigJson);
+        }
+
         // Windows default flags — can be overridden via chromiumFlags in config
         static const std::vector<electrobun::DefaultFlag> defaults = {
             {"disable-web-security", ""},
@@ -578,6 +611,23 @@ public:
             CEF_SCHEME_OPTION_SECURE |
             CEF_SCHEME_OPTION_CSP_BYPASSING |
             CEF_SCHEME_OPTION_FETCH_ENABLED);
+
+        forEachProtocolRegistration([&](const ProtocolRegistration& registration) {
+            int options = 0;
+            if (registration.privileges.standard) options |= CEF_SCHEME_OPTION_STANDARD;
+            if (registration.privileges.secure) options |= CEF_SCHEME_OPTION_SECURE;
+            if (registration.privileges.corsEnabled) options |= CEF_SCHEME_OPTION_CORS_ENABLED;
+            if (registration.privileges.bypassCSP) options |= CEF_SCHEME_OPTION_CSP_BYPASSING;
+            if (registration.privileges.supportFetchAPI) options |= CEF_SCHEME_OPTION_FETCH_ENABLED;
+            registrar->AddCustomScheme(registration.scheme, options);
+        });
+    }
+
+    void OnBeforeChildProcessLaunch(CefRefPtr<CefCommandLine> command_line) override {
+        std::string protocolConfigJson = getProtocolConfigJson();
+        if (!protocolConfigJson.empty()) {
+            command_line->AppendSwitchWithValue("electrobun-custom-protocols", protocolConfigJson);
+        }
     }
 
 private:
@@ -761,67 +811,435 @@ static void EnsureDevToolsWindowClassRegistered() {
 }
 
 // Forward declarations for functions defined later in the file
+std::wstring StringToWString(const std::string& str);
+std::string WStringToString(const std::wstring& wstr);
+void dispatchProtocolRequestSync(std::function<void()> callback);
 std::string loadViewsFile(const std::string& path);
 std::string getMimeTypeForFile(const std::string& path);
+
+static std::string escapeProtocolJSONString(const std::string& value) {
+    std::string output;
+    output.reserve(value.size() + 16);
+
+    for (char c : value) {
+        switch (c) {
+            case '"': output += "\\\""; break;
+            case '\\': output += "\\\\"; break;
+            case '\n': output += "\\n"; break;
+            case '\r': output += "\\r"; break;
+            case '\t': output += "\\t"; break;
+            default: output += c; break;
+        }
+    }
+
+    return output;
+}
+
+static std::string extractProtocolScheme(const std::string& url) {
+    size_t schemeSeparator = url.find(':');
+    if (schemeSeparator == std::string::npos) {
+        return "";
+    }
+    return normalizeProtocolScheme(url.substr(0, schemeSeparator));
+}
+
+static std::vector<std::pair<std::string, std::string>> parseProtocolHeaderPairs(const std::string& headersJson) {
+    std::vector<std::pair<std::string, std::string>> headers;
+    size_t pos = 0;
+
+    auto skipWhitespace = [&]() {
+        while (pos < headersJson.size() && std::isspace(static_cast<unsigned char>(headersJson[pos]))) {
+            pos++;
+        }
+    };
+
+    auto parseString = [&]() -> std::string {
+        if (pos >= headersJson.size() || headersJson[pos] != '"') {
+            return "";
+        }
+
+        pos++;
+        std::string result;
+        while (pos < headersJson.size()) {
+            char c = headersJson[pos++];
+            if (c == '\\' && pos < headersJson.size()) {
+                char escaped = headersJson[pos++];
+                switch (escaped) {
+                    case 'n': result += '\n'; break;
+                    case 'r': result += '\r'; break;
+                    case 't': result += '\t'; break;
+                    case '\\': result += '\\'; break;
+                    case '"': result += '"'; break;
+                    default: result += escaped; break;
+                }
+                continue;
+            }
+
+            if (c == '"') {
+                break;
+            }
+
+            result += c;
+        }
+
+        return result;
+    };
+
+    skipWhitespace();
+    if (pos >= headersJson.size() || headersJson[pos] != '[') {
+        return headers;
+    }
+
+    pos++;
+    while (pos < headersJson.size()) {
+        skipWhitespace();
+        if (pos < headersJson.size() && headersJson[pos] == ']') {
+            break;
+        }
+
+        if (pos >= headersJson.size() || headersJson[pos] != '[') {
+            break;
+        }
+
+        pos++;
+        skipWhitespace();
+        std::string key = parseString();
+        skipWhitespace();
+        if (pos < headersJson.size() && headersJson[pos] == ',') {
+            pos++;
+        }
+        skipWhitespace();
+        std::string value = parseString();
+        skipWhitespace();
+        if (pos < headersJson.size() && headersJson[pos] == ']') {
+            pos++;
+        }
+
+        headers.emplace_back(std::move(key), std::move(value));
+
+        skipWhitespace();
+        if (pos < headersJson.size() && headersJson[pos] == ',') {
+            pos++;
+        }
+    }
+
+    return headers;
+}
+
+static std::string buildProtocolHeadersJSON(const CefRequest::HeaderMap& headerMap) {
+    std::string json = "[";
+    bool firstHeader = true;
+    for (const auto& header : headerMap) {
+        if (!firstHeader) {
+            json += ",";
+        }
+        firstHeader = false;
+        json += "[\"" + escapeProtocolJSONString(header.first.ToString()) + "\",\"" +
+                escapeProtocolJSONString(header.second.ToString()) + "\"]";
+    }
+    json += "]";
+    return json;
+}
+
+static std::string buildProtocolHeadersJSON(ICoreWebView2HttpRequestHeaders* headers) {
+    if (!headers) {
+        return "[]";
+    }
+
+    std::string json = "[";
+    bool firstHeader = true;
+    ComPtr<ICoreWebView2HttpHeadersCollectionIterator> iterator;
+    if (FAILED(headers->GetIterator(&iterator)) || !iterator) {
+        return "[]";
+    }
+
+    BOOL hasCurrent = FALSE;
+    if (FAILED(iterator->get_HasCurrentHeader(&hasCurrent))) {
+        return "[]";
+    }
+
+    while (hasCurrent) {
+        LPWSTR name = nullptr;
+        LPWSTR value = nullptr;
+        if (SUCCEEDED(iterator->GetCurrentHeader(&name, &value)) && name && value) {
+            if (!firstHeader) {
+                json += ",";
+            }
+            firstHeader = false;
+            json += "[\"" + escapeProtocolJSONString(WStringToString(name)) + "\",\"" +
+                    escapeProtocolJSONString(WStringToString(value)) + "\"]";
+        }
+        if (name) {
+            CoTaskMemFree(name);
+        }
+        if (value) {
+            CoTaskMemFree(value);
+        }
+
+        BOOL hasNext = FALSE;
+        if (FAILED(iterator->MoveNext(&hasNext))) {
+            break;
+        }
+        hasCurrent = hasNext;
+    }
+
+    json += "]";
+    return json;
+}
+
+static std::vector<uint8_t> readProtocolRequestBody(CefRefPtr<CefPostData> postData) {
+    std::vector<uint8_t> body;
+    if (!postData || postData->GetElementCount() == 0) {
+        return body;
+    }
+
+    CefPostData::ElementVector elements;
+    postData->GetElements(elements);
+    for (auto& element : elements) {
+        if (element->GetType() != PDE_TYPE_BYTES) {
+            continue;
+        }
+
+        size_t size = element->GetBytesCount();
+        if (size == 0) {
+            continue;
+        }
+
+        size_t start = body.size();
+        body.resize(start + size);
+        element->GetBytes(size, body.data() + start);
+    }
+
+    return body;
+}
+
+static std::vector<uint8_t> readProtocolRequestBody(IStream* stream) {
+    std::vector<uint8_t> body;
+    if (!stream) {
+        return body;
+    }
+
+    LARGE_INTEGER zero = {};
+    stream->Seek(zero, STREAM_SEEK_SET, nullptr);
+
+    uint8_t buffer[4096];
+    ULONG bytesRead = 0;
+    while (SUCCEEDED(stream->Read(buffer, sizeof(buffer), &bytesRead)) && bytesRead > 0) {
+        body.insert(body.end(), buffer, buffer + bytesRead);
+    }
+
+    stream->Seek(zero, STREAM_SEEK_SET, nullptr);
+    return body;
+}
+
+static std::string buildProtocolRequestJson(const std::string& url,
+                                            const std::string& method,
+                                            const std::string& headersJson,
+                                            bool hasBody) {
+    return std::string("{\"url\":\"") + escapeProtocolJSONString(url) +
+           "\",\"method\":\"" + escapeProtocolJSONString(method) +
+           "\",\"headers\":" + headersJson +
+           ",\"hasBody\":" + (hasBody ? "true" : "false") + "}";
+}
 
 // CEF Resource Handler for views:// scheme (based on Mac implementation)
 class ElectrobunSchemeHandler : public CefResourceHandler {
 public:
     ElectrobunSchemeHandler(uint32_t webviewId)
-        : webviewId_(webviewId), offset_(0), hasResponse_(false) {}
+        : webviewId_(webviewId), hasResponse_(false), offset_(0), requestId_(0), statusCode_(200), headerReady_(false), finished_(false), failed_(false) {}
+
+    void OnProtocolResponseStart(int statusCode, const std::string& statusText, const std::string& headersJson);
+    void OnProtocolResponseChunk(const uint8_t* chunk, size_t size);
+    void OnProtocolResponseFinish();
+    void OnProtocolResponseError(const std::string& message);
 
     bool Open(CefRefPtr<CefRequest> request, bool& handle_request, CefRefPtr<CefCallback> callback) override {
         handle_request = true;
 
-        std::string url = request->GetURL();
-        std::string path = url.substr(8); // Remove "views://" prefix
-        if (path.empty()) path = "index.html";
+        std::string url = request->GetURL().ToString();
+        std::string scheme = extractProtocolScheme(url);
+        std::string responseDataBlock;
+        std::string mimeTypeBlock;
+        bool hasResponseBlock = false;
 
-        std::string content;
-        // Check for internal/index.html (inline HTML content)
-        if (path == "internal/index.html") {
-            const char* htmlContent = getWebviewHTMLContent(webviewId_);
-            if (htmlContent && strlen(htmlContent) > 0) {
-                content = std::string(htmlContent);
-                free((void*)htmlContent);
-            } else {
-                content = "<html><body><h1>No content set</h1></body></html>";
+        responseData_.clear();
+        hasResponse_ = false;
+        offset_ = 0;
+        requestId_ = 0;
+        statusCode_ = 200;
+        statusText_ = "OK";
+        headerReady_ = false;
+        finished_ = false;
+        failed_ = false;
+        errorMessage_.clear();
+        responseHeaders_.clear();
+        headerMap_.clear();
+        chunks_.clear();
+        chunkOffset_ = 0;
+
+        if (url.find("views://") == 0) {
+            std::string path = url.substr(8);
+            if (path.empty()) {
+                path = "index.html";
             }
-        } else {
-            content = loadViewsFile(path);
-        }
-        mimeType_ = getMimeTypeForFile(path);
 
-        if (!content.empty()) {
-            responseData_.assign(content.begin(), content.end());
+            std::string content;
+            if (path == "internal/index.html") {
+                const char* htmlContent = getWebviewHTMLContent(webviewId_);
+                if (htmlContent && strlen(htmlContent) > 0) {
+                    content = std::string(htmlContent);
+                    free((void*)htmlContent);
+                } else {
+                    content = "<html><body><h1>No content set</h1></body></html>";
+                }
+            } else {
+                content = loadViewsFile(path);
+            }
+
+            mimeTypeBlock = getMimeTypeForFile(path);
+            if (!content.empty()) {
+                responseDataBlock.assign(content.begin(), content.end());
+                hasResponseBlock = true;
+            }
+        } else if (hasProtocolRegistration(scheme)) {
+            requestId_ = g_nextProtocolRequestId.fetch_add(1);
             hasResponse_ = true;
-        } else {
-            hasResponse_ = false;
+            offset_ = 0;
+
+            std::string method = request->GetMethod().ToString();
+            CefRequest::HeaderMap headerMap;
+            request->GetHeaderMap(headerMap);
+            std::string headersJson = buildProtocolHeadersJSON(headerMap);
+
+            std::vector<uint8_t> body = readProtocolRequestBody(request->GetPostData());
+            bool hasBody = !body.empty();
+            if (hasBody) {
+                std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+                g_protocolRequestBodies[requestId_] = std::move(body);
+            }
+
+            std::string requestJson = buildProtocolRequestJson(url, method, headersJson, hasBody);
+
+            {
+                std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+                g_pendingCEFProtocolHandlers[requestId_] = this;
+            }
+
+            if (g_protocolRequestHandler) {
+                uint64_t requestId = requestId_;
+                uint32_t webviewId = webviewId_;
+                dispatchProtocolRequestSync([requestId, webviewId, requestJson]() {
+                    char* requestJsonCopy = strdup(requestJson.c_str());
+                    g_protocolRequestHandler(requestId, webviewId, requestJsonCopy);
+                });
+                hasResponseBlock = true;
+            } else {
+                std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+                g_pendingCEFProtocolHandlers.erase(requestId_);
+                g_protocolRequestBodies.erase(requestId_);
+                requestId_ = 0;
+            }
         }
 
+        mimeType_ = mimeTypeBlock;
+        responseData_.assign(responseDataBlock.begin(), responseDataBlock.end());
+        hasResponse_ = hasResponseBlock;
         return hasResponse_;
     }
 
     void GetResponseHeaders(CefRefPtr<CefResponse> response, int64_t& response_length, CefString& redirectUrl) override {
+        if (requestId_ != 0) {
+            std::unique_lock<std::mutex> lock(mutex_);
+            condition_.wait(lock, [&] { return headerReady_ || failed_; });
+            if (failed_) {
+                response->SetStatus(500);
+                response_length = 0;
+                return;
+            }
+
+            response->SetStatus(statusCode_);
+            response->SetStatusText(statusText_);
+            response->SetHeaderMap(headerMap_);
+            auto contentType = responseHeaders_.find("content-type");
+            if (contentType != responseHeaders_.end()) {
+                response->SetMimeType(contentType->second);
+            }
+            response_length = -1;
+            return;
+        }
+
+        if (!hasResponse_) {
+            response->SetStatus(404);
+            response_length = 0;
+            return;
+        }
+
         response->SetStatus(200);
         response->SetMimeType(mimeType_);
         response_length = static_cast<int64_t>(responseData_.size());
+
+        CefResponse::HeaderMap headers;
+        headers.insert(std::make_pair("Access-Control-Allow-Origin", "*"));
+        response->SetHeaderMap(headers);
     }
 
     bool Read(void* data_out, int bytes_to_read, int& bytes_read, CefRefPtr<CefResourceReadCallback> callback) override {
         bytes_read = 0;
+
+        if (requestId_ != 0) {
+            std::unique_lock<std::mutex> lock(mutex_);
+            condition_.wait(lock, [&] {
+                return failed_ || !chunks_.empty() || finished_;
+            });
+
+            if (failed_) {
+                return false;
+            }
+
+            if (chunks_.empty()) {
+                return false;
+            }
+
+            std::vector<uint8_t>& chunk = chunks_.front();
+            size_t remaining = chunk.size() - chunkOffset_;
+            bytes_read = std::min(bytes_to_read, static_cast<int>(remaining));
+            memcpy(data_out, chunk.data() + chunkOffset_, bytes_read);
+            chunkOffset_ += bytes_read;
+            if (chunkOffset_ >= chunk.size()) {
+                chunks_.pop_front();
+                chunkOffset_ = 0;
+            }
+            return true;
+        }
+
         if (!hasResponse_ || offset_ >= responseData_.size()) {
             return false;
         }
+
         size_t remaining = responseData_.size() - offset_;
-        bytes_read = (bytes_to_read < static_cast<int>(remaining)) ? 
-                     bytes_to_read : static_cast<int>(remaining);
+        bytes_read = std::min(bytes_to_read, static_cast<int>(remaining));
         memcpy(data_out, responseData_.data() + offset_, bytes_read);
         offset_ += bytes_read;
         return true;
     }
 
-    void Cancel() override {}
+    void Cancel() override {
+        if (requestId_ != 0) {
+            if (g_protocolRequestCancelledHandler) {
+                g_protocolRequestCancelledHandler(requestId_);
+            }
+            {
+                std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+                g_pendingCEFProtocolHandlers.erase(requestId_);
+                g_protocolRequestBodies.erase(requestId_);
+            }
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                failed_ = true;
+            }
+            condition_.notify_all();
+        }
+    }
 
 private:
     uint32_t webviewId_;
@@ -829,8 +1247,63 @@ private:
     std::vector<char> responseData_;
     bool hasResponse_;
     size_t offset_;
+    uint64_t requestId_;
+    int statusCode_;
+    std::string statusText_;
+    bool headerReady_;
+    bool finished_;
+    bool failed_;
+    std::string errorMessage_;
+    std::map<std::string, std::string> responseHeaders_;
+    CefResponse::HeaderMap headerMap_;
+    std::mutex mutex_;
+    std::condition_variable condition_;
+    std::deque<std::vector<uint8_t>> chunks_;
+    size_t chunkOffset_ = 0;
+
     IMPLEMENT_REFCOUNTING(ElectrobunSchemeHandler);
 };
+
+void ElectrobunSchemeHandler::OnProtocolResponseStart(int statusCode,
+                                                      const std::string& statusText,
+                                                      const std::string& headersJson) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    statusCode_ = statusCode;
+    statusText_ = statusText.empty() ? "OK" : statusText;
+    headerReady_ = true;
+    headerMap_.clear();
+    responseHeaders_.clear();
+
+    for (const auto& header : parseProtocolHeaderPairs(headersJson)) {
+        std::string normalizedKey = header.first;
+        std::transform(normalizedKey.begin(), normalizedKey.end(), normalizedKey.begin(), [](unsigned char c) {
+            return static_cast<char>(std::tolower(c));
+        });
+        responseHeaders_[normalizedKey] = header.second;
+        headerMap_.insert(std::make_pair(header.first, header.second));
+    }
+
+    condition_.notify_all();
+}
+
+void ElectrobunSchemeHandler::OnProtocolResponseChunk(const uint8_t* chunk, size_t size) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    chunks_.emplace_back(chunk, chunk + size);
+    condition_.notify_all();
+}
+
+void ElectrobunSchemeHandler::OnProtocolResponseFinish() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    finished_ = true;
+    condition_.notify_all();
+}
+
+void ElectrobunSchemeHandler::OnProtocolResponseError(const std::string& message) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    failed_ = true;
+    errorMessage_ = message;
+    condition_.notify_all();
+}
 
 // CEF Scheme Handler Factory
 class ElectrobunSchemeHandlerFactory : public CefSchemeHandlerFactory {
@@ -2350,6 +2823,11 @@ CefRefPtr<CefResponseFilter> ElectrobunResourceRequestHandler::GetResourceRespon
     CefRefPtr<CefResponse> response) {
 
     std::string url = request->GetURL().ToString();
+    std::string scheme = extractProtocolScheme(url);
+    if (!scheme.empty() && scheme != "views" && hasProtocolRegistration(scheme)) {
+        return nullptr;
+    }
+
     std::string mimeType = response->GetMimeType().ToString();
     bool isMain = frame->IsMain();
     bool hasClient = client_ != nullptr;
@@ -2406,9 +2884,10 @@ public:
 
 
 // Forward declare helper functions
-void setupViewsSchemeHandler(ICoreWebView2* webview, uint32_t webviewId);
+void setupViewsSchemeHandler(ICoreWebView2* webview, ICoreWebView2Environment* environment, uint32_t webviewId);
 void handleViewsSchemeRequest(ICoreWebView2WebResourceRequestedEventArgs* args, 
-                             const std::wstring& uri, 
+                             const std::wstring& uri,
+                             ICoreWebView2Environment* environment,
                              uint32_t webviewId);
 std::string loadViewsFile(const std::string& path);
 std::string getMimeTypeForFile(const std::string& path);
@@ -2762,6 +3241,17 @@ public:
 };
 
 HWND MainThreadDispatcher::g_messageWindow = NULL;
+
+void dispatchProtocolRequestSync(std::function<void()> callback) {
+    if (g_mainThreadId == 0 || GetCurrentThreadId() == g_mainThreadId) {
+        callback();
+        return;
+    }
+
+    MainThreadDispatcher::dispatch_sync([callback = std::move(callback)]() {
+        callback();
+    });
+}
 
 // AbstractView base class - Windows implementation matching Mac pattern
 class AbstractView {
@@ -5811,6 +6301,7 @@ ELECTROBUN_EXPORT bool initCEF() {
     std::string buildJsonContent = electrobun::readFileToString(buildJsonPath);
     if (!buildJsonContent.empty()) {
         g_userChromiumFlags = electrobun::parseChromiumFlags(buildJsonContent);
+        electrobun::loadProtocolConfigFromBuildJson(buildJsonContent);
     }
 
     // CEF settings
@@ -5848,8 +6339,11 @@ ELECTROBUN_EXPORT bool initCEF() {
     bool success = CefInitialize(main_args, settings, g_cef_app.get(), nullptr);
     if (success) {
         g_cef_initialized = true;
-        // Register the views:// scheme handler factory
-        CefRegisterSchemeHandlerFactory("views", "", new ElectrobunSchemeHandlerFactory());
+        CefRefPtr<ElectrobunSchemeHandlerFactory> schemeFactory = new ElectrobunSchemeHandlerFactory();
+        CefRegisterSchemeHandlerFactory("views", "", schemeFactory);
+        forEachProtocolRegistration([&](const ProtocolRegistration& registration) {
+            CefRegisterSchemeHandlerFactory(registration.scheme, "", schemeFactory);
+        });
         
         // We'll start the message pump timer when we create the first browser
     } else {
@@ -6029,100 +6523,7 @@ static std::shared_ptr<WebView2View> createWebView2View(uint32_t webviewId,
                             uint32_t capturedWebviewId = view->webviewId;
                             WebviewEventHandler capturedHandler = view->webviewEventHandler;
 
-                            // Add views:// scheme support - TEST ADDITION
-                            webview->AddWebResourceRequestedFilter(L"views://*", COREWEBVIEW2_WEB_RESOURCE_CONTEXT_ALL);
-
-                            // Set up WebResourceRequested event handler for views:// scheme
-                            webview->add_WebResourceRequested(
-                                Callback<ICoreWebView2WebResourceRequestedEventHandler>(
-                                    [env, capturedWebviewId, capturedHandler](ICoreWebView2* sender, ICoreWebView2WebResourceRequestedEventArgs* args) -> HRESULT {
-                                        // ::log("[WebView2] WebResourceRequested event triggered");
-                                        ComPtr<ICoreWebView2WebResourceRequest> request;
-                                        args->get_Request(&request);
-                                        
-                                        LPWSTR uri;
-                                        request->get_Uri(&uri);
-                                        
-                                        // Safe string conversion
-                                        std::string uriStr;
-                                        int size = WideCharToMultiByte(CP_UTF8, 0, uri, -1, nullptr, 0, nullptr, nullptr);
-                                        if (size > 0) {
-                                            uriStr.resize(size - 1);
-                                            WideCharToMultiByte(CP_UTF8, 0, uri, -1, &uriStr[0], size, nullptr, nullptr);
-                                        }
-                                        
-                                        // ::log("[WebView2] Request URI converted successfully");
-                                        
-                                        if (uriStr.substr(0, 8) == "views://") {
-                                            std::string filePath = uriStr.substr(8);
-                                            std::string content;
-
-                                            // Check for internal/index.html (inline HTML content)
-                                            if (filePath == "internal/index.html") {
-                                                const char* htmlContent = getWebviewHTMLContent(capturedWebviewId);
-                                                if (htmlContent && strlen(htmlContent) > 0) {
-                                                    content = std::string(htmlContent);
-                                                    free((void*)htmlContent);
-                                                } else {
-                                                    content = "<html><body><h1>No content set</h1></body></html>";
-                                                }
-                                            } else {
-                                                content = loadViewsFile(filePath);
-                                            }
-
-                                            if (!content.empty()) {
-                                                // ::log("[WebView2] Loaded views file content, creating response");
-
-                                                // Create response (simplified)
-                                                std::string mimeType = "text/html";
-                                                bool isDocument = false;
-                                                if (filePath.find(".js") != std::string::npos) mimeType = "application/javascript";
-                                                else if (filePath.find(".css") != std::string::npos) mimeType = "text/css";
-                                                else if (filePath.find(".png") != std::string::npos) mimeType = "image/png";
-                                                else {
-                                                    isDocument = true; // HTML document
-                                                }
-
-                                                // For HTML documents (main frame navigation), fire navigation events manually
-                                                // since WebResourceRequested bypasses NavigationStarting/NavigationCompleted
-                                                // These events are already fired in loadURL, so we don't need to fire them here
-                                                // This block can be removed if we want to clean up
-                                                if (isDocument && capturedHandler) {
-                                                    // Events are now fired in loadURL() for consistency
-                                                    // This avoids duplicate events and ensures proper timing
-                                                }
-
-                                                std::wstring wMimeType(mimeType.begin(), mimeType.end());
-
-                                                // Create memory stream
-                                                ComPtr<IStream> contentStream;
-                                                HGLOBAL hGlobal = GlobalAlloc(GMEM_MOVEABLE, content.size());
-                                                if (hGlobal) {
-                                                    void* pData = GlobalLock(hGlobal);
-                                                    memcpy(pData, content.c_str(), content.size());
-                                                    GlobalUnlock(hGlobal);
-                                                    CreateStreamOnHGlobal(hGlobal, TRUE, &contentStream);
-                                                }
-
-                                                std::wstring headers = L"Content-Type: " + wMimeType + L"\r\nAccess-Control-Allow-Origin: *";
-
-                                                ComPtr<ICoreWebView2WebResourceResponse> response;
-                                                env->CreateWebResourceResponse(
-                                                    contentStream.Get(),
-                                                    200,
-                                                    L"OK",
-                                                    headers.c_str(),
-                                                    &response);
-
-                                                args->put_Response(response.Get());
-                                                // ::log("[WebView2] Successfully served views:// file");
-                                            }
-                                        }
-                                        
-                                        CoTaskMemFree(uri);
-                                        return S_OK;
-                                    }).Get(),
-                                nullptr);
+                            setupViewsSchemeHandler(webview.Get(), env, capturedWebviewId);
                             
                             
                             // Add preload scripts
@@ -6555,23 +6956,31 @@ static std::shared_ptr<WebView2View> createWebView2View(uint32_t webviewId,
             // Get the interface that supports custom scheme registration
             Microsoft::WRL::ComPtr<ICoreWebView2EnvironmentOptions4> options4;
             if (SUCCEEDED(options.As(&options4))) {
-                // ::log("Setting up views:// custom scheme registration");
-
-                // Set allowed origins for the custom scheme
                 const WCHAR* allowedOrigins[1] = {L"*"};
 
-                // Create custom scheme registration for "views"
-                auto viewsSchemeRegistration = Microsoft::WRL::Make<CoreWebView2CustomSchemeRegistration>(L"views");
+                std::vector<std::wstring> registrationNames;
+                std::vector<ComPtr<ICoreWebView2CustomSchemeRegistration>> registrationObjects;
+                std::vector<ICoreWebView2CustomSchemeRegistration*> registrations;
+
+                registrationNames.push_back(L"views");
+                auto viewsSchemeRegistration = Microsoft::WRL::Make<CoreWebView2CustomSchemeRegistration>(registrationNames.back().c_str());
                 viewsSchemeRegistration->put_TreatAsSecure(TRUE);
-                viewsSchemeRegistration->put_HasAuthorityComponent(TRUE); // This allows views://host/path format
+                viewsSchemeRegistration->put_HasAuthorityComponent(TRUE);
                 viewsSchemeRegistration->SetAllowedOrigins(1, allowedOrigins);
+                registrationObjects.push_back(viewsSchemeRegistration);
+                registrations.push_back(viewsSchemeRegistration.Get());
 
-                // Set the custom scheme registrations
-                ICoreWebView2CustomSchemeRegistration* registrations[1] = {
-                    viewsSchemeRegistration.Get()
-                };
+                forEachProtocolRegistration([&](const ProtocolRegistration& registration) {
+                    registrationNames.push_back(StringToWString(registration.scheme));
+                    auto schemeRegistration = Microsoft::WRL::Make<CoreWebView2CustomSchemeRegistration>(registrationNames.back().c_str());
+                    schemeRegistration->put_TreatAsSecure(registration.privileges.secure ? TRUE : FALSE);
+                    schemeRegistration->put_HasAuthorityComponent(TRUE);
+                    schemeRegistration->SetAllowedOrigins(1, allowedOrigins);
+                    registrationObjects.push_back(schemeRegistration);
+                    registrations.push_back(schemeRegistration.Get());
+                });
 
-                HRESULT schemeResult = options4->SetCustomSchemeRegistrations(1, registrations);
+                HRESULT schemeResult = options4->SetCustomSchemeRegistrations(static_cast<UINT32>(registrations.size()), registrations.data());
 
                 if (SUCCEEDED(schemeResult)) {
                     // ::log("views:// custom scheme registration set successfully");
@@ -6697,6 +7106,10 @@ CefRefPtr<CefRequestContext> CreateRequestContextForPartition(const char* partit
     bool registered = context->RegisterSchemeHandlerFactory("views", "", schemeFactory);
     printf("DEBUG CEF: Registered scheme handler factory for partition '%s' - success: %s\n",
            partitionIdentifier ? partitionIdentifier : "(default)", registered ? "yes" : "no");
+
+    forEachProtocolRegistration([&](const ProtocolRegistration& registration) {
+        context->RegisterSchemeHandlerFactory(registration.scheme, "", schemeFactory);
+    });
 
     return context;
 }
@@ -10360,86 +10773,302 @@ ELECTROBUN_EXPORT uint32_t getWindowStyle(
 
 } // extern "C"
 
-// New function for handling views:// scheme requests
-void setupViewsSchemeHandler(ICoreWebView2* webview, uint32_t webviewId) {
-    
-    // Add web resource request filter for views:// scheme
+static HRESULT createWebView2MemoryStreamFromBytes(const uint8_t* data, size_t size, IStream** outStream) {
+    if (!outStream) {
+        return E_POINTER;
+    }
+
+    *outStream = nullptr;
+
+    ComPtr<IStream> stream;
+    HRESULT hr = CreateStreamOnHGlobal(NULL, TRUE, &stream);
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    if (data && size > 0) {
+        ULONG written = 0;
+        hr = stream->Write(data, static_cast<ULONG>(size), &written);
+        if (FAILED(hr) || written != size) {
+            return FAILED(hr) ? hr : E_FAIL;
+        }
+    }
+
+    LARGE_INTEGER zero = {};
+    stream->Seek(zero, STREAM_SEEK_SET, nullptr);
+    return stream.CopyTo(outStream);
+}
+
+static std::wstring buildWebView2HeaderString(const std::string& headersJson) {
+    std::wstring headers;
+    bool first = true;
+    for (const auto& header : parseProtocolHeaderPairs(headersJson)) {
+        if (!first) {
+            headers += L"\r\n";
+        }
+        first = false;
+        headers += StringToWString(header.first);
+        headers += L": ";
+        headers += StringToWString(header.second);
+    }
+    return headers;
+}
+
+static void cleanupPendingWebView2ProtocolRequestLocked(uint64_t requestId) {
+    g_pendingWebView2Deferrals.erase(requestId);
+    g_pendingWebView2Responses.erase(requestId);
+    g_pendingWebView2Environments.erase(requestId);
+    g_pendingWebView2ResponseStates.erase(requestId);
+    g_protocolRequestBodies.erase(requestId);
+}
+
+static void completePendingWebView2ProtocolResponse(uint64_t requestId) {
+    ComPtr<ICoreWebView2WebResourceRequestedEventArgs> args;
+    ComPtr<ICoreWebView2Deferral> deferral;
+    ComPtr<ICoreWebView2Environment> environment;
+    PendingWebView2ProtocolResponseState state;
+
+    {
+        std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+        auto argsIt = g_pendingWebView2Responses.find(requestId);
+        auto deferralIt = g_pendingWebView2Deferrals.find(requestId);
+        if (argsIt == g_pendingWebView2Responses.end() || deferralIt == g_pendingWebView2Deferrals.end()) {
+            cleanupPendingWebView2ProtocolRequestLocked(requestId);
+            return;
+        }
+
+        args = argsIt->second;
+        deferral = deferralIt->second;
+
+        auto environmentIt = g_pendingWebView2Environments.find(requestId);
+        if (environmentIt != g_pendingWebView2Environments.end()) {
+            environment = environmentIt->second;
+        }
+
+        auto stateIt = g_pendingWebView2ResponseStates.find(requestId);
+        if (stateIt != g_pendingWebView2ResponseStates.end()) {
+            state = stateIt->second;
+        }
+
+        cleanupPendingWebView2ProtocolRequestLocked(requestId);
+    }
+
+    if (!deferral) {
+        return;
+    }
+
+    if (!args || !environment) {
+        deferral->Complete();
+        return;
+    }
+
+    ComPtr<IStream> stream;
+    if (FAILED(createWebView2MemoryStreamFromBytes(state.body.data(), state.body.size(), &stream))) {
+        deferral->Complete();
+        return;
+    }
+
+    ComPtr<ICoreWebView2WebResourceResponse> response;
+    std::wstring statusText = StringToWString(state.statusText.empty() ? "OK" : state.statusText);
+    std::wstring headers = buildWebView2HeaderString(state.headersJson);
+    if (SUCCEEDED(environment->CreateWebResourceResponse(stream.Get(), state.statusCode, statusText.c_str(), headers.c_str(), &response)) && response) {
+        args->put_Response(response.Get());
+    }
+
+    deferral->Complete();
+}
+
+static void completePendingWebView2ProtocolError(uint64_t requestId, const std::string& message) {
+    ComPtr<ICoreWebView2WebResourceRequestedEventArgs> args;
+    ComPtr<ICoreWebView2Deferral> deferral;
+    ComPtr<ICoreWebView2Environment> environment;
+
+    {
+        std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+        auto argsIt = g_pendingWebView2Responses.find(requestId);
+        auto deferralIt = g_pendingWebView2Deferrals.find(requestId);
+        if (argsIt == g_pendingWebView2Responses.end() || deferralIt == g_pendingWebView2Deferrals.end()) {
+            cleanupPendingWebView2ProtocolRequestLocked(requestId);
+            return;
+        }
+
+        args = argsIt->second;
+        deferral = deferralIt->second;
+
+        auto environmentIt = g_pendingWebView2Environments.find(requestId);
+        if (environmentIt != g_pendingWebView2Environments.end()) {
+            environment = environmentIt->second;
+        }
+
+        cleanupPendingWebView2ProtocolRequestLocked(requestId);
+    }
+
+    if (!deferral) {
+        return;
+    }
+
+    if (!args || !environment) {
+        deferral->Complete();
+        return;
+    }
+
+    std::vector<uint8_t> body(message.begin(), message.end());
+    ComPtr<IStream> stream;
+    if (FAILED(createWebView2MemoryStreamFromBytes(body.data(), body.size(), &stream))) {
+        deferral->Complete();
+        return;
+    }
+
+    ComPtr<ICoreWebView2WebResourceResponse> response;
+    if (SUCCEEDED(environment->CreateWebResourceResponse(stream.Get(), 500, L"Internal Server Error", L"Content-Type: text/plain", &response)) && response) {
+        args->put_Response(response.Get());
+    }
+
+    deferral->Complete();
+}
+
+static void handleCustomProtocolSchemeRequest(ICoreWebView2WebResourceRequestedEventArgs* args,
+                                              ICoreWebView2WebResourceRequest* request,
+                                              const std::string& uri,
+                                              ICoreWebView2Environment* environment,
+                                              uint32_t webviewId) {
+    if (!request) {
+        return;
+    }
+
+    ComPtr<ICoreWebView2Deferral> deferral;
+    if (FAILED(args->GetDeferral(&deferral)) || !deferral) {
+        ::log("ERROR: Failed to get WebView2 deferral for custom protocol request");
+        return;
+    }
+
+    uint64_t requestId = g_nextProtocolRequestId.fetch_add(1);
+
+    std::string method = "GET";
+    LPWSTR methodW = nullptr;
+    if (SUCCEEDED(request->get_Method(&methodW)) && methodW) {
+        method = WStringToString(methodW);
+    }
+    if (methodW) {
+        CoTaskMemFree(methodW);
+    }
+
+    std::string headersJson = "[]";
+    ComPtr<ICoreWebView2HttpRequestHeaders> headers;
+    if (SUCCEEDED(request->get_Headers(&headers)) && headers) {
+        headersJson = buildProtocolHeadersJSON(headers.Get());
+    }
+
+    std::vector<uint8_t> body;
+    ComPtr<IStream> content;
+    if (SUCCEEDED(request->get_Content(&content)) && content) {
+        body = readProtocolRequestBody(content.Get());
+    }
+
+    bool hasBody = !body.empty();
+    std::string requestJson = buildProtocolRequestJson(uri, method, headersJson, hasBody);
+
+    {
+        std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+        g_pendingWebView2Deferrals[requestId] = deferral;
+        g_pendingWebView2Responses[requestId] = args;
+        if (environment) {
+            g_pendingWebView2Environments[requestId] = environment;
+        }
+        g_pendingWebView2ResponseStates[requestId] = PendingWebView2ProtocolResponseState();
+        if (hasBody) {
+            g_protocolRequestBodies[requestId] = std::move(body);
+        }
+    }
+
+    if (g_protocolRequestHandler) {
+        char* requestJsonCopy = strdup(requestJson.c_str());
+        g_protocolRequestHandler(requestId, webviewId, requestJsonCopy);
+    } else {
+        completePendingWebView2ProtocolError(requestId, "No protocol handler configured");
+    }
+}
+
+void setupViewsSchemeHandler(ICoreWebView2* webview, ICoreWebView2Environment* environment, uint32_t webviewId) {
+    ComPtr<ICoreWebView2Environment> environmentRef = environment;
     EventRegistrationToken resourceToken;
     HRESULT hr = webview->add_WebResourceRequested(
         Callback<ICoreWebView2WebResourceRequestedEventHandler>(
-            [webviewId](ICoreWebView2* sender, ICoreWebView2WebResourceRequestedEventArgs* args) -> HRESULT {
+            [webviewId, environmentRef](ICoreWebView2* sender, ICoreWebView2WebResourceRequestedEventArgs* args) -> HRESULT {
                 ComPtr<ICoreWebView2WebResourceRequest> request;
-                args->get_Request(&request);
-                
-                LPWSTR uri;
-                request->get_Uri(&uri);
-                
-                std::wstring wUri(uri);
-                
-                // Convert to string for logging
-                int size = WideCharToMultiByte(CP_UTF8, 0, uri, -1, NULL, 0, NULL, NULL);
-                std::string uriStr(size - 1, 0);
-                WideCharToMultiByte(CP_UTF8, 0, uri, -1, &uriStr[0], size, NULL, NULL);
-                
-                
-                
-                // Check if this is a views:// URL
-                if (wUri.find(L"views://") == 0) {
-                    handleViewsSchemeRequest(args, wUri, webviewId);
+                if (FAILED(args->get_Request(&request)) || !request) {
+                    return S_OK;
                 }
-                
+
+                LPWSTR uri = nullptr;
+                if (FAILED(request->get_Uri(&uri)) || !uri) {
+                    return S_OK;
+                }
+
+                std::wstring wUri(uri);
+                std::string uriStr = WStringToString(wUri);
+
+                if (wUri.rfind(L"views://", 0) == 0) {
+                    handleViewsSchemeRequest(args, wUri, environmentRef.Get(), webviewId);
+                } else {
+                    std::string scheme = extractProtocolScheme(uriStr);
+                    if (!scheme.empty() && hasProtocolRegistration(scheme)) {
+                        handleCustomProtocolSchemeRequest(args, request.Get(), uriStr, environmentRef.Get(), webviewId);
+                    }
+                }
+
                 CoTaskMemFree(uri);
                 return S_OK;
-            }).Get(), 
+            }).Get(),
         &resourceToken);
-    
+
     if (FAILED(hr)) {
         char errorMsg[256];
         sprintf_s(errorMsg, "Failed to add WebResourceRequested handler: 0x%lx", hr);
         ::log(errorMsg);
         return;
     }
-    
-    // Add filter for views:// scheme
+
     hr = webview->AddWebResourceRequestedFilter(L"views://*", COREWEBVIEW2_WEB_RESOURCE_CONTEXT_ALL);
     if (FAILED(hr)) {
         char errorMsg[256];
         sprintf_s(errorMsg, "Failed to add resource filter for views://: 0x%lx", hr);
         ::log(errorMsg);
-    } else {
     }
+
+    forEachProtocolRegistration([&](const ProtocolRegistration& registration) {
+        std::wstring filter = StringToWString(registration.scheme + "://*");
+        HRESULT filterResult = webview->AddWebResourceRequestedFilter(filter.c_str(), COREWEBVIEW2_WEB_RESOURCE_CONTEXT_ALL);
+        if (FAILED(filterResult)) {
+            char errorMsg[256];
+            sprintf_s(errorMsg, "Failed to add resource filter for %s://: 0x%lx", registration.scheme.c_str(), filterResult);
+            ::log(errorMsg);
+        }
+    });
 }
 
-// Updated function to handle views:// scheme requests
-void handleViewsSchemeRequest(ICoreWebView2WebResourceRequestedEventArgs* args, 
-                             const std::wstring& uri, 
-                             uint32_t webviewId) {
-    
-    
-    // Convert URI to std::string for processing
-    int size = WideCharToMultiByte(CP_UTF8, 0, uri.c_str(), -1, NULL, 0, NULL, NULL);
-    std::string uriStr(size - 1, 0);
-    WideCharToMultiByte(CP_UTF8, 0, uri.c_str(), -1, &uriStr[0], size, NULL, NULL);
+void handleViewsSchemeRequest(ICoreWebView2WebResourceRequestedEventArgs* args,
+                              const std::wstring& uri,
+                              ICoreWebView2Environment* environment,
+                              uint32_t webviewId) {
+    std::string uriStr = WStringToString(uri);
 
-    
-    // Extract the path after "views://"
     std::string path;
     if (uriStr.length() > 8) {
-        path = uriStr.substr(8); // Remove "views://" prefix
+        path = uriStr.substr(8);
     } else {
-        path = "index.html"; // Default
+        path = "index.html";
     }
-    
+
     std::string responseData;
     std::string mimeType = "text/html";
-    
+
     if (path == "internal/index.html") {
-        // Handle internal HTML content using stored content
         ::log("DEBUG Windows: Handling views://internal/index.html");
         const char* htmlContent = getWebviewHTMLContent(webviewId);
         if (htmlContent && strlen(htmlContent) > 0) {
             responseData = std::string(htmlContent);
-            free((void*)htmlContent); // Free the strdup'd memory
+            free((void*)htmlContent);
             ::log("DEBUG Windows: Retrieved HTML content from storage");
         } else {
             responseData = "<html><body><h1>No content set</h1></body></html>";
@@ -10447,77 +11076,41 @@ void handleViewsSchemeRequest(ICoreWebView2WebResourceRequestedEventArgs* args,
         }
         mimeType = "text/html";
     } else {
-        // Handle other file requests
         responseData = loadViewsFile(path);
         mimeType = getMimeTypeForFile(path);
-        
+
         if (responseData.empty()) {
             responseData = "<html><body><h1>404 - Views file not found</h1><p>Path: " + path + "</p></body></html>";
             mimeType = "text/html";
             ::log("Views file not found, returning 404");
         }
     }
-    
-    // sprintf_s(logMsg, "Response data length: %zu bytes, MIME type: %s", responseData.length(), mimeType.c_str());
-    // log(logMsg);
-    
-    // Create the response using the global environment
-    if (!g_environment) {
-        ::log("ERROR: No global environment available for creating response");
+
+    if (!environment) {
+        ::log("ERROR: No WebView2 environment available for creating response");
         return;
     }
-    
+
     try {
-        // Create memory stream first
         ComPtr<IStream> stream;
-        HGLOBAL hGlobal = GlobalAlloc(GMEM_MOVEABLE, responseData.length());
-        if (!hGlobal) {
-            ::log("ERROR: Failed to allocate global memory");
+        if (FAILED(createWebView2MemoryStreamFromBytes(reinterpret_cast<const uint8_t*>(responseData.data()), responseData.size(), &stream))) {
+            ::log("ERROR: Failed to create WebView2 response stream");
             return;
         }
-        
-        void* pData = GlobalLock(hGlobal);
-        if (!pData) {
-            GlobalFree(hGlobal);
-            ::log("ERROR: Failed to lock global memory");
-            return;
-        }
-        
-        memcpy(pData, responseData.c_str(), responseData.length());
-        GlobalUnlock(hGlobal);
-        
-        HRESULT streamResult = CreateStreamOnHGlobal(hGlobal, TRUE, &stream);
-        if (FAILED(streamResult)) {
-            GlobalFree(hGlobal);
-            ::log("ERROR: Failed to create stream on global");
-            return;
-        }
-        
-        // Create the response
+
         ComPtr<ICoreWebView2WebResourceResponse> response;
-        std::wstring mimeTypeW(mimeType.begin(), mimeType.end());
-        std::wstring headers = L"Content-Type: " + mimeTypeW + L"\r\nAccess-Control-Allow-Origin: *";
-        
-        HRESULT responseResult = g_environment->CreateWebResourceResponse(
-            stream.Get(),               // content stream
-            200,                       // status code
-            L"OK",                     // reason phrase
-            headers.c_str(),           // headers
-            &response);
-        
+        std::wstring headers = L"Content-Type: " + StringToWString(mimeType) + L"\r\nAccess-Control-Allow-Origin: *";
+        HRESULT responseResult = environment->CreateWebResourceResponse(stream.Get(), 200, L"OK", headers.c_str(), &response);
         if (FAILED(responseResult)) {
             ::log("ERROR: Failed to create web resource response");
             return;
         }
-        
-        // Set the response
+
         HRESULT setResult = args->put_Response(response.Get());
         if (FAILED(setResult)) {
             ::log("ERROR: Failed to set response");
             return;
         }
-        
-        
     } catch (...) {
         ::log("ERROR: Exception occurred while creating response");
     }
@@ -11576,6 +12169,144 @@ extern "C" ELECTROBUN_EXPORT void sessionClearStorageData(const char* partitionI
             }
         }
     }
+}
+
+extern "C" ELECTROBUN_EXPORT void setCustomProtocolConfig(const char* protocolConfigJson) {
+    setProtocolConfigJson(protocolConfigJson ? protocolConfigJson : "[]");
+}
+
+extern "C" ELECTROBUN_EXPORT void setCustomProtocolHandlers(ProtocolRequestHandler requestHandler,
+                                                             ProtocolRequestCancelledHandler cancelHandler) {
+    g_protocolRequestHandler = requestHandler;
+    g_protocolRequestCancelledHandler = cancelHandler;
+}
+
+extern "C" ELECTROBUN_EXPORT const uint8_t* protocolGetRequestBody(uint64_t requestId, uint64_t* outSize) {
+    std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+    auto it = g_protocolRequestBodies.find(requestId);
+    if (it == g_protocolRequestBodies.end()) {
+        if (outSize) {
+            *outSize = 0;
+        }
+        return nullptr;
+    }
+
+    const auto& body = it->second;
+    if (outSize) {
+        *outSize = body.size();
+    }
+
+    if (body.empty()) {
+        g_protocolRequestBodies.erase(it);
+        return nullptr;
+    }
+
+    uint8_t* result = static_cast<uint8_t*>(malloc(body.size()));
+    if (!result) {
+        if (outSize) {
+            *outSize = 0;
+        }
+        g_protocolRequestBodies.erase(it);
+        return nullptr;
+    }
+    memcpy(result, body.data(), body.size());
+    g_protocolRequestBodies.erase(it);
+    return result;
+}
+
+extern "C" ELECTROBUN_EXPORT void freeProtocolBuffer(const uint8_t* buffer) {
+    if (buffer) {
+        free((void*)buffer);
+    }
+}
+
+extern "C" ELECTROBUN_EXPORT void protocolStartResponse(uint64_t requestId,
+                                                         int statusCode,
+                                                         const char* statusText,
+                                                         const char* headersJson) {
+    std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+    auto cefIt = g_pendingCEFProtocolHandlers.find(requestId);
+    if (cefIt != g_pendingCEFProtocolHandlers.end()) {
+        cefIt->second->OnProtocolResponseStart(statusCode, statusText ? statusText : "OK", headersJson ? headersJson : "[]");
+        return;
+    }
+
+    if (g_pendingWebView2Responses.find(requestId) == g_pendingWebView2Responses.end()) {
+        return;
+    }
+
+    auto stateIt = g_pendingWebView2ResponseStates.find(requestId);
+    if (stateIt == g_pendingWebView2ResponseStates.end()) {
+        return;
+    }
+
+    auto& state = stateIt->second;
+    state.statusCode = statusCode;
+    state.statusText = statusText ? statusText : "OK";
+    state.headersJson = headersJson ? headersJson : "[]";
+}
+
+extern "C" ELECTROBUN_EXPORT void protocolWriteResponseChunk(uint64_t requestId, const uint8_t* chunk, uint64_t size) {
+    if (!chunk || size == 0) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+    auto cefIt = g_pendingCEFProtocolHandlers.find(requestId);
+    if (cefIt != g_pendingCEFProtocolHandlers.end()) {
+        cefIt->second->OnProtocolResponseChunk(chunk, static_cast<size_t>(size));
+        return;
+    }
+
+    if (g_pendingWebView2Responses.find(requestId) == g_pendingWebView2Responses.end()) {
+        return;
+    }
+
+    auto stateIt = g_pendingWebView2ResponseStates.find(requestId);
+    if (stateIt == g_pendingWebView2ResponseStates.end()) {
+        return;
+    }
+
+    // WebView2 requires a complete IStream when put_Response is called, so we
+    // buffer chunks here and create the response stream in protocolFinishResponse.
+    auto& body = stateIt->second.body;
+    body.insert(body.end(), chunk, chunk + size);
+}
+
+extern "C" ELECTROBUN_EXPORT void protocolFinishResponse(uint64_t requestId) {
+    {
+        std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+        auto cefIt = g_pendingCEFProtocolHandlers.find(requestId);
+        if (cefIt != g_pendingCEFProtocolHandlers.end()) {
+            cefIt->second->OnProtocolResponseFinish();
+            g_pendingCEFProtocolHandlers.erase(cefIt);
+            g_protocolRequestBodies.erase(requestId);
+            return;
+        }
+    }
+
+    MainThreadDispatcher::dispatch_async([requestId]() {
+        completePendingWebView2ProtocolResponse(requestId);
+    });
+}
+
+extern "C" ELECTROBUN_EXPORT void protocolErrorResponse(uint64_t requestId, const char* message) {
+    std::string errorMessage = message ? message : "Protocol request failed";
+
+    {
+        std::lock_guard<std::mutex> lock(g_protocolRequestMutex);
+        auto cefIt = g_pendingCEFProtocolHandlers.find(requestId);
+        if (cefIt != g_pendingCEFProtocolHandlers.end()) {
+            cefIt->second->OnProtocolResponseError(errorMessage);
+            g_pendingCEFProtocolHandlers.erase(cefIt);
+            g_protocolRequestBodies.erase(requestId);
+            return;
+        }
+    }
+
+    MainThreadDispatcher::dispatch_async([requestId, errorMessage]() {
+        completePendingWebView2ProtocolError(requestId, errorMessage);
+    });
 }
 
 // URL scheme handler - macOS only, stub for Windows

--- a/package/src/shared/protocol.ts
+++ b/package/src/shared/protocol.ts
@@ -1,0 +1,17 @@
+export type CustomSchemePrivileges = {
+	standard?: boolean;
+	secure?: boolean;
+	bypassCSP?: boolean;
+	allowServiceWorkers?: boolean;
+	supportFetchAPI?: boolean;
+	corsEnabled?: boolean;
+	stream?: boolean;
+	codeCache?: boolean;
+};
+
+export type CustomScheme = {
+	scheme: string;
+	privileges?: CustomSchemePrivileges;
+};
+
+export type ProtocolHandler = (request: Request) => Response | Promise<Response>;


### PR DESCRIPTION
### Problem

Electrobun had no way to serve custom content from a user-defined URL scheme. The only built-in content protocol was `views://`, which is hardcoded to serve bundled static assets. If an app needed to serve dynamic content without a localhost HTTP server - for example, to serve API responses or handle server-side rendered pages, assets from an in-process database, or streamed content from a local source - there was no supported path. The only options were a localhost sidecar server or the `loadHTML()` single-page injection, both of which have significant limitations.

This is the missing primitive that Electron addresses with `protocol.handle()` and `session.protocol.handle()`.

### Solution

Adds a first-class custom protocol API for Electrobun following the same two-phase design as Electron:

1. **Declare schemes in config** - registered before any webview or CEF context initializes
2. **Handle requests at runtime** - `(request: Request) => Response | Promise<Response>` using Web-standard Fetch semantics

The handler model intentionally mirrors Bun's native `Bun.serve` fetch handler. Any scheme declared in config that matches a registered `Protocol.handle()` callback receives full `Request` → `Response` control, including streaming response bodies, arbitrary status codes, custom headers, binary bodies, and `AbortController` cancellation.

### Usage

```typescript
// electrobun.config.ts
export default {
  runtime: {
    protocols: [
      {
        scheme: "app",
        privileges: {
          standard: true,
          secure: true,
          corsEnabled: true,
          supportFetchAPI: true,
          stream: true,
        },
      },
    ],
  },
} satisfies ElectrobunConfig;
```

```typescript
// src/bun/index.ts
import { Protocol } from "electrobun/bun";

Protocol.handle("app", async (request) => {
  const url = new URL(request.url);

  if (url.pathname === "/data") {
    const rows = await db.query("SELECT * FROM items");
    return Response.json(rows);
  }

  if (url.pathname === "/stream") {
    return new Response(
      new ReadableStream({
        async start(controller) {
          for await (const chunk of largeDataSource()) {
            controller.enqueue(chunk);
          }
          controller.close();
        },
      }),
      { headers: { "content-type": "application/octet-stream" } },
    );
  }

  return new Response("not found", { status: 404 });
});
```

The webview sees `app://...` URLs as a normal secure origin with full Fetch API support.

### Architecture

The implementation follows the same two-phase split that Electron requires for `registerSchemesAsPrivileged`: schemes must be known before the browser engine initializes, but handlers are registered at runtime after the app starts.

**Phase 1 - early declaration.** When `electrobun build` or `electrobun dev` runs, the CLI reads `runtime.protocols` from `electrobun.config.ts` and writes it into `build.json` alongside the existing renderer config. On startup, each platform's native wrapper reads `build.json` before calling `CefInitialize` or creating any `WKWebView`/`WebView2`/`WebKitWebView`. Schemes are registered there - `OnRegisterCustomSchemes` in the CEF helper processes also receives them via a command-line switch propagated through `OnBeforeCommandLineProcessing` and `OnBeforeChildProcessLaunch`. This is the only moment registration is possible; any later call has no effect on the engine.

**Phase 2 - runtime request handling.** When a webview issues a fetch or navigation to a registered scheme, the native scheme handler fires on a background thread. It serializes the request - URL, method, headers, and body bytes - and invokes a Bun `JSCallback` registered via FFI. That callback lands in the Bun event loop, constructs a Web-standard `Request` object, and calls the matching `Protocol.handle()` function. The returned `Response` - including its `ReadableStream` body if present - is streamed back chunk by chunk through a second set of FFI calls: `protocolStartResponse` delivers status and headers, repeated `protocolWriteResponseChunk` calls deliver body data as it becomes available, and `protocolFinishResponse` signals completion. Cancellation is handled via `AbortController`: if the webview cancels a request mid-flight, the native `Cancel()` method wakes any blocked FFI thread and the Bun-side stream reader is cancelled.

On macOS, both the native `WKURLSchemeHandler` path and the CEF `CefResourceHandler` path deliver response chunks to the browser as they arrive. On Windows (`WebResourceRequested` + `ICoreWebView2Deferral`) and Linux (`webkit_uri_scheme_request_finish_with_response`), the native renderer path requires a complete response stream at delivery time, so chunks are buffered until `protocolFinishResponse` fires. The CEF path on all platforms is genuinely streaming in both cases.

### Fetch spec coverage (kitchen test suite)

The 13 automated tests in `kitchen/src/tests/protocol.test.ts` cover:

- Top-level navigation to a custom protocol page (native and CEF renderers)
- `GET` text response with custom response headers
- `PUT`, `DELETE`, `OPTIONS`, `HEAD` methods - verified method forwarding and HEAD body stripping
- Custom request header forwarding - `x-custom-req` visible in handler
- Multiple response headers with same name - `headers.get()` combines values
- `headers.has()`, `headers.forEach()`, spread/iteration of response headers
- `response.ok`, `response.type`, `response.url`, `response.statusText`, `response.redirected`
- Status codes: 200 (`ok: true`), 201, 400, 500 (`ok: false`), 204 (no-body)
- Body consumption: `.text()`, `.json()`, `.arrayBuffer()`, `.bytes()`, `.blob()`, `.formData()`
- `response.clone()` - independent reads of cloned body
- `bodyUsed` tracking - second `.text()` call throws `TypeError`
- Streaming response consumed via `response.body.getReader()` - verifies `Uint8Array` chunks
- `URLSearchParams` request body and `application/x-www-form-urlencoded` response via `.formData()`
- Binary request and response round-trip - 256-byte 0x00–0xFF sequence preserved byte-for-byte
- Large POST body (8 MiB) - complete round-trip through the protocol handler
- `AbortController.abort()` before fetch - rejects with `AbortError`
- `AbortController.abort()` during body streaming - stream errors with `AbortError`

All 13 tests pass on macOS (both native WKWebView and CEF renderers). Windows and Linux passes require building on those platforms.

### Known limitations

- **Windows WebView2 and Linux WebKitGTK native paths buffer the full response body** before delivery. Streaming `ReadableStream` responses work at the `Protocol.handle()` API level but the browser receives all bytes at once. CEF is not affected.
- **Linux WebKitGTK request body** requires WebKitGTK ≥ 2.40.0. On older versions `request.body` will be `null`.
- **Custom schemes are not hot-reloadable.** Schemes must be declared in `electrobun.config.ts` before app startup; adding schemes at runtime after webviews are created has no effect on the native renderer.

### Test plan

- [x] `bun dev:clean` in `package/` - full native build passes on macOS (arm64)
- [x] `bun run typecheck` in `package/`
- [x] `bun dev` in `package/` - kitchen app boots with `electrobun-test://` scheme active
- [x] All 13 Protocol category tests pass (Run All Automated in kitchen)
- [x] All existing automated tests continue to pass (no regressions in 101 pre-existing tests)
- [ ] Windows native build - verify `nativeWrapper.cpp` compiles with MSVC/clang-cl
- [x] Linux native build - verify `nativeWrapper.cpp` compiles with GCC/clang