### PR TITLE
fix: hiddenInset frameless window on Windows

### DIFF
--- a/package/src/native/shared/callbacks.h
+++ b/package/src/native/shared/callbacks.h
@@ -19,6 +19,9 @@ typedef uint32_t (*HandlePostMessage)(uint32_t webviewId, const char* message);
 typedef const char* (*HandlePostMessageWithReply)(uint32_t webviewId, const char* message);
 typedef void (*AsyncJavascriptCompletionHandler)(const char* messageId, uint32_t webviewId, uint32_t hostWebviewId, const char* responseJSON);
 
+// Window chrome style enum, shared across platforms for titleBarStyle handling
+enum class ChromeStyle : uint32_t { Default, Hidden, HiddenInset };
+
 // Window event callbacks
 typedef void (*WindowCloseHandler)(uint32_t windowId);
 typedef void (*WindowMoveHandler)(uint32_t windowId, double x, double y);

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -4630,6 +4630,7 @@ typedef struct {
     WindowFocusHandler focusHandler;
     WindowBlurHandler blurHandler;
     WindowKeyHandler keyHandler;
+    bool isHiddenInset;
 } WindowData;
 
 
@@ -4767,7 +4768,19 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
     WindowData* data = (WindowData*)GetWindowLongPtr(hwnd, GWLP_USERDATA);
     
     switch (msg) {
-        
+        case WM_NCCALCSIZE:
+            if (wParam == TRUE) {
+                WindowData* data = (WindowData*)GetWindowLongPtr(hwnd, GWLP_USERDATA);
+                if (data && data->isHiddenInset) {
+                    NCCALCSIZE_PARAMS* p = (NCCALCSIZE_PARAMS*)lParam;
+                    RECT original = p->rgrc[0];
+                    LRESULT ret = DefWindowProc(hwnd, msg, wParam, lParam);
+                    p->rgrc[0].top = original.top;
+                    return ret;
+                }
+            }
+            break;
+
         case WM_INPUT: {
             if (g_isMovingWindow && g_targetWindow) {
                 UINT dwSize = 0;
@@ -8598,15 +8611,18 @@ ELECTROBUN_EXPORT HWND createWindowWithFrameAndStyleFromWorker(
         DWORD windowExStyle = WS_EX_APPWINDOW;
 
         // Handle titleBarStyle options
+        data->isHiddenInset = false;
         if (titleBarStyle && strcmp(titleBarStyle, "hidden") == 0) {
             // "hidden" = borderless window (no titlebar, no native controls)
             // This is for completely custom chrome
             windowStyle = WS_POPUP | WS_VISIBLE;
         } else if (titleBarStyle && strcmp(titleBarStyle, "hiddenInset") == 0) {
-            // "hiddenInset" = window with border but custom titlebar area
-            // On Windows, we can't easily do the exact macOS inset style,
-            // so we provide a borderless window with shadow for similar effect
-            windowStyle = WS_POPUP | WS_VISIBLE | WS_THICKFRAME;
+            // "hiddenInset" = frameless window with resize borders and DWM shadow.
+            // We use WS_CAPTION | WS_THICKFRAME so the system treats it as a
+            // standard framed window (giving us shadow and border resizing),
+            // then remove the caption bar area in WM_NCCALCSIZE.
+            windowStyle = WS_VISIBLE | WS_CAPTION | WS_THICKFRAME | WS_CLIPCHILDREN | WS_CLIPSIBLINGS;
+            data->isHiddenInset = true;
         }
         // else: default titleBarStyle = WS_OVERLAPPEDWINDOW (standard window)
 
@@ -8655,6 +8671,13 @@ ELECTROBUN_EXPORT HWND createWindowWithFrameAndStyleFromWorker(
                 }
             }
 
+
+            // Force the window frame to recalculate so WM_NCCALCSIZE
+            // is sent again with isHiddenInset already set.
+            if (data->isHiddenInset) {
+                SetWindowPos(hwnd, NULL, 0, 0, 0, 0,
+                    SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+            }
 
             // Show the window
             ShowWindow(hwnd, SW_SHOW);

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -4630,7 +4630,7 @@ typedef struct {
     WindowFocusHandler focusHandler;
     WindowBlurHandler blurHandler;
     WindowKeyHandler keyHandler;
-    bool isHiddenInset;
+    ChromeStyle chromeStyle;
 } WindowData;
 
 
@@ -4769,7 +4769,7 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
     
     switch (msg) {
         case WM_NCCALCSIZE:
-            if (wParam == TRUE && data && data->isHiddenInset) {
+            if (wParam == TRUE && data && data->chromeStyle == ChromeStyle::HiddenInset) {
                 NCCALCSIZE_PARAMS* p = (NCCALCSIZE_PARAMS*)lParam;
                 RECT original = p->rgrc[0];
                 LRESULT ret = DefWindowProc(hwnd, msg, wParam, lParam);
@@ -8619,7 +8619,7 @@ ELECTROBUN_EXPORT HWND createWindowWithFrameAndStyleFromWorker(
         DWORD windowExStyle = WS_EX_APPWINDOW;
 
         // Handle titleBarStyle options
-        data->isHiddenInset = false;
+        data->chromeStyle = ChromeStyle::Default;
         if (titleBarStyle && strcmp(titleBarStyle, "hidden") == 0) {
             // "hidden" = borderless window (no titlebar, no native controls)
             // This is for completely custom chrome
@@ -8630,7 +8630,7 @@ ELECTROBUN_EXPORT HWND createWindowWithFrameAndStyleFromWorker(
             // standard framed window (giving us shadow and border resizing),
             // then remove the caption bar area in WM_NCCALCSIZE.
             windowStyle = WS_VISIBLE | WS_CAPTION | WS_THICKFRAME | WS_CLIPCHILDREN | WS_CLIPSIBLINGS;
-            data->isHiddenInset = true;
+            data->chromeStyle = ChromeStyle::HiddenInset;
         }
         // else: default titleBarStyle = WS_OVERLAPPEDWINDOW (standard window)
 
@@ -8681,8 +8681,8 @@ ELECTROBUN_EXPORT HWND createWindowWithFrameAndStyleFromWorker(
 
 
             // Force the window frame to recalculate so WM_NCCALCSIZE
-            // is sent again with isHiddenInset already set.
-            if (data->isHiddenInset) {
+            // is sent again with chromeStyle already set.
+            if (data->chromeStyle == ChromeStyle::HiddenInset) {
                 SetWindowPos(hwnd, NULL, 0, 0, 0, 0,
                     SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
             }

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -4769,15 +4769,23 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
     
     switch (msg) {
         case WM_NCCALCSIZE:
-            if (wParam == TRUE) {
-                WindowData* data = (WindowData*)GetWindowLongPtr(hwnd, GWLP_USERDATA);
-                if (data && data->isHiddenInset) {
-                    NCCALCSIZE_PARAMS* p = (NCCALCSIZE_PARAMS*)lParam;
-                    RECT original = p->rgrc[0];
-                    LRESULT ret = DefWindowProc(hwnd, msg, wParam, lParam);
+            if (wParam == TRUE && data && data->isHiddenInset) {
+                NCCALCSIZE_PARAMS* p = (NCCALCSIZE_PARAMS*)lParam;
+                RECT original = p->rgrc[0];
+                LRESULT ret = DefWindowProc(hwnd, msg, wParam, lParam);
+                if (IsZoomed(hwnd)) {
+                    // Maximized: clip client area to monitor work area so
+                    // we still strip the caption bar without pushing content
+                    // above the visible screen.
+                    MONITORINFO mi = { sizeof(MONITORINFO) };
+                    HMONITOR hmon = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+                    if (GetMonitorInfo(hmon, &mi)) {
+                        p->rgrc[0].top = mi.rcWork.top;
+                    }
+                } else {
                     p->rgrc[0].top = original.top;
-                    return ret;
                 }
+                return ret;
             }
             break;
 


### PR DESCRIPTION
problem

on windows, \`titleBarStyle: \"hiddenInset\"\` currently uses \`WS_POPUP | WS_THICKFRAME\`. this leaves a ~2-4px caption bar residue at the top. and another choice \`titleBarStyle: \"hidden\"\` drops the DWM shadow, while resize borders behave inconsistently.

root cause

\`WS_POPUP | WS_THICKFRAME\` tells the window manager to draw a thickframe without a caption, but windows still reserves a small non-client area at the top. without handling \`WM_NCCALCSIZE\`, that residue stays. \`WS_POPUP\` also disables the standard DWM frame entirely.

comparison with other frameworks

| framework | windows hiddenInset approach |
|---|---|
| electron | uses \`WS_THICKFRAME | WS_CAPTION\` + custom \`WM_NCCALCSIZE\` handling via \`DwmDefWindowProc\` / chromium ui layer |
| flutter | sets \`WS_POPUP\` and draws its own shadow/resize handles via skia |
| photino | relies on \`DwmExtendFrameIntoClientArea\` with a full-glass effect |
| tauri/wry | delegates to webview2 defaults; custom chrome is typically borderless with os_shadow disabled |

this patch aligns with the electron approach: keep the system frame for shadow and resize, then surgically remove only the caption area in \`WM_NCCALCSIZE\`.

fix

- switch \`hiddenInset\` style to \`WS_CAPTION | WS_THICKFRAME\`. this keeps the system frame (shadow + resize borders) while giving us a hook to remove the caption area.
- handle \`WM_NCCALCSIZE\` in \`WindowProc\`: call \`DefWindowProc\`, then reset \`rgrc[0].top\` to the original window top. this strips the caption bar height without losing the frame.
- send \`SWP_FRAMECHANGED\` after \`SetWindowLongPtr\` so the non-client area recalculates with the new handler active.

verification

- built and tested in a real app (yandu): window is fully frameless, no top residue, four-edge resize works, DWM shadow is present.
- \`bun test src/shared\` passes (48/48).