### PR TITLE
Display full error messages when the build fails in `electrobun build` or `electrobun dev`.

### DIFF
--- a/package/src/cli/index.ts
+++ b/package/src/cli/index.ts
@@ -1932,9 +1932,7 @@ ${schemesXml}
 		try {
 			await runBuild(config, buildEnvironment);
 		} catch (error) {
-			if (error instanceof Error) {
-				console.error(error.message);
-			}
+			console.error("Build failed:", error);
 			process.exit(1);
 		}
 	} else if (commandArg === "run") {
@@ -1950,9 +1948,7 @@ ${schemesXml}
 			try {
 				await runBuild(config, "dev");
 			} catch (error) {
-				if (error instanceof Error) {
-					console.error(error.message);
-				}
+				console.error("Build failed:", error);
 				process.exit(1);
 			}
 			await runAppWithSignalHandling(config);


### PR DESCRIPTION
`runBuild` can throw other types of errors, e.g. [AggregateError](https://github.com/oven-sh/bun/blob/1afabdde2eb7fe609933b770364611854f8e8dda/src/bundler/bundle_v2.zig#L2275).

Currently those errors are just swallowed, leading to the output of a failed build being:

```
$ electrobun dev
Using config file: electrobun.config.ts
Bundle failed
```

This fix displays the full error by aligning the `dev` and `build` commands with `dev --watch` which [already logs errors in a similar manner](https://github.com/blackboardsh/electrobun/blob/fc3e62da6335845f02d9ed7e5d3d9480c741f08a/package/src/cli/index.ts#L4370):

```
$ electrobun dev
Build failed: 1 | import foo from 'bar';foo();
                    ^
error: Could not resolve: "bar". Maybe you need to "bun install"?
    at /Users/chrismcc/workspace/src/my-hello-world-app/src/bun/index.ts:1:17
```