### PR TITLE
feat(macos): add CEF support to setPageZoom/getPageZoom

### DIFF
--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -6986,6 +6986,14 @@ extern "C" void webviewSetPageZoom(AbstractView *abstractView, double zoomLevel)
                 [wkImpl.webView setNeedsDisplay:YES];
                 [wkImpl.webView setNeedsLayout:YES];
             }
+        } else if ([abstractView isKindOfClass:[CEFWebViewImpl class]]) {
+            CEFWebViewImpl *cefImpl = (CEFWebViewImpl *)abstractView;
+            if (cefImpl.browser && cefImpl.browser->GetHost()) {
+                // CEF zoom is logarithmic (base 1.2): 0.0 = 100%, 1.0 ≈ 120%
+                // Convert linear zoom (1.0 = 100%, 1.5 = 150%) to CEF scale
+                double cefZoomLevel = log(zoomLevel) / log(1.2);
+                cefImpl.browser->GetHost()->SetZoomLevel(cefZoomLevel);
+            }
         }
     });
 }
@@ -7002,6 +7010,22 @@ extern "C" double webviewGetPageZoom(AbstractView *abstractView) {
                     zoomLevel = wkImpl.webView.pageZoom;
                 });
             }
+        }
+    } else if ([abstractView isKindOfClass:[CEFWebViewImpl class]]) {
+        CEFWebViewImpl *cefImpl = (CEFWebViewImpl *)abstractView;
+        if (cefImpl.browser && cefImpl.browser->GetHost()) {
+            double cefZoomLevel;
+            if ([NSThread isMainThread]) {
+                cefZoomLevel = cefImpl.browser->GetHost()->GetZoomLevel();
+            } else {
+                __block double level;
+                dispatch_sync(dispatch_get_main_queue(), ^{
+                    level = cefImpl.browser->GetHost()->GetZoomLevel();
+                });
+                cefZoomLevel = level;
+            }
+            // Convert CEF logarithmic zoom back to linear
+            zoomLevel = pow(1.2, cefZoomLevel);
         }
     }
     return zoomLevel;


### PR DESCRIPTION
## Summary
- `webviewSetPageZoom` and `webviewGetPageZoom` only handled WKWebView, silently doing nothing for CEF views
- Adds CEF zoom via `browser->GetHost()->SetZoomLevel()`/`GetZoomLevel()` with linear-to-logarithmic conversion so the JS API stays consistent across renderers (1.0 = 100%, 1.5 = 150%, etc.)

## Test plan
- [x] Verified CMD+=/CMD- zoom in/out works on CEF BrowserWindow
- [x] Verified CMD+0 resets to 100%
- [x] Verified zoom bounds (0.5x–2.0x) are respected
- [x] Verified no regression for WKWebView zoom

🤖 Generated with [Claude Code](https://claude.com/claude-code)