### PR TITLE
Fix `openFileDialog` for files that have commas in their filename.

### DIFF
--- a/package/src/bun/core/Utils.ts
+++ b/package/src/bun/core/Utils.ts
@@ -187,7 +187,7 @@ export const openFileDialog = async (
 		allowsMultipleSelection: optsWithDefault.allowsMultipleSelection,
 	});
 
-	const filePaths = result.split(",");
+	const filePaths = result.split("\x1C");
 	return filePaths;
 };
 

--- a/package/src/native/linux/nativeWrapper.cpp
+++ b/package/src/native/linux/nativeWrapper.cpp
@@ -8508,7 +8508,7 @@ ELECTROBUN_EXPORT const char* openFileDialog(const char* startingFolder, const c
                 
                 while (iter != nullptr) {
                     if (!resultString.empty()) {
-                        resultString += ","; // Separate multiple files with comma (like Mac)
+                        resultString += "\x1C"; // ASCII File Separator; safe for filenames (commas are legal in paths)
                     }
                     resultString += (char*)iter->data;
                     g_free(iter->data);

--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -7565,14 +7565,14 @@ extern "C" const char *openFileDialog(const char *startingFolder,
                 
         result = [panel runModal]; // Run the modal dialog on the main thread        
         
-        if (result == NSModalResponseOK) {            
+        if (result == NSModalResponseOK) {
             NSArray<NSURL *> *selectedFileURLs = [panel URLs];
             NSMutableArray<NSString *> *pathStrings = [NSMutableArray array];
             for (NSURL *u in selectedFileURLs) {
                 [pathStrings addObject:u.path];
             }
-            concatenatedPaths = [pathStrings componentsJoinedByString:@","];
-        }        
+            concatenatedPaths = [pathStrings componentsJoinedByString:@"\x1C"];
+        }
     });
     
     // Return the result after the dispatch_sync completes

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -10033,9 +10033,9 @@ ELECTROBUN_EXPORT const char* openFileDialog(const char *startingFolder,
                 }
                 pShellItemArray->Release();
                 
-                // Join paths with comma
+                // Join paths with ASCII File Separator (commas are legal in filenames)
                 for (size_t i = 0; i < paths.size(); i++) {
-                    if (i > 0) result += ",";
+                    if (i > 0) result += "\x1C";
                     result += paths[i];
                 }
             }


### PR DESCRIPTION
Currently, if you select a file with a comma in it via `openFileDialog`, you'll get an array like `["file", "with comma.png"]` even though the user only selected a single file `file, with comma.png`.

This fixes that by changing the joiner from `,` to `\x1C`, which is a [C0 Control Character](https://en.wikipedia.org/wiki/C0_and_C1_control_codes#Field_separators) for File Separator, unlikely to be in a filename.

A more "proper" fix would be to use an encoding like JSON, but that is non-trivial particularly on platforms like linux (unless you know some tricks I don't!)