### PR TITLE
Improve contributor UX: watchIgnore, compile_flags, and release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,27 +272,8 @@ jobs:
           tag_name: ${{ github.event.inputs.tag || github.ref_name }}
           files: |
             artifacts/**/*.tar.gz
-          generate_release_notes: false
+          generate_release_notes: true
           prerelease: ${{ github.event.inputs.prerelease || contains(github.ref_name, '-beta') || contains(github.event.inputs.tag, '-beta') }}
-          body: |
-            ## Getting Started
-
-            To build apps with Electrobun, add it as a dependency in your package.json:
-
-            ```bash
-            bun add electrobun
-            ```
-
-            The Electrobun CLI will automatically download these artifacts when you build your app. You don't need to download them directly.
-
-            See the [documentation](https://blackboard.sh/electrobun/docs/guides/quick-start/) for more information.
-
-            ---
-
-            **Artifact Reference** (downloaded automatically by the CLI):
-            - `electrobun-cli-[platform]-[arch].tar.gz` - CLI tools
-            - `electrobun-core-[platform]-[arch].tar.gz` - Core binaries
-            - `electrobun-cef-[platform]-[arch].tar.gz` - CEF binaries (optional)
 
   npm-publish:
     needs: release

--- a/package/build.ts
+++ b/package/build.ts
@@ -1954,19 +1954,19 @@ async function buildNative() {
 					pkgConfigCflags = `-I/usr/include/gtk-3.0 -I/usr/include/webkit2gtk-4.1 -I/usr/include/glib-2.0 -I/usr/lib/${arch}-linux-gnu/glib-2.0/include -I/usr/include/pango-1.0 -I/usr/include/cairo -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/atk-1.0`;
 					pkgConfigLibs = "-lgtk-3 -lwebkit2gtk-4.1 -lglib-2.0 -lgobject-2.0";
 				}
-				}
+			}
 
-				writeCompileFlagsTxt([
-					"-std=c++20",
-					"-fPIC",
-					...pkgConfigCflags.split(/\s+/).filter((f) => f),
-					`-I${cefInclude}`,
-					...(existsSync(wgpuIncludeDir) ? [`-I${wgpuIncludeDir}`] : []),
-					...(hasAppIndicator ? [] : ["-DNO_APPINDICATOR"]),
-				]);
+			writeCompileFlagsTxt([
+				"-std=c++20",
+				"-fPIC",
+				...pkgConfigCflags.split(/\s+/).filter((f) => f),
+				`-I${cefInclude}`,
+				...(existsSync(wgpuIncludeDir) ? [`-I${wgpuIncludeDir}`] : []),
+				...(hasAppIndicator ? [] : ["-DNO_APPINDICATOR"]),
+			]);
 
-				// Compile the main wrapper with WebKitGTK, AppIndicator, and CEF headers
-				await $`mkdir -p src/native/linux/build`;
+			// Compile the main wrapper with WebKitGTK, AppIndicator, and CEF headers
+			await $`mkdir -p src/native/linux/build`;
 			console.log(
 				"Compiling with flags:",
 				pkgConfigCflags ? "pkg-config flags present" : "NO FLAGS!",

--- a/package/build.ts
+++ b/package/build.ts
@@ -92,6 +92,13 @@ function validateDownload(filePath: string, type: string): void {
 	}
 }
 
+function writeCompileFlagsTxt(flags: string[]) {
+	const compileFlagsPath = join(process.cwd(), "src", "native", "compile_flags.txt");
+	const uniqueFlags = Array.from(new Set(flags.map((f) => f.trim()).filter(Boolean)));
+	writeFileSync(compileFlagsPath, `${uniqueFlags.join("\n")}\n`, "utf-8");
+	console.log(`Wrote clangd flags to ${compileFlagsPath}`);
+}
+
 // Pause between GitHub downloads to avoid rate limiting
 // Track if we've done a GitHub download this session
 let lastGitHubDownload = 0;
@@ -1793,6 +1800,13 @@ async function buildNative() {
 		const wgpuIncludeFlag = existsSync(wgpuIncludeDir)
 			? `-I${wgpuIncludeDir}`
 			: "";
+		writeCompileFlagsTxt([
+			"-std=c++20",
+			"-fobjc-arc",
+			"-fno-objc-msgsend-selector-stubs",
+			`-I${join(process.cwd(), "vendors", "cef")}`,
+			...(wgpuIncludeFlag ? [wgpuIncludeFlag] : []),
+		]);
 		await $`mkdir -p src/native/macos/build && xcrun --sdk macosx clang++ -c src/native/macos/nativeWrapper.mm -o src/native/macos/build/nativeWrapper.o -fobjc-arc -fno-objc-msgsend-selector-stubs -I./vendors/cef ${wgpuIncludeFlag} -std=c++20`;
 		await $`mkdir -p src/native/build && xcrun --sdk macosx clang++ -o src/native/build/libNativeWrapper.dylib src/native/macos/build/nativeWrapper.o ./vendors/zig-asar/libasar.dylib -framework Cocoa -framework WebKit -framework QuartzCore -framework Metal -framework MetalKit -framework UserNotifications -F./vendors/cef/Release -weak_framework 'Chromium Embedded Framework' -L./vendors/cef/build/libcef_dll_wrapper -lcef_dll_wrapper -stdlib=libc++ -shared -install_name @executable_path/libNativeWrapper.dylib -Wl,-rpath,@executable_path`;
 	} else if (OS === "win") {
@@ -1814,6 +1828,13 @@ async function buildNative() {
 		const wgpuIncludeFlag = existsSync(wgpuIncludeDir)
 			? `/I"${wgpuIncludeDir}"`
 			: "";
+		writeCompileFlagsTxt([
+			"-std=c++20",
+			"-DNOMINMAX",
+			`-I${join(process.cwd(), "vendors", "webview2", "Microsoft.Web.WebView2", "build", "native", "include")}`,
+			`-I${join(process.cwd(), "vendors", "cef")}`,
+			...(existsSync(wgpuIncludeDir) ? [`-I${wgpuIncludeDir}`] : []),
+		]);
 
 		// Dawn native lib for zero-copy DComp bridge (D3D11On12 interop)
 		const wgpuLibDir = join(
@@ -1933,10 +1954,19 @@ async function buildNative() {
 					pkgConfigCflags = `-I/usr/include/gtk-3.0 -I/usr/include/webkit2gtk-4.1 -I/usr/include/glib-2.0 -I/usr/lib/${arch}-linux-gnu/glib-2.0/include -I/usr/include/pango-1.0 -I/usr/include/cairo -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/atk-1.0`;
 					pkgConfigLibs = "-lgtk-3 -lwebkit2gtk-4.1 -lglib-2.0 -lgobject-2.0";
 				}
-			}
+				}
 
-			// Compile the main wrapper with WebKitGTK, AppIndicator, and CEF headers
-			await $`mkdir -p src/native/linux/build`;
+				writeCompileFlagsTxt([
+					"-std=c++20",
+					"-fPIC",
+					...pkgConfigCflags.split(/\s+/).filter((f) => f),
+					`-I${cefInclude}`,
+					...(existsSync(wgpuIncludeDir) ? [`-I${wgpuIncludeDir}`] : []),
+					...(hasAppIndicator ? [] : ["-DNO_APPINDICATOR"]),
+				]);
+
+				// Compile the main wrapper with WebKitGTK, AppIndicator, and CEF headers
+				await $`mkdir -p src/native/linux/build`;
 			console.log(
 				"Compiling with flags:",
 				pkgConfigCflags ? "pkg-config flags present" : "NO FLAGS!",

--- a/package/src/cli/index.ts
+++ b/package/src/cli/index.ts
@@ -1936,24 +1936,47 @@ ${utiDecls}
 (async () => {
 	if (commandArg === "init") {
 		await (async () => {
-			const secondArg = process.argv[indexOfElectrobun + 2];
 			const availableTemplates = getTemplateNames();
+			const initArgs = process.argv.slice(indexOfElectrobun + 2);
 
 			let projectName: string;
 			let templateName: string;
+			let templateNameFromFlag: string | undefined;
+			const positionalArgs: string[] = [];
 
-			// Check if --template= flag is used
-			const templateFlag = process.argv.find((arg) =>
-				arg.startsWith("--template="),
-			);
-			if (templateFlag) {
-				// Traditional usage: electrobun init my-project --template=photo-booth
-				projectName = secondArg || "my-electrobun-app";
-				templateName = templateFlag.split("=")[1]!;
-			} else if (secondArg && availableTemplates.includes(secondArg)) {
-				// New intuitive usage: electrobun init photo-booth
-				projectName = secondArg; // Use template name as project name
-				templateName = secondArg;
+			// Support both --template=photo-booth and --template photo-booth (-t photo-booth)
+			for (let i = 0; i < initArgs.length; i++) {
+				const arg = initArgs[i];
+				if (!arg) continue;
+				if (arg.startsWith("--template=")) {
+					templateNameFromFlag = arg.slice("--template=".length);
+					continue;
+				}
+				if (arg === "--template" || arg === "-t") {
+					const nextArg = initArgs[i + 1];
+					if (nextArg && !nextArg.startsWith("-")) {
+						templateNameFromFlag = nextArg;
+						i++;
+					}
+					continue;
+				}
+				if (!arg.startsWith("-")) {
+					positionalArgs.push(arg);
+				}
+			}
+
+			if (templateNameFromFlag) {
+				// Traditional usage:
+				// - electrobun init my-project --template=photo-booth
+				// - electrobun init my-project --template photo-booth
+				projectName = positionalArgs[0] || `my-${templateNameFromFlag}-app`;
+				templateName = templateNameFromFlag;
+			} else if (positionalArgs[0] && availableTemplates.includes(positionalArgs[0])) {
+				// Intuitive usage:
+				// - electrobun init photo-booth
+				// - electrobun init photo-booth my-project
+				templateName = positionalArgs[0];
+				projectName = positionalArgs[1] || templateName;
 			} else {
 				// Interactive menu when no template specified
 				console.log("🚀 Welcome to Electrobun!");
@@ -1995,10 +2018,10 @@ ${utiDecls}
 
 				projectName = await new Promise<string>((resolve) => {
 					rl2.question(
-						`Enter project name (default: my-${templateName}-app): `,
+						`Enter project name (default: ${positionalArgs[0] || `my-${templateName}-app`}): `,
 						(answer) => {
 							rl2.close();
-							resolve(answer.trim() || `my-${templateName}-app`);
+							resolve(answer.trim() || positionalArgs[0] || `my-${templateName}-app`);
 						},
 					);
 				});
@@ -4537,7 +4560,15 @@ usageDescriptions : ""}${urlTypes ? "\n" + urlTypes : ""}${documentTypes ?
 			}
 			// Check user-configured watchIgnore globs (match against project-relative path)
 			const relativePath = fullPath.replace(projectRoot + "/", "");
-			if (ignoreGlobs.some((glob) => glob.match(relativePath))) {
+			// Bun watch may report directory changes as "src" while users configure "src/**".
+			// Try both plain and trailing-slash forms to make directory globs behave as expected.
+			const candidatePaths =
+				relativePath.endsWith("/") ? [relativePath] : [relativePath, `${relativePath}/`];
+			if (
+				ignoreGlobs.some((glob) =>
+					candidatePaths.some((candidate) => glob.match(candidate)),
+				)
+			) {
 				return true;
 			}
 			return false;


### PR DESCRIPTION
## Summary
- fix `dev --watch` ignore behavior when Bun emits directory-level paths (e.g. `src`) so patterns like `src/**` work as expected
- generate `src/native/compile_flags.txt` during native builds for clangd/editor support across macOS/Windows/Linux
- enable generated GitHub release notes instead of a static repeated release body
- expand `electrobun init` template parsing to support `--template foo`, `-t foo`, and `init <template> <project>`

## Why
- addresses reported watch-ignore mismatch behavior (#378)
- implements requested clangd support path (#225)
- improves release feed readability based on issue feedback (#366)

## Validation
- verified Bun glob behavior (`src/**` does not match `src`, but does match `src/`) and updated matching accordingly
- tested init flows:
  - `electrobun init --template hello-world`
  - `electrobun init sample-a -t hello-world`
  - `electrobun init hello-world sample-b`
- validated updated files parse/build via Bun build API for changed TS entrypoints
