### PR TITLE
Add dedicated export paths for webview element types

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ Don't miss our:
 - Our `<electrobun-webview>` and `<electrobun-wpgu>` html elements that let you composit proper OOPIFs and native GPU surfaces into your UIs
 - so much more.
 
+### Webview TypeScript Types
+
+If you want explicit typing for custom elements in renderer code, import the type directly:
+
+```ts
+import type { WebviewTagElement } from "electrobun/webview";
+
+const webview = document.querySelector("electrobun-webview") as WebviewTagElement;
+webview.toggleHidden(false);
+```
+
 **Project Goals**
 
 - Write typescript for the main process and webviews without having to think about it.

--- a/package/package.json
+++ b/package/package.json
@@ -15,6 +15,8 @@
 		".": "./dist/api/bun/index.ts",
 		"./bun": "./dist/api/bun/index.ts",
 		"./view": "./dist/api/browser/index.ts",
+		"./webview": "./dist/api/browser/webviewtag.ts",
+		"./wgpu-view": "./dist/api/browser/wgputag.ts",
 		"./carrot": "./dist/api/carrot/bun.ts"
 	},
 	"type": "module",


### PR DESCRIPTION
## Summary
- add dedicated package export paths for webview element typing:
  - `electrobun/webview` -> `WebviewTagElement` types
  - `electrobun/wgpu-view` -> WGPU custom element types
- add README usage snippet showing typed `electrobun-webview` access in renderer code

## Why
This lowers friction for users looking for importable custom-element types and makes the intended type import path explicit.

Related: #377

## Validation
- verified `package/package.json` remains valid JSON
- verified export targets exist in the published API layout under `dist/api/browser/`
