### PR TITLE
Export RESOURCES_FOLDER and VIEWS_FOLDER directly from bun API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ Don't miss our:
 - Our `<electrobun-webview>` and `<electrobun-wpgu>` html elements that let you composit proper OOPIFs and native GPU surfaces into your UIs
 - so much more.
 
+### App Paths Helpers
+
+You can access app resource paths through either `PATHS` or direct named exports:
+
+```ts
+import { PATHS, RESOURCES_FOLDER, VIEWS_FOLDER } from "electrobun/bun";
+
+console.log(PATHS.RESOURCES_FOLDER, RESOURCES_FOLDER);
+console.log(PATHS.VIEWS_FOLDER, VIEWS_FOLDER);
+```
+
 **Project Goals**
 
 - Write typescript for the main process and webviews without having to think about it.

--- a/package/src/bun/index.ts
+++ b/package/src/bun/index.ts
@@ -26,6 +26,7 @@ import {
 } from "../shared/rpc.js";
 import type ElectrobunEvent from "./events/event";
 import * as PATHS from "./core/Paths";
+import { RESOURCES_FOLDER, VIEWS_FOLDER } from "./core/Paths";
 import * as Socket from "./core/Socket";
 import WGPU from "./webGPU";
 import webgpu from "./webgpuAdapter";
@@ -220,6 +221,8 @@ export {
 	ApplicationMenu,
 	ContextMenu,
 	PATHS,
+	RESOURCES_FOLDER,
+	VIEWS_FOLDER,
 	Socket,
 	WGPU,
 	webgpu,
@@ -252,6 +255,8 @@ const Electrobun = {
 	BuildConfig,
 	events: electobunEventEmmitter,
 	PATHS,
+	RESOURCES_FOLDER,
+	VIEWS_FOLDER,
 	Socket,
 	WGPU,
 	webgpu,


### PR DESCRIPTION
## Summary
- export `RESOURCES_FOLDER` and `VIEWS_FOLDER` directly from `electrobun/bun` in addition to the existing `PATHS` namespace
- keep `PATHS` behavior unchanged for backward compatibility
- add README usage snippet showing both access styles

## Why
This reduces friction when users expect these path constants to be directly accessible and makes path usage clearer in docs.

Related: #344

## Validation
- verified `src/bun/index.ts` compiles via Bun build API
- confirmed both named exports and `PATHS.*` exports coexist
