### PR TITLE
Implement setPageZoom/getPageZoom across platforms and engines

### DIFF
--- a/package/src/bun/core/BrowserView.ts
+++ b/package/src/bun/core/BrowserView.ts
@@ -282,7 +282,7 @@ export class BrowserView<T extends RPCWithTransport = RPCWithTransport> {
 	}
 
 	/**
-	 * Set the page zoom level (WebKit only, similar to browser zoom).
+	 * Set the page zoom level (best-effort across WebKit/CEF/WebView2).
 	 * @param zoomLevel - The zoom level (1.0 = 100%, 1.5 = 150%, etc.)
 	 */
 	setPageZoom(zoomLevel: number) {

--- a/package/src/bun/core/BrowserWindow.ts
+++ b/package/src/bun/core/BrowserWindow.ts
@@ -386,7 +386,7 @@ export class BrowserWindow<T extends RPCWithTransport = RPCWithTransport> {
 	}
 
 	/**
-	 * Set the page zoom level for the window's webview (WebKit only).
+	 * Set the page zoom level for the window's webview (best-effort across engines).
 	 * @param zoomLevel - The zoom level (1.0 = 100%, 1.5 = 150%, etc.)
 	 */
 	setPageZoom(zoomLevel: number) {

--- a/package/src/native/linux/nativeWrapper.cpp
+++ b/package/src/native/linux/nativeWrapper.cpp
@@ -8116,12 +8116,42 @@ ELECTROBUN_EXPORT void webviewToggleDevTools(AbstractView* abstractView) {
 }
 
 ELECTROBUN_EXPORT void webviewSetPageZoom(AbstractView* abstractView, double zoomLevel) {
-    // pageZoom is WebKit-specific, not available on Linux CEF
-    // TODO: implement CEF zoom if needed
+    if (!abstractView || zoomLevel <= 0.0) return;
+
+    if (auto* webkitImpl = dynamic_cast<WebKitWebViewImpl*>(abstractView)) {
+        if (webkitImpl->webview) {
+            webkit_web_view_set_zoom_level(WEBKIT_WEB_VIEW(webkitImpl->webview), zoomLevel);
+        }
+        return;
+    }
+
+    if (auto* cefImpl = dynamic_cast<CEFWebViewImpl*>(abstractView)) {
+        if (cefImpl->browser && cefImpl->browser->GetHost()) {
+            // CEF zoom is logarithmic in 1.2x steps; convert from web-style factor.
+            const double cefZoomLevel = std::log(zoomLevel) / std::log(1.2);
+            cefImpl->browser->GetHost()->SetZoomLevel(cefZoomLevel);
+        }
+    }
 }
 
 ELECTROBUN_EXPORT double webviewGetPageZoom(AbstractView* abstractView) {
-    // pageZoom is WebKit-specific, not available on Linux CEF
+    if (!abstractView) return 1.0;
+
+    if (auto* webkitImpl = dynamic_cast<WebKitWebViewImpl*>(abstractView)) {
+        if (webkitImpl->webview) {
+            return webkit_web_view_get_zoom_level(WEBKIT_WEB_VIEW(webkitImpl->webview));
+        }
+        return 1.0;
+    }
+
+    if (auto* cefImpl = dynamic_cast<CEFWebViewImpl*>(abstractView)) {
+        if (cefImpl->browser && cefImpl->browser->GetHost()) {
+            const double cefZoomLevel = cefImpl->browser->GetHost()->GetZoomLevel();
+            return std::pow(1.2, cefZoomLevel);
+        }
+        return 1.0;
+    }
+
     return 1.0;
 }
 

--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -7126,6 +7126,7 @@ extern "C" void webviewToggleDevTools(AbstractView *abstractView) {
 }
 
 extern "C" void webviewSetPageZoom(AbstractView *abstractView, double zoomLevel) {
+    if (!abstractView || zoomLevel <= 0.0) return;
     dispatch_async(dispatch_get_main_queue(), ^{
         if ([abstractView isKindOfClass:[WKWebViewImpl class]]) {
             WKWebViewImpl *wkImpl = (WKWebViewImpl *)abstractView;
@@ -7133,6 +7134,16 @@ extern "C" void webviewSetPageZoom(AbstractView *abstractView, double zoomLevel)
                 wkImpl.webView.pageZoom = zoomLevel;
                 [wkImpl.webView setNeedsDisplay:YES];
                 [wkImpl.webView setNeedsLayout:YES];
+            }
+            return;
+        }
+
+        if ([abstractView isKindOfClass:[CEFWebViewImpl class]]) {
+            CEFWebViewImpl *cefImpl = (CEFWebViewImpl *)abstractView;
+            if (cefImpl.browser && cefImpl.browser->GetHost()) {
+                // CEF zoom is logarithmic in 1.2x steps; convert from web-style factor.
+                const double cefZoomLevel = log(zoomLevel) / log(1.2);
+                cefImpl.browser->GetHost()->SetZoomLevel(cefZoomLevel);
             }
         }
     });
@@ -7150,6 +7161,19 @@ extern "C" double webviewGetPageZoom(AbstractView *abstractView) {
                     zoomLevel = wkImpl.webView.pageZoom;
                 });
             }
+        }
+    } else if ([abstractView isKindOfClass:[CEFWebViewImpl class]]) {
+        CEFWebViewImpl *cefImpl = (CEFWebViewImpl *)abstractView;
+        if (cefImpl.browser && cefImpl.browser->GetHost()) {
+            __block double cefZoomLevel = 0.0;
+            if ([NSThread isMainThread]) {
+                cefZoomLevel = cefImpl.browser->GetHost()->GetZoomLevel();
+            } else {
+                dispatch_sync(dispatch_get_main_queue(), ^{
+                    cefZoomLevel = cefImpl.browser->GetHost()->GetZoomLevel();
+                });
+            }
+            zoomLevel = pow(1.2, cefZoomLevel);
         }
     }
     return zoomLevel;

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -11,6 +11,7 @@
 #include <fstream>
 #include <sstream>
 #include <ctime>
+#include <cmath>
 #include <chrono>
 #include <functional>
 #include <future>
@@ -9123,12 +9124,53 @@ ELECTROBUN_EXPORT void webviewToggleDevTools(AbstractView *abstractView) {
 }
 
 ELECTROBUN_EXPORT void webviewSetPageZoom(AbstractView *abstractView, double zoomLevel) {
-    // pageZoom is WebKit-specific, not available on Windows
-    // TODO: implement WebView2 zoom if needed
+    if (!abstractView || zoomLevel <= 0.0) return;
+
+    MainThreadDispatcher::dispatch_sync([abstractView, zoomLevel]() {
+        if (auto* webview2Impl = dynamic_cast<WebView2View*>(abstractView)) {
+            ComPtr<ICoreWebView2Controller> controller = webview2Impl->getController();
+            if (controller) {
+                controller->put_ZoomFactor(zoomLevel);
+            }
+            return;
+        }
+
+        if (auto* cefImpl = dynamic_cast<CEFView*>(abstractView)) {
+            CefRefPtr<CefBrowser> browser = cefImpl->getBrowser();
+            if (browser && browser->GetHost()) {
+                // CEF zoom is logarithmic in 1.2x steps; convert from web-style factor.
+                const double cefZoomLevel = std::log(zoomLevel) / std::log(1.2);
+                browser->GetHost()->SetZoomLevel(cefZoomLevel);
+            }
+        }
+    });
 }
 
 ELECTROBUN_EXPORT double webviewGetPageZoom(AbstractView *abstractView) {
-    // pageZoom is WebKit-specific, not available on Windows
+    if (!abstractView) return 1.0;
+
+    if (auto* webview2Impl = dynamic_cast<WebView2View*>(abstractView)) {
+        double zoomFactor = 1.0;
+        MainThreadDispatcher::dispatch_sync([webview2Impl, &zoomFactor]() {
+            ComPtr<ICoreWebView2Controller> controller = webview2Impl->getController();
+            if (controller) {
+                controller->get_ZoomFactor(&zoomFactor);
+            }
+        });
+        return zoomFactor;
+    }
+
+    if (auto* cefImpl = dynamic_cast<CEFView*>(abstractView)) {
+        double cefZoomLevel = 0.0;
+        MainThreadDispatcher::dispatch_sync([cefImpl, &cefZoomLevel]() {
+            CefRefPtr<CefBrowser> browser = cefImpl->getBrowser();
+            if (browser && browser->GetHost()) {
+                cefZoomLevel = browser->GetHost()->GetZoomLevel();
+            }
+        });
+        return std::pow(1.2, cefZoomLevel);
+    }
+
     return 1.0;
 }
 


### PR DESCRIPTION
## Summary
- implement `webviewSetPageZoom` / `webviewGetPageZoom` on:
  - Windows WebView2 (`ZoomFactor`)
  - Windows CEF (`SetZoomLevel`/`GetZoomLevel` with conversion)
  - Linux WebKitGTK (`webkit_web_view_set/get_zoom_level`)
  - Linux CEF (`SetZoomLevel`/`GetZoomLevel` with conversion)
  - macOS CEF (`SetZoomLevel`/`GetZoomLevel` with conversion)
- keep API semantics consistent with existing TS docs (`1.0 = 100%`) by converting CEF zoom levels to/from factor form
- update TS comments to reflect best-effort cross-engine support

## Why
This addresses the gap where zoom APIs existed but returned no-op/default behavior on multiple OS/engine combinations.

Related: #381

## Notes
CEF internally uses logarithmic zoom steps (`1.2^level`), so this PR maps:
- factor -> level via `log(factor)/log(1.2)`
- level -> factor via `pow(1.2, level)`

## Validation
- focused source-level verification on all native wrapper paths above
- TS-only spot check attempted; repo-level pre-existing top-level-await/require interaction prevents isolated Bun.build entrypoint check unrelated to this change
