### PR TITLE
Add BrowserWindow.isVisible() with native visibility checks

### DIFF
--- a/package/src/bun/core/BrowserWindow.ts
+++ b/package/src/bun/core/BrowserWindow.ts
@@ -299,6 +299,10 @@ export class BrowserWindow<T extends RPCWithTransport = RPCWithTransport> {
 		return ffi.request.hideWindow({ winId: this.id });
 	}
 
+	isVisible(): boolean {
+		return ffi.request.isWindowVisible({ winId: this.id });
+	}
+
 	minimize() {
 		return ffi.request.minimizeWindow({ winId: this.id });
 	}

--- a/package/src/bun/proc/native.ts
+++ b/package/src/bun/proc/native.ts
@@ -132,6 +132,10 @@ export const native = (() => {
 				args: [FFIType.ptr],
 				returns: FFIType.void,
 			},
+			isWindowVisible: {
+				args: [FFIType.ptr],
+				returns: FFIType.bool,
+			},
 			closeWindow: {
 				args: [
 					FFIType.ptr, // window ptr
@@ -987,6 +991,17 @@ const _ffiImpl = {
 			}
 
 			native.symbols.hideWindow(windowPtr);
+		},
+
+		isWindowVisible: (params: { winId: number }): boolean => {
+			const { winId } = params;
+			const windowPtr = getWindowPtr(winId);
+
+			if (!windowPtr) {
+				return false;
+			}
+
+			return native_.symbols.isWindowVisible(windowPtr);
 		},
 
 		minimizeWindow: (params: { winId: number }) => {

--- a/package/src/native/linux/nativeWrapper.cpp
+++ b/package/src/native/linux/nativeWrapper.cpp
@@ -6474,6 +6474,23 @@ ELECTROBUN_EXPORT void hideWindow(void* window) {
     }
 }
 
+ELECTROBUN_EXPORT bool isWindowVisible(void* window) {
+    if (!window) return false;
+
+    if (isCEFAvailable()) {
+        X11Window* x11win = static_cast<X11Window*>(window);
+        if (!x11win || !x11win->display || !x11win->window) return false;
+
+        XWindowAttributes attrs;
+        if (XGetWindowAttributes(x11win->display, x11win->window, &attrs) == 0) {
+            return false;
+        }
+        return attrs.map_state == IsViewable;
+    }
+
+    return gtk_widget_get_visible(GTK_WIDGET(window));
+}
+
 // Cross-platform compatible function for Linux - return dummy style mask
 ELECTROBUN_EXPORT uint32_t getWindowStyle(bool borderless, bool titled, bool closable, bool miniaturizable,
                         bool resizable, bool unifiedTitleAndToolbar, bool fullScreen,

--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -7339,6 +7339,14 @@ extern "C" void hideWindow(NSWindow *window) {
     });
 }
 
+extern "C" bool isWindowVisible(NSWindow *window) {
+    __block bool visible = false;
+    dispatch_sync(dispatch_get_main_queue(), ^{
+        visible = [window isVisible];
+    });
+    return visible;
+}
+
 extern "C" void setWindowTitle(NSWindow *window, const char *title) {
     NSString *titleString = [NSString stringWithUTF8String:title ?: ""];
 

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -9376,6 +9376,14 @@ ELECTROBUN_EXPORT void hideWindow(void *window) {
     });
 }
 
+ELECTROBUN_EXPORT bool isWindowVisible(void *window) {
+    HWND hwnd = reinterpret_cast<HWND>(window);
+    if (!IsWindow(hwnd)) {
+        return false;
+    }
+    return IsWindowVisible(hwnd) != FALSE;
+}
+
 ELECTROBUN_EXPORT void setWindowTitle(NSWindow *window, const char *title) {
     // On Windows, NSWindow* is actually HWND
     HWND hwnd = reinterpret_cast<HWND>(window);


### PR DESCRIPTION
## Summary
- add new `BrowserWindow.isVisible(): boolean` API in Bun layer
- wire through FFI (`isWindowVisible`) and request handler
- implement native `isWindowVisible` for:
  - macOS: `[NSWindow isVisible]`
  - Windows: `IsWindowVisible(hwnd)`
  - Linux GTK: `gtk_widget_get_visible(...)`
  - Linux CEF/X11 path: `XGetWindowAttributes(...).map_state == IsViewable`

## Why
`BrowserWindow` already has `show()`/`hide()`, but lacked a direct visibility query method useful for launcher/panel workflows.

Related: #328

## Validation
- TS build check for touched Bun entrypoints completed successfully
  - `src/bun/proc/native.ts`
  - `src/bun/core/BrowserWindow.ts`
