### PR TITLE
feat(macos): Dock menu, badge label, and progress overlay

### DIFF
--- a/kitchen/src/tests/dock-api.test.ts
+++ b/kitchen/src/tests/dock-api.test.ts
@@ -1,0 +1,96 @@
+import { defineTest, expect } from "../test-framework/types";
+import { Dock } from "electrobun/bun";
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Dock APIs are macOS-only — on Linux and Windows the native layer stubs them
+// to no-op. These tests therefore verify the contract (calls are safe to make
+// everywhere, no throw) rather than observable UI effects.
+export const dockApiTests = [
+  defineTest({
+    name: "Dock.setMenu accepts configs and clears",
+    category: "Dock",
+    description: "Dock.setMenu should accept a menu array and an empty array without throwing",
+    timeout: 8000,
+    async run({ log }) {
+      Dock.setMenu([
+        { type: "normal", label: "Play", action: "toggle" },
+        { type: "normal", label: "Next", action: "next" },
+        { type: "divider" },
+        { type: "normal", label: "Show", action: "show" },
+      ]);
+      await wait(100);
+
+      Dock.setMenu([]);
+      await wait(100);
+
+      Dock.setMenu([
+        { type: "normal", label: "Single", action: "only" },
+      ]);
+      await wait(100);
+
+      log(
+        process.platform === "darwin"
+          ? "setMenu calls dispatched to NSApp.applicationDockMenu"
+          : `setMenu is a no-op on ${process.platform} (stub behavior)`,
+      );
+    },
+  }),
+
+  defineTest({
+    name: "Dock.setBadge accepts strings and clears",
+    category: "Dock",
+    description: "Dock.setBadge should accept text, null, and empty string without throwing",
+    timeout: 6000,
+    async run({ log }) {
+      Dock.setBadge("3");
+      await wait(50);
+      Dock.setBadge("♪"); // ♪
+      await wait(50);
+      Dock.setBadge(null);
+      await wait(50);
+      Dock.setBadge("");
+      await wait(50);
+      Dock.setBadge(undefined);
+      await wait(50);
+
+      log(
+        process.platform === "darwin"
+          ? "badge label updated via NSDockTile"
+          : `setBadge is a no-op on ${process.platform} (stub behavior)`,
+      );
+      expect(true).toBe(true);
+    },
+  }),
+
+  defineTest({
+    name: "Dock.setProgress accepts values and clears",
+    category: "Dock",
+    description: "Dock.setProgress should accept [0,1], null, and negative values without throwing",
+    timeout: 6000,
+    async run({ log }) {
+      Dock.setProgress(0);
+      await wait(50);
+      Dock.setProgress(0.42);
+      await wait(50);
+      Dock.setProgress(1);
+      await wait(50);
+      Dock.setProgress(null);
+      await wait(50);
+      Dock.setProgress(undefined);
+      await wait(50);
+      // Out-of-range values should be clamped natively, not throw.
+      Dock.setProgress(2);
+      await wait(50);
+      Dock.setProgress(-0.5);
+      await wait(50);
+
+      log(
+        process.platform === "darwin"
+          ? "progress overlay redraws via NSDockTile"
+          : `setProgress is a no-op on ${process.platform} (stub behavior)`,
+      );
+      expect(true).toBe(true);
+    },
+  }),
+];

--- a/kitchen/src/tests/index.ts
+++ b/kitchen/src/tests/index.ts
@@ -18,6 +18,7 @@ import { preloadTests } from "./preload.test";
 import { updaterTests } from "./updater.test";
 import { sandboxTests } from "./sandbox.test";
 import { trayApiTests } from "./tray-api.test";
+import { dockApiTests } from "./dock-api.test";
 
 // Interactive tests
 import { dialogTests } from "./interactive/dialogs.test";
@@ -50,6 +51,7 @@ export const allTests: TestDefinition[] = [
   ...updaterTests,
   ...sandboxTests,
   ...trayApiTests,
+  ...dockApiTests,
   ...wgpuFfiTests,
   ...wgpuAdapterTests,
   ...babylonAdapterTests,
@@ -90,6 +92,7 @@ export {
   updaterTests,
   sandboxTests,
   trayApiTests,
+  dockApiTests,
   wgpuFfiTests,
   wgpuAdapterTests,
   babylonAdapterTests,

--- a/package/src/bun/core/Dock.ts
+++ b/package/src/bun/core/Dock.ts
@@ -1,0 +1,114 @@
+import { ffi, type ApplicationMenuItemConfig } from "../proc/native";
+import electrobunEventEmitter from "../events/eventEmitter";
+import { roleLabelMap } from "./menuRoles";
+
+type NonDividerMenuItem = {
+	type?: "normal";
+	label?: string;
+	tooltip?: string;
+	action?: string;
+	role?: string;
+	data?: unknown;
+	submenu?: Array<ApplicationMenuItemConfig>;
+	enabled?: boolean;
+	checked?: boolean;
+	hidden?: boolean;
+	accelerator?: string;
+};
+
+/**
+ * Install (or replace) the menu shown when the user right-clicks / long-presses
+ * the Dock icon on macOS. Pass an empty array to clear the menu.
+ *
+ * No-op on Linux and Windows (the native layer stubs the call there).
+ *
+ * Listen for clicks with `Dock.on("application-dock-menu-clicked", ...)`.
+ *
+ * @example
+ * Dock.setMenu([
+ *   { type: "normal", label: "Play",     action: "toggle" },
+ *   { type: "normal", label: "Next",     action: "next" },
+ *   { type: "normal", label: "Previous", action: "prev" },
+ * ]);
+ * Dock.on("application-dock-menu-clicked", (event) => {
+ *   console.log(event.data.action);
+ * });
+ */
+export const setMenu = (menu: Array<ApplicationMenuItemConfig>): void => {
+	const menuWithDefaults = menuConfigWithDefaults(menu);
+	ffi.request.setApplicationDockMenu({
+		menuConfig: JSON.stringify(menuWithDefaults),
+	});
+};
+
+/**
+ * Set the badge text shown on the Dock icon (macOS). Pass `null` or an empty
+ * string to clear the badge. Typical values: unread counts ("3"), small
+ * status indicators ("♪"), short labels ("!").
+ *
+ * No-op on Linux and Windows.
+ */
+export const setBadge = (text: string | null | undefined): void => {
+	ffi.request.setDockBadge({ text: text ?? "" });
+};
+
+/**
+ * Show a progress bar overlaid on the Dock icon (macOS). `progress` in the
+ * closed interval `[0, 1]` shows the bar; pass `null` or any negative value
+ * to clear it and restore the stock icon.
+ *
+ * Intended for long-running work like downloads, builds, imports, or media
+ * playback position.
+ *
+ * No-op on Linux and Windows.
+ */
+export const setProgress = (progress: number | null | undefined): void => {
+	const value = progress == null ? -1 : progress;
+	ffi.request.setDockProgress({ progress: value });
+};
+
+/**
+ * Subscribe to dock-menu clicks. Fired when the user selects an item from the
+ * menu installed by `setMenu`. The event's `data.action` matches the `action`
+ * field on the selected menu item.
+ */
+export const on = (
+	name: "application-dock-menu-clicked",
+	handler: (event: unknown) => void,
+): void => {
+	electrobunEventEmitter.on(name, handler);
+};
+
+const menuConfigWithDefaults = (
+	menu: Array<ApplicationMenuItemConfig>,
+): Array<ApplicationMenuItemConfig> => {
+	return menu.map((item) => {
+		if (item.type === "divider" || item.type === "separator") {
+			return { type: "divider" } as const;
+		}
+		const menuItem = item as NonDividerMenuItem;
+		const actionWithDataId = ffi.internal.serializeMenuAction(
+			menuItem.action || "",
+			menuItem.data,
+		);
+
+		return {
+			label:
+				menuItem.label ||
+				roleLabelMap[menuItem.role as keyof typeof roleLabelMap] ||
+				"",
+			type: menuItem.type || "normal",
+			...(menuItem.role
+				? { role: menuItem.role }
+				: { action: actionWithDataId }),
+			enabled: menuItem.enabled === false ? false : true,
+			checked: Boolean(menuItem.checked),
+			hidden: Boolean(menuItem.hidden),
+			tooltip: menuItem.tooltip || undefined,
+			accelerator: menuItem.accelerator || undefined,
+			...(menuItem.submenu
+				? { submenu: menuConfigWithDefaults(menuItem.submenu) }
+				: {}),
+		};
+	});
+};

--- a/package/src/bun/events/ApplicationEvents.ts
+++ b/package/src/bun/events/ApplicationEvents.ts
@@ -14,6 +14,11 @@ export default {
 			"context-menu-clicked",
 			data,
 		),
+	applicationDockMenuClicked: (data: MenuClickedData) =>
+		new ElectrobunEvent<MenuClickedData, { allow: boolean }>(
+			"application-dock-menu-clicked",
+			data,
+		),
 	openUrl: (data: OpenUrlData) =>
 		new ElectrobunEvent<OpenUrlData, void>("open-url", data),
 	reopen: (data: {}) => new ElectrobunEvent<{}, void>("reopen", data),

--- a/package/src/bun/index.ts
+++ b/package/src/bun/index.ts
@@ -6,6 +6,7 @@ import { WGPUView, type WGPUViewOptions } from "./core/WGPUView";
 import { Tray, type TrayOptions } from "./core/Tray";
 import * as ApplicationMenu from "./core/ApplicationMenu";
 import * as ContextMenu from "./core/ContextMenu";
+import * as Dock from "./core/Dock";
 import {
 	Updater,
 	type UpdateStatusType,
@@ -219,6 +220,7 @@ export {
 	Utils,
 	ApplicationMenu,
 	ContextMenu,
+	Dock,
 	PATHS,
 	Socket,
 	WGPU,
@@ -244,6 +246,7 @@ const Electrobun = {
 	Utils,
 	ApplicationMenu,
 	ContextMenu,
+	Dock,
 	GlobalShortcut,
 	Screen,
 	Session,

--- a/package/src/bun/proc/native.ts
+++ b/package/src/bun/proc/native.ts
@@ -658,6 +658,18 @@ export const native = (() => {
 				args: [],
 				returns: FFIType.bool,
 			},
+			setApplicationDockMenu: {
+				args: [FFIType.cstring, FFIType.function],
+				returns: FFIType.void,
+			},
+			setDockBadge: {
+				args: [FFIType.cstring],
+				returns: FFIType.void,
+			},
+			setDockProgress: {
+				args: [FFIType.f64],
+				returns: FFIType.void,
+			},
 
 			// Window style utilities
 			getWindowStyle: {
@@ -1623,6 +1635,18 @@ window.__electrobunBunBridge = window.__electrobunBunBridge || window.webkit?.me
 		},
 		isDockIconVisible: (): boolean => {
 			return native_.symbols.isDockIconVisible();
+		},
+		setApplicationDockMenu: (params: { menuConfig: string }): void => {
+			native_.symbols.setApplicationDockMenu(
+				toCString(params.menuConfig),
+				dockMenuHandler,
+			);
+		},
+		setDockBadge: (params: { text: string }): void => {
+			native_.symbols.setDockBadge(toCString(params.text));
+		},
+		setDockProgress: (params: { progress: number }): void => {
+			native_.symbols.setDockProgress(params.progress);
 		},
 		openFileDialog: (params: {
 			startingFolder: string;
@@ -2719,6 +2743,26 @@ const contextMenuHandler = new JSCallback(
 		const event = electrobunEventEmitter.events.app.contextMenuClicked({
 			action: actualAction,
 			data, // Always include data property (undefined if no data)
+		});
+
+		electrobunEventEmitter.emitEvent(event);
+	},
+	{
+		args: [FFIType.u32, FFIType.cstring],
+		returns: FFIType.void,
+		threadsafe: true,
+	},
+);
+
+const dockMenuHandler = new JSCallback(
+	(_id, action) => {
+		const actionString = new CString(action).toString();
+
+		const { action: actualAction, data } = deserializeMenuAction(actionString);
+
+		const event = electrobunEventEmitter.events.app.applicationDockMenuClicked({
+			action: actualAction,
+			data,
 		});
 
 		electrobunEventEmitter.emitEvent(event);

--- a/package/src/native/linux/nativeWrapper.cpp
+++ b/package/src/native/linux/nativeWrapper.cpp
@@ -11046,6 +11046,21 @@ ELECTROBUN_EXPORT bool isDockIconVisible() {
     return true;
 }
 
+// Dock menu / badge / progress - macOS only, stubs for Linux.
+// Linux launcher-entry equivalents (Unity LauncherEntry) could be added later.
+ELECTROBUN_EXPORT void setApplicationDockMenu(const char* json, void (*handler)(uint32_t, const char*)) {
+    (void)json;
+    (void)handler;
+}
+
+ELECTROBUN_EXPORT void setDockBadge(const char* text) {
+    (void)text;
+}
+
+ELECTROBUN_EXPORT void setDockProgress(double progress) {
+    (void)progress;
+}
+
 // Graceful shutdown function to coordinate cleanup
 ELECTROBUN_EXPORT void shutdownNativeWrapper() {
     printf("Starting graceful shutdown of native wrapper...\n");

--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -618,6 +618,12 @@ static std::vector<std::string> g_pendingUrlOpenPaths;
 static std::mutex g_urlOpenMutex;
 static AppReopenHandler g_appReopenHandler = nullptr;
 static QuitRequestedHandler g_quitRequestedHandler = nullptr;
+// Dock menu state (macOS): NSApp's delegate returns g_dockMenu from
+// applicationDockMenu:, and clicks on menu items fire the associated
+// target which dispatches to g_dockMenuHandler with the action string.
+static NSMenu *g_dockMenu = nil;
+static id g_dockMenuTarget = nil;  // retained StatusItemTarget*
+static DockProgressView *g_dockProgressView = nil;
 static std::atomic<bool> g_shutdownComplete{false};
 static std::atomic<bool> g_eventLoopStopping{false};
 
@@ -998,6 +1004,10 @@ static NSMutableDictionary<NSNumber *, AbstractView *> *globalAbstractViews = ni
 @end
 
 @interface AppDelegate : NSObject <NSApplicationDelegate>
+@end
+
+@interface DockProgressView : NSView
+@property (nonatomic, assign) double progress;
 @end
 
 @interface WindowDelegate : NSObject <NSWindowDelegate>
@@ -6427,6 +6437,54 @@ CefRefPtr<CefRequestContext> CreateRequestContextForPartition(const char* partit
 
         return YES;
     }
+
+    // AppKit calls this whenever the user right-clicks / long-presses the Dock icon.
+    // We return the menu last supplied by setApplicationDockMenu, or nil if none.
+    - (NSMenu *)applicationDockMenu:(NSApplication *)sender {
+        (void)sender;
+        return g_dockMenu;
+    }
+@end
+
+@implementation DockProgressView
+    - (void)drawRect:(NSRect)dirtyRect {
+        (void)dirtyRect;
+
+        // Base: the application icon fills the tile.
+        NSImage *appIcon = [NSApp applicationIconImage];
+        if (appIcon) {
+            [appIcon drawInRect:self.bounds
+                       fromRect:NSZeroRect
+                      operation:NSCompositingOperationCopy
+                       fraction:1.0];
+        }
+
+        CGFloat width = self.bounds.size.width;
+        CGFloat barHeight = MAX(6.0, width * 0.08);
+        CGFloat margin = width * 0.08;
+        NSRect track = NSMakeRect(margin, margin, width - 2 * margin, barHeight);
+        CGFloat radius = barHeight / 2.0;
+
+        NSBezierPath *trackPath = [NSBezierPath bezierPathWithRoundedRect:track
+                                                                  xRadius:radius
+                                                                  yRadius:radius];
+        [[NSColor colorWithWhite:0.0 alpha:0.35] setFill];
+        [trackPath fill];
+
+        double p = self.progress;
+        if (p < 0.0) p = 0.0;
+        if (p > 1.0) p = 1.0;
+
+        CGFloat fillWidth = track.size.width * p;
+        if (fillWidth > 0.0) {
+            NSRect fill = NSMakeRect(track.origin.x, track.origin.y, fillWidth, barHeight);
+            NSBezierPath *fillPath = [NSBezierPath bezierPathWithRoundedRect:fill
+                                                                    xRadius:radius
+                                                                    yRadius:radius];
+            [[NSColor colorWithRed:0.20 green:0.60 blue:0.96 alpha:1.0] setFill];
+            [fillPath fill];
+        }
+    }
 @end
 
 @implementation WindowDelegate
@@ -8031,6 +8089,83 @@ extern "C" bool isDockIconVisible() {
     }
 
     return isVisible;
+}
+
+// Install (or replace) the menu shown when the user right-clicks / long-presses
+// the Dock icon. Pass an empty / null JSON string to clear the menu.
+//
+// Click routing mirrors setApplicationMenu: a retained StatusItemTarget owns
+// the handler and each NSMenuItem's target/action points at it, so when an
+// item is picked menuItemClicked: fires the JS callback with the action string.
+extern "C" void setApplicationDockMenu(const char *jsonString, ZigStatusItemHandler zigHandler) {
+    char *jsonCopy = jsonString ? strdup(jsonString) : nullptr;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (!jsonCopy || strlen(jsonCopy) == 0) {
+            g_dockMenu = nil;
+            g_dockMenuTarget = nil;
+            if (jsonCopy) free(jsonCopy);
+            return;
+        }
+        NSData *jsonData = [NSData dataWithBytes:jsonCopy length:strlen(jsonCopy)];
+        NSError *error = nil;
+        NSArray *menuArray = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error];
+        free(jsonCopy);
+        if (error || ![menuArray isKindOfClass:[NSArray class]]) {
+            NSLog(@"setApplicationDockMenu: failed to parse JSON: %@", error);
+            return;
+        }
+        StatusItemTarget *target = [[StatusItemTarget alloc] init];
+        target.zigHandler = zigHandler;
+        target.trayId = 0;
+        NSMenu *menu = createMenuFromConfig(menuArray, target);
+        g_dockMenu = menu;
+        g_dockMenuTarget = target;  // strong retain keeps the handler alive
+    });
+}
+
+// Set the text shown as a badge on the Dock icon. Pass null or empty to clear.
+extern "C" void setDockBadge(const char *text) {
+    NSString *label = (text && strlen(text) > 0)
+        ? [NSString stringWithUTF8String:text]
+        : nil;
+
+    void (^apply)(void) = ^{
+        [[NSApp dockTile] setBadgeLabel:label];
+    };
+
+    if ([NSThread isMainThread]) {
+        apply();
+    } else {
+        dispatch_async(dispatch_get_main_queue(), apply);
+    }
+}
+
+// Show (or clear) a progress bar overlaid on the Dock icon.
+// progress in [0.0, 1.0] shows the bar; any negative value clears it and
+// restores the stock icon.
+extern "C" void setDockProgress(double progress) {
+    void (^apply)(void) = ^{
+        NSDockTile *tile = [NSApp dockTile];
+        if (progress < 0.0) {
+            tile.contentView = nil;
+            g_dockProgressView = nil;
+            [tile display];
+            return;
+        }
+        if (!g_dockProgressView) {
+            g_dockProgressView = [[DockProgressView alloc] initWithFrame:NSMakeRect(0, 0, 128, 128)];
+        }
+        g_dockProgressView.progress = progress;
+        tile.contentView = g_dockProgressView;
+        [g_dockProgressView setNeedsDisplay:YES];
+        [tile display];
+    };
+
+    if ([NSThread isMainThread]) {
+        apply();
+    } else {
+        dispatch_async(dispatch_get_main_queue(), apply);
+    }
 }
 
 extern "C" NSStatusItem* createTray(uint32_t trayId, const char *title, const char *pathToImage, bool isTemplate,

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -12262,6 +12262,22 @@ extern "C" ELECTROBUN_EXPORT bool isDockIconVisible() {
     return true;
 }
 
+// Dock menu / badge / progress - macOS only, stubs for Windows.
+// Windows has taskbar equivalents (ITaskbarList3::SetProgressValue,
+// overlay icon) that could be wired up in a follow-up.
+extern "C" ELECTROBUN_EXPORT void setApplicationDockMenu(const char* json, void (*handler)(uint32_t, const char*)) {
+    (void)json;
+    (void)handler;
+}
+
+extern "C" ELECTROBUN_EXPORT void setDockBadge(const char* text) {
+    (void)text;
+}
+
+extern "C" ELECTROBUN_EXPORT void setDockProgress(double progress) {
+    (void)progress;
+}
+
 // Window icon - Linux only, no-op for Windows
 extern "C" ELECTROBUN_EXPORT void setWindowIcon(void* window, const char* iconPath) {
     // Not yet implemented on Windows


### PR DESCRIPTION
Closes #392.

## Summary

Adds the three standard macOS Dock tile affordances most desktop apps expect: a dock menu, a badge label, and a progress overlay. The TS surface lives under a new `Dock` export that mirrors the existing `ApplicationMenu` / `Tray` shape.

\`\`\`ts
import { Dock } from \"electrobun/bun\";

Dock.setMenu([
  { type: \"normal\", label: \"Play\",     action: \"toggle\" },
  { type: \"normal\", label: \"Next\",     action: \"next\" },
  { type: \"normal\", label: \"Previous\", action: \"prev\" },
  { type: \"divider\" },
  { type: \"normal\", label: \"Show\",     action: \"show\" },
]);
Dock.on(\"application-dock-menu-clicked\", (e: any) => {
  console.log(e.data.action);
});

Dock.setBadge(\"♪\");      // string sets label
Dock.setBadge(null);      // null / empty clears

Dock.setProgress(0.42);   // 0..1 shows progress bar
Dock.setProgress(null);   // null / negative clears
\`\`\`

## Implementation

**Native (macOS)** — `package/src/native/macos/nativeWrapper.mm`
- `AppDelegate.applicationDockMenu:` now returns a globally stored `NSMenu*` last supplied by JS. The menu is built with the existing `createMenuFromConfig` and owned by a retained `StatusItemTarget`, so role handling, accelerators, data payloads, and click dispatch are identical to the Tray / ApplicationMenu paths — clicks route through `menuItemClicked:` → `zigHandler` just like the rest of the menu system.
- `setDockBadge(const char*)` sets `NSApp.dockTile.badgeLabel` on the main thread; null/empty clears.
- `setDockProgress(double)` draws a rounded progress bar over the application icon via a custom `DockProgressView` set as the `NSDockTile.contentView`. Negative values clear `contentView` so the stock icon returns. `progress` is clamped to `[0, 1]` in `drawRect:`.

**Native stubs** — `package/src/native/{linux,win}/nativeWrapper.cpp`
- No-op `setApplicationDockMenu`, `setDockBadge`, `setDockProgress` matching the pattern used by the existing `setDockIconVisible` stubs. This keeps Bun FFI symbol binding happy on every platform. Windows `ITaskbarList3` and Linux Unity LauncherEntry equivalents would be natural follow-ups.

**TS / FFI** — `package/src/bun/proc/native.ts`
- Three new FFI signatures and corresponding `ffi.request.*` wrappers.
- New `dockMenuHandler` `JSCallback` routing clicks as a new `application-dock-menu-clicked` event on the existing emitter.

**TS API** — `package/src/bun/core/Dock.ts` (new)
- `setMenu`, `setBadge`, `setProgress`, `on` — parallel in style to `core/ApplicationMenu.ts`. Exported as `Dock` from `package/src/bun/index.ts` (both named and default exports, alongside `ApplicationMenu` / `ContextMenu`).

## Tests

- **Kitchen sink — `kitchen/src/tests/dock-api.test.ts` (new):** three automated tests covering the contract on every platform (calls are safe to make on Linux/Windows thanks to the stubs) and exercising in-range, out-of-range, null, and empty values. Wired into `kitchen/src/tests/index.ts`.
- **`bun test src/shared`** — existing unit tests still pass (48 pass, 0 fail).
- **Typecheck** — new files (`Dock.ts`, `dock-api.test.ts`, modifications to `native.ts`, `ApplicationEvents.ts`, `index.ts`) add no new TS errors; the only `tsc --noEmit` errors are preexisting ones in `src/cli/`, `src/launcher/`, and `src/bun/webGPU.ts`.
- **Obj-C smoke** — compiled and linked the new `nativeWrapper.mm` additions as a standalone TU against the macOS SDK (`clang++ -fobjc-arc -std=c++20 -framework Cocoa`); produces the three expected external symbols (`_setApplicationDockMenu`, `_setDockBadge`, `_setDockProgress`) with no warnings.

## Platform scope

macOS implementation only in this PR — Linux and Windows ship no-op stubs so symbol binding succeeds everywhere. Windows taskbar equivalents (`ITaskbarList3::SetProgressValue`, overlay icon) and Linux Unity `LauncherEntry` could follow in a separate PR.