### PR TITLE
 feat(win): add native titlebar theme API and defer initial show to avoid caption flicker

### DIFF
--- a/kitchen/src/test-framework/executor.ts
+++ b/kitchen/src/test-framework/executor.ts
@@ -121,6 +121,7 @@ export class TestExecutor {
           },
           rpc: options.rpc,
           titleBarStyle: options.titleBarStyle,
+          nativeTitleBar: options.nativeTitleBar,
           trafficLightOffset: options.trafficLightOffset,
           sandbox: options.sandbox || false,
         });

--- a/kitchen/src/test-framework/types.ts
+++ b/kitchen/src/test-framework/types.ts
@@ -57,6 +57,12 @@ export interface WindowOptions {
   y?: number;
   title?: string;
   titleBarStyle?: TitleBarStyle;
+  nativeTitleBar?: {
+    darkMode?: boolean;
+    captionColor?: `#${string}`;
+    textColor?: `#${string}`;
+    borderColor?: `#${string}`;
+  };
   trafficLightOffset?: { x: number; y: number };
   renderer?: 'cef' | 'native';
   hidden?: boolean;

--- a/kitchen/src/tests/window.test.ts
+++ b/kitchen/src/tests/window.test.ts
@@ -566,6 +566,49 @@ export const windowTests = [
   }),
 
   defineTest({
+    name: "Window native titlebar theme option",
+    category: "BrowserWindow",
+    description: "Test creating a window with native titlebar theming options",
+    async run({ createWindow, log }) {
+      const win = await createWindow({
+        url: "views://test-harness/index.html",
+        title: "Native Titlebar Theme Test",
+        titleBarStyle: "default",
+        nativeTitleBar: {
+          darkMode: true,
+          captionColor: "#10203a",
+          textColor: "#e2e8f0",
+          borderColor: "#314767",
+        },
+        renderer: "cef",
+      });
+
+      expect(win.id).toBeGreaterThan(0);
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      log("Window created with native titlebar theme options");
+    },
+  }),
+
+  defineTest({
+    name: "Window native titlebar theme validates colors",
+    category: "BrowserWindow",
+    description: "Test that invalid native titlebar colors are rejected before window creation",
+    async run({ log }) {
+      expect(() => new BrowserWindow({
+        title: "Invalid Native Titlebar Theme",
+        url: "views://test-harness/index.html",
+        renderer: "cef",
+        titleBarStyle: "default",
+        nativeTitleBar: {
+          captionColor: "#12345g",
+        },
+      })).toThrow();
+
+      log("Invalid native titlebar color was rejected");
+    },
+  }),
+
+  defineTest({
     name: "Window traffic light position API",
     category: "BrowserWindow",
     description: "Test macOS traffic light offset creation and runtime repositioning",

--- a/package/src/bun/core/BrowserWindow.ts
+++ b/package/src/bun/core/BrowserWindow.ts
@@ -11,13 +11,17 @@ import { WGPUView } from "./WGPUView";
 
 const buildConfig = await BuildConfig.get();
 
+export type NativeTitleBarOptions = {
+	// Windows-only. Applies to the native OS title bar and is ignored for custom
+	// titlebar styles such as "hidden" and "hiddenInset".
+	darkMode?: boolean;
+	captionColor?: `#${string}`;
+	textColor?: `#${string}`;
+	borderColor?: `#${string}`;
+};
+
 export type WindowOptionsType<T = undefined> = {
-	nativeTitleBar?: {
-		darkMode?: boolean;
-		captionColor?: `#${string}`;
-		textColor?: `#${string}`;
-		borderColor?: `#${string}`;
-	};
+	nativeTitleBar?: NativeTitleBarOptions;
 	trafficLightOffset?: {
 		x: number;
 		y: number;
@@ -134,12 +138,7 @@ export class BrowserWindow<T extends RPCWithTransport = RPCWithTransport> {
 	transparent: boolean = false;
 	passthrough: boolean = false;
 	hidden: boolean = false;
-	nativeTitleBar: {
-		darkMode?: boolean;
-		captionColor?: `#${string}`;
-		textColor?: `#${string}`;
-		borderColor?: `#${string}`;
-	} = {};
+	nativeTitleBar?: NativeTitleBarOptions;
 	trafficLightOffset: { x: number; y: number } = { x: 0, y: 0 };
 	navigationRules: string | null = null;
 	// Sandbox mode disables RPC and only allows event emission (for untrusted content)
@@ -171,7 +170,7 @@ export class BrowserWindow<T extends RPCWithTransport = RPCWithTransport> {
 		this.transparent = options.transparent ?? false;
 		this.passthrough = options.passthrough ?? false;
 		this.hidden = options.hidden ?? false;
-		this.nativeTitleBar = options.nativeTitleBar ?? {};
+		this.nativeTitleBar = options.nativeTitleBar;
 		this.trafficLightOffset = {
 			x: options.trafficLightOffset?.x ?? 0,
 			y: options.trafficLightOffset?.y ?? 0,

--- a/package/src/bun/core/BrowserWindow.ts
+++ b/package/src/bun/core/BrowserWindow.ts
@@ -12,6 +12,12 @@ import { WGPUView } from "./WGPUView";
 const buildConfig = await BuildConfig.get();
 
 export type WindowOptionsType<T = undefined> = {
+	nativeTitleBar?: {
+		darkMode?: boolean;
+		captionColor?: `#${string}`;
+		textColor?: `#${string}`;
+		borderColor?: `#${string}`;
+	};
 	trafficLightOffset?: {
 		x: number;
 		y: number;
@@ -128,6 +134,12 @@ export class BrowserWindow<T extends RPCWithTransport = RPCWithTransport> {
 	transparent: boolean = false;
 	passthrough: boolean = false;
 	hidden: boolean = false;
+	nativeTitleBar: {
+		darkMode?: boolean;
+		captionColor?: `#${string}`;
+		textColor?: `#${string}`;
+		borderColor?: `#${string}`;
+	} = {};
 	trafficLightOffset: { x: number; y: number } = { x: 0, y: 0 };
 	navigationRules: string | null = null;
 	// Sandbox mode disables RPC and only allows event emission (for untrusted content)
@@ -159,6 +171,7 @@ export class BrowserWindow<T extends RPCWithTransport = RPCWithTransport> {
 		this.transparent = options.transparent ?? false;
 		this.passthrough = options.passthrough ?? false;
 		this.hidden = options.hidden ?? false;
+		this.nativeTitleBar = options.nativeTitleBar ?? {};
 		this.trafficLightOffset = {
 			x: options.trafficLightOffset?.x ?? 0,
 			y: options.trafficLightOffset?.y ?? 0,
@@ -176,6 +189,7 @@ export class BrowserWindow<T extends RPCWithTransport = RPCWithTransport> {
 		transparent,
 		hidden,
 		activate,
+		nativeTitleBar,
 	}: Partial<WindowOptionsType<T>>) {
 		this.ptr = ffi.request.createWindow({
 			id: this.id,
@@ -220,6 +234,7 @@ export class BrowserWindow<T extends RPCWithTransport = RPCWithTransport> {
 			transparent: transparent ?? false,
 			hidden: hidden ?? false,
 			activate: activate ?? true,
+			nativeTitleBar: nativeTitleBar ?? this.nativeTitleBar,
 			trafficLightOffset: this.trafficLightOffset,
 		}) as Pointer;
 

--- a/package/src/bun/proc/native.ts
+++ b/package/src/bun/proc/native.ts
@@ -79,6 +79,23 @@ function getWindowPtr(winId: number) {
 	);
 }
 
+const WINDOWS_COLOR_SENTINEL = 0xffffffff;
+
+function parseWindowsColorRef(color?: `#${string}`): number {
+	if (!color) return WINDOWS_COLOR_SENTINEL;
+	const hex = color.slice(1);
+	if (!/^[0-9a-fA-F]{6}$/.test(hex)) {
+		throw new Error(
+			`Invalid native title bar color "${color}". Expected #RRGGBB.`,
+		);
+	}
+	const rgb = parseInt(hex, 16);
+	const r = (rgb >> 16) & 0xff;
+	const g = (rgb >> 8) & 0xff;
+	const b = rgb & 0xff;
+	return (b << 16) | (g << 8) | r;
+}
+
 export const native = (() => {
 	try {
 		// Use absolute path to native wrapper DLL to avoid working directory issues
@@ -112,6 +129,16 @@ export const native = (() => {
 				args: [
 					FFIType.ptr, // window ptr
 					FFIType.cstring, // title
+				],
+				returns: FFIType.void,
+			},
+			setWindowTitleBarTheme: {
+				args: [
+					FFIType.ptr, // window ptr
+					FFIType.i32, // dark mode: -1 unset, 0 false, 1 true
+					FFIType.u32, // caption color COLORREF or sentinel
+					FFIType.u32, // text color COLORREF or sentinel
+					FFIType.u32, // border color COLORREF or sentinel
 				],
 				returns: FFIType.void,
 			},
@@ -853,6 +880,12 @@ const _ffiImpl = {
 			transparent: boolean;
 			hidden?: boolean;
 			activate?: boolean;
+			nativeTitleBar?: {
+				darkMode?: boolean;
+				captionColor?: `#${string}`;
+				textColor?: `#${string}`;
+				borderColor?: `#${string}`;
+			};
 			trafficLightOffset?: {
 				x: number;
 				y: number;
@@ -881,6 +914,7 @@ const _ffiImpl = {
 				transparent,
 				hidden = false,
 				activate = true,
+				nativeTitleBar,
 				trafficLightOffset = { x: 0, y: 0 },
 			} = params;
 
@@ -926,6 +960,19 @@ const _ffiImpl = {
 			}
 
 			native_.symbols.setWindowTitle(windowPtr, toCString(title));
+			if (nativeTitleBar) {
+				native_.symbols.setWindowTitleBarTheme(
+					windowPtr,
+					nativeTitleBar.darkMode === undefined
+						? -1
+						: nativeTitleBar.darkMode
+							? 1
+							: 0,
+					parseWindowsColorRef(nativeTitleBar.captionColor),
+					parseWindowsColorRef(nativeTitleBar.textColor),
+					parseWindowsColorRef(nativeTitleBar.borderColor),
+				);
+			}
 			if (!hidden) {
 				native_.symbols.showWindow(windowPtr, activate);
 			}

--- a/package/src/bun/proc/native.ts
+++ b/package/src/bun/proc/native.ts
@@ -70,7 +70,10 @@ import {
 	toArrayBuffer,
 	type Pointer,
 } from "bun:ffi";
-import { BrowserWindow } from "../core/BrowserWindow";
+import {
+	BrowserWindow,
+	type NativeTitleBarOptions,
+} from "../core/BrowserWindow";
 import { GpuWindow } from "../core/GpuWindow";
 
 function getWindowPtr(winId: number) {
@@ -94,6 +97,29 @@ function parseWindowsColorRef(color?: `#${string}`): number {
 	const g = (rgb >> 8) & 0xff;
 	const b = rgb & 0xff;
 	return (b << 16) | (g << 8) | r;
+}
+
+function hasNativeTitleBarTheme(
+	nativeTitleBar?: NativeTitleBarOptions,
+): nativeTitleBar is NativeTitleBarOptions {
+	if (!nativeTitleBar) return false;
+	return (
+		nativeTitleBar.darkMode !== undefined ||
+		nativeTitleBar.captionColor !== undefined ||
+		nativeTitleBar.textColor !== undefined ||
+		nativeTitleBar.borderColor !== undefined
+	);
+}
+
+function shouldApplyNativeTitleBarTheme(
+	titleBarStyle: string,
+	nativeTitleBar?: NativeTitleBarOptions,
+): nativeTitleBar is NativeTitleBarOptions {
+	return (
+		process.platform === "win32" &&
+		titleBarStyle === "default" &&
+		hasNativeTitleBarTheme(nativeTitleBar)
+	);
 }
 
 export const native = (() => {
@@ -880,12 +906,7 @@ const _ffiImpl = {
 			transparent: boolean;
 			hidden?: boolean;
 			activate?: boolean;
-			nativeTitleBar?: {
-				darkMode?: boolean;
-				captionColor?: `#${string}`;
-				textColor?: `#${string}`;
-				borderColor?: `#${string}`;
-			};
+			nativeTitleBar?: NativeTitleBarOptions;
 			trafficLightOffset?: {
 				x: number;
 				y: number;
@@ -960,7 +981,7 @@ const _ffiImpl = {
 			}
 
 			native_.symbols.setWindowTitle(windowPtr, toCString(title));
-			if (nativeTitleBar) {
+			if (shouldApplyNativeTitleBarTheme(titleBarStyle, nativeTitleBar)) {
 				native_.symbols.setWindowTitleBarTheme(
 					windowPtr,
 					nativeTitleBar.darkMode === undefined

--- a/package/src/native/linux/nativeWrapper.cpp
+++ b/package/src/native/linux/nativeWrapper.cpp
@@ -6347,6 +6347,15 @@ ELECTROBUN_EXPORT void setWindowTitle(void* window, const char* title) {
     }
 }
 
+ELECTROBUN_EXPORT void setWindowTitleBarTheme(void* window, int32_t darkMode, uint32_t captionColor, uint32_t textColor, uint32_t borderColor) {
+    (void)window;
+    (void)darkMode;
+    (void)captionColor;
+    (void)textColor;
+    (void)borderColor;
+    // Windows-only API. Linux titlebar theming is managed by the window manager.
+}
+
 void showX11Window(void* window) {
     dispatch_sync_main_void([&]() {
         X11Window* x11win = static_cast<X11Window*>(window);

--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -7347,6 +7347,15 @@ extern "C" void setWindowTitle(NSWindow *window, const char *title) {
     });
 }
 
+extern "C" void setWindowTitleBarTheme(NSWindow *window, int32_t darkMode, uint32_t captionColor, uint32_t textColor, uint32_t borderColor) {
+    (void)window;
+    (void)darkMode;
+    (void)captionColor;
+    (void)textColor;
+    (void)borderColor;
+    // Windows-only API. macOS keeps native titlebar styling under AppKit control.
+}
+
 extern "C" void closeWindow(NSWindow *window) {
     dispatch_sync(dispatch_get_main_queue(), ^{
         [window close];

--- a/package/src/native/win/dcomp_compositor.h
+++ b/package/src/native/win/dcomp_compositor.h
@@ -28,6 +28,31 @@
 
 using Microsoft::WRL::ComPtr;
 
+static bool getWindowsVersion(OSVERSIONINFOEXW* osInfo) {
+    if (!osInfo) return false;
+
+    typedef LONG (WINAPI *RtlGetVersionPtr)(OSVERSIONINFOEXW*);
+    HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
+    if (!ntdll) return false;
+
+    auto fn = (RtlGetVersionPtr)GetProcAddress(ntdll, "RtlGetVersion");
+    if (!fn) return false;
+
+    ZeroMemory(osInfo, sizeof(*osInfo));
+    osInfo->dwOSVersionInfoSize = sizeof(*osInfo);
+    return fn(osInfo) == 0;
+}
+
+static bool isWindowsBuildOrGreater(DWORD minimumBuild) {
+    OSVERSIONINFOEXW osInfo = {};
+    if (!getWindowsVersion(&osInfo)) {
+        return true;
+    }
+
+    return osInfo.dwMajorVersion > 10 ||
+           (osInfo.dwMajorVersion == 10 && osInfo.dwBuildNumber >= minimumBuild);
+}
+
 // Feature gate: DirectComposition requires Windows 8.1+.
 // Note: IsWindows8Point1OrGreater() requires an app manifest to report correctly.
 // Without a manifest, Windows lies about the version. We use RtlGetVersion instead
@@ -37,22 +62,12 @@ static bool isDCompAvailable() {
     if (cached >= 0) return cached == 1;
 
     // RtlGetVersion is not affected by manifests — always returns the real version.
-    typedef LONG (WINAPI *RtlGetVersionPtr)(OSVERSIONINFOEXW*);
-    HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
-    if (ntdll) {
-        auto fn = (RtlGetVersionPtr)GetProcAddress(ntdll, "RtlGetVersion");
-        if (fn) {
-            OSVERSIONINFOEXW osInfo = {};
-            osInfo.dwOSVersionInfoSize = sizeof(osInfo);
-            if (fn(&osInfo) == 0) {
-                // Windows 8.1 = 6.3, Windows 10/11 = 10.0
-                bool ok = (osInfo.dwMajorVersion > 6) ||
-                          (osInfo.dwMajorVersion == 6 && osInfo.dwMinorVersion >= 3);
-                // OS version check done
-                cached = ok ? 1 : 0;
-                return ok;
-            }
-        }
+    OSVERSIONINFOEXW osInfo = {};
+    if (getWindowsVersion(&osInfo)) {
+        bool ok = (osInfo.dwMajorVersion > 6) ||
+                  (osInfo.dwMajorVersion == 6 && osInfo.dwMinorVersion >= 3);
+        cached = ok ? 1 : 0;
+        return ok;
     }
 
     // Fallback: assume available on modern Windows

--- a/package/src/native/win/dcomp_compositor.h
+++ b/package/src/native/win/dcomp_compositor.h
@@ -62,12 +62,22 @@ static bool isDCompAvailable() {
     if (cached >= 0) return cached == 1;
 
     // RtlGetVersion is not affected by manifests — always returns the real version.
-    OSVERSIONINFOEXW osInfo = {};
-    if (getWindowsVersion(&osInfo)) {
-        bool ok = (osInfo.dwMajorVersion > 6) ||
-                  (osInfo.dwMajorVersion == 6 && osInfo.dwMinorVersion >= 3);
-        cached = ok ? 1 : 0;
-        return ok;
+    typedef LONG (WINAPI *RtlGetVersionPtr)(OSVERSIONINFOEXW*);
+    HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
+    if (ntdll) {
+        auto fn = (RtlGetVersionPtr)GetProcAddress(ntdll, "RtlGetVersion");
+        if (fn) {
+            OSVERSIONINFOEXW osInfo = {};
+            osInfo.dwOSVersionInfoSize = sizeof(osInfo);
+            if (fn(&osInfo) == 0) {
+                // Windows 8.1 = 6.3, Windows 10/11 = 10.0
+                bool ok = (osInfo.dwMajorVersion > 6) ||
+                          (osInfo.dwMajorVersion == 6 && osInfo.dwMinorVersion >= 3);
+                // OS version check done
+                cached = ok ? 1 : 0;
+                return ok;
+            }
+        }
     }
 
     // Fallback: assume available on modern Windows

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -9327,9 +9327,8 @@ ELECTROBUN_EXPORT HWND createWindowWithFrameAndStyleFromWorker(
                     SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
             }
 
-            // Show the window
-            ShowWindow(hwnd, SW_SHOW);
-            UpdateWindow(hwnd);
+            // Visibility is controlled by the higher-level bridge after it
+            // applies any window attributes such as native titlebar theming.
         } else {
             // Clean up if window creation failed
             free(data);

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -3,6 +3,7 @@
 #include <winhttp.h>
 #include <Windows.h>
 #include <windowsx.h>  // For GET_X_LPARAM and GET_Y_LPARAM
+#include <dwmapi.h>
 #include <string>
 #include <cstring>
 #include <functional>
@@ -45,6 +46,23 @@
 #include <d2d1.h>      // For Direct2D
 #include <direct.h>    // For _getcwd
 #include <tlhelp32.h>  // For process enumeration
+
+#pragma comment(lib, "dwmapi.lib")
+
+#ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
+#define DWMWA_USE_IMMERSIVE_DARK_MODE 20
+#endif
+#ifndef DWMWA_BORDER_COLOR
+#define DWMWA_BORDER_COLOR 34
+#endif
+#ifndef DWMWA_CAPTION_COLOR
+#define DWMWA_CAPTION_COLOR 35
+#endif
+#ifndef DWMWA_TEXT_COLOR
+#define DWMWA_TEXT_COLOR 36
+#endif
+
+typedef LONG (WINAPI *RtlGetVersionPtr)(PRTL_OSVERSIONINFOW);
 
 // Shared cross-platform utilities
 #include "../shared/glob_match.h"
@@ -9157,6 +9175,49 @@ ELECTROBUN_EXPORT void testFFI2(void (*completionHandler)()) {
     }
 }
 
+static void applyTitleBarTheme(HWND hwnd, int32_t darkMode, uint32_t captionColor, uint32_t textColor, uint32_t borderColor) {
+    if (!hwnd || !IsWindow(hwnd)) return;
+
+    const uint32_t colorSentinel = 0xffffffff;
+    bool supportsDwmTitleBarColors = false;
+
+    HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
+    if (ntdll) {
+        auto rtlGetVersion = reinterpret_cast<RtlGetVersionPtr>(GetProcAddress(ntdll, "RtlGetVersion"));
+        if (rtlGetVersion) {
+            RTL_OSVERSIONINFOW versionInfo = {};
+            versionInfo.dwOSVersionInfoSize = sizeof(versionInfo);
+            if (rtlGetVersion(&versionInfo) == 0) {
+                supportsDwmTitleBarColors =
+                    versionInfo.dwMajorVersion > 10 ||
+                    (versionInfo.dwMajorVersion == 10 && versionInfo.dwBuildNumber >= 22000);
+            }
+        }
+    }
+
+    if (darkMode != -1) {
+        BOOL enabled = darkMode ? TRUE : FALSE;
+        DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &enabled, sizeof(enabled));
+    }
+
+    if (supportsDwmTitleBarColors && captionColor != colorSentinel) {
+        COLORREF color = static_cast<COLORREF>(captionColor);
+        DwmSetWindowAttribute(hwnd, DWMWA_CAPTION_COLOR, &color, sizeof(color));
+    }
+
+    if (supportsDwmTitleBarColors && textColor != colorSentinel) {
+        COLORREF color = static_cast<COLORREF>(textColor);
+        DwmSetWindowAttribute(hwnd, DWMWA_TEXT_COLOR, &color, sizeof(color));
+    }
+
+    if (supportsDwmTitleBarColors && borderColor != colorSentinel) {
+        COLORREF color = static_cast<COLORREF>(borderColor);
+        DwmSetWindowAttribute(hwnd, DWMWA_BORDER_COLOR, &color, sizeof(color));
+    }
+
+    RedrawWindow(hwnd, NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW | RDW_FRAME);
+}
+
 ELECTROBUN_EXPORT HWND createWindowWithFrameAndStyleFromWorker(
     uint32_t windowId,
     double x, double y,
@@ -9287,6 +9348,19 @@ ELECTROBUN_EXPORT HWND createWindowWithFrameAndStyleFromWorker(
     });
 
     return hwnd;
+}
+
+ELECTROBUN_EXPORT void setWindowTitleBarTheme(void* window, int32_t darkMode, uint32_t captionColor, uint32_t textColor, uint32_t borderColor) {
+    HWND hwnd = reinterpret_cast<HWND>(window);
+
+    if (!IsWindow(hwnd)) {
+        ::log("ERROR: Invalid window handle in setWindowTitleBarTheme");
+        return;
+    }
+
+    MainThreadDispatcher::dispatch_sync([=]() {
+        applyTitleBarTheme(hwnd, darkMode, captionColor, textColor, borderColor);
+    });
 }
 
 static void activateVisibleWindow(HWND hwnd) {

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -62,8 +62,6 @@
 #define DWMWA_TEXT_COLOR 36
 #endif
 
-typedef LONG (WINAPI *RtlGetVersionPtr)(PRTL_OSVERSIONINFOW);
-
 // Shared cross-platform utilities
 #include "../shared/glob_match.h"
 #include "../shared/callbacks.h"
@@ -9179,21 +9177,14 @@ static void applyTitleBarTheme(HWND hwnd, int32_t darkMode, uint32_t captionColo
     if (!hwnd || !IsWindow(hwnd)) return;
 
     const uint32_t colorSentinel = 0xffffffff;
-    bool supportsDwmTitleBarColors = false;
-
-    HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
-    if (ntdll) {
-        auto rtlGetVersion = reinterpret_cast<RtlGetVersionPtr>(GetProcAddress(ntdll, "RtlGetVersion"));
-        if (rtlGetVersion) {
-            RTL_OSVERSIONINFOW versionInfo = {};
-            versionInfo.dwOSVersionInfoSize = sizeof(versionInfo);
-            if (rtlGetVersion(&versionInfo) == 0) {
-                supportsDwmTitleBarColors =
-                    versionInfo.dwMajorVersion > 10 ||
-                    (versionInfo.dwMajorVersion == 10 && versionInfo.dwBuildNumber >= 22000);
-            }
-        }
+    if (darkMode == -1 &&
+        captionColor == colorSentinel &&
+        textColor == colorSentinel &&
+        borderColor == colorSentinel) {
+        return;
     }
+
+    const bool supportsDwmTitleBarColors = isWindowsBuildOrGreater(22000);
 
     if (darkMode != -1) {
         BOOL enabled = darkMode ? TRUE : FALSE;


### PR DESCRIPTION
## Summary

Adds a Windows native titlebar theme API for `BrowserWindow` and defers the initial HWND show until after the theme is applied.

So when user have a dark theme, we could make it work, and not show a white titlebar.

Flicker-fix fixes a first-paint issue where the window could briefly appear with the default white caption before the requested dark/custom titlebar styling was applied.

## What changed

- added `nativeTitleBar` options to `BrowserWindow`
  - `darkMode`
  - `captionColor`
  - `textColor`
  - `borderColor`
- validate color input in JS before crossing the FFI boundary
- only apply the native titlebar theme on:
  - Windows
  - `titleBarStyle: "default"`
- export no-op `setWindowTitleBarTheme` implementations on macOS/Linux so the FFI surface stays consistent
- stop showing the HWND inside native window creation on Windows
- let the higher-level bridge apply titlebar attributes first, then explicitly show the window

## Why this is safe

Before this change, the window was effectively shown twice on Windows:
- once during native creation
- again from the Bun bridge after setup

This PR removes the earlier native-side show so the theme can be applied before first paint. 
=> visibility is still controlled by the existing higher-level create/show flow.

## Scope

This PR is intentionally limited to the Windows native titlebar theme API and initial-show ordering.

It does not change DirectComposition behavior. The small `dcomp_compositor.h` change only reuses the existing Windows build detection helper needed for titlebar color gating.

## Tests

Added kitchen coverage for:
- creating a window with `nativeTitleBar` options
- rejecting invalid `#RRGGBB` color input before window creation

## Platform behavior

- Windows: applies native titlebar theming when supported
- macOS/Linux: no-op for the new symbol
