### PR TITLE
fix(macos/wkwebview): detach inspector before show to keep host webview visible

### DIFF
--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -2990,6 +2990,20 @@ runOpenPanelWithParameters:(WKOpenPanelParameters *)parameters
             // WKWebView doesn't have public DevTools API, but we can use private API if available
             if ([self.webView respondsToSelector:@selector(_inspector)]) {
                 id inspector = [self.webView performSelector:@selector(_inspector)];
+                // Force the inspector into its own NSWindow before showing.
+                // Default `[inspector show]` opens it docked, which reparents
+                // the host WKWebView into a split-view container; closing the
+                // docked panel does not always restore the original parent
+                // and leaves the host view orphaned. On windows configured
+                // with `transparent: true`, the user then sees an empty/
+                // transparent window — the WebContent process is still alive
+                // and there is no NSException, but the main view is no longer
+                // displayed. Detaching first keeps the inspector in a
+                // separate window so the host's view hierarchy is never
+                // disturbed.
+                if ([inspector respondsToSelector:@selector(detach)]) {
+                    [inspector performSelector:@selector(detach)];
+                }
                 if ([inspector respondsToSelector:@selector(show)]) {
                     [inspector performSelector:@selector(show)];
                 }


### PR DESCRIPTION
> [!WARNING]
> **This patch is untested locally** and was authored with significant LLM assistance (Claude). The hypothesis is plausible and matches the observed unified-log signal, but I have not yet rebuilt `libNativeWrapper.dylib` against this change to confirm. Please verify before merging — happy to iterate or close if the hypothesis is wrong.

## Symptom

In a downstream Electrobun app on macOS (Apple Silicon, recent macOS), opening the WebKit inspector via `openDevTools` and then closing the inspector window leaves the host `BrowserWindow` in a broken state: the window remains, the `bun` and host `WebContent` processes are both alive, no `NSException` is raised — but the main `WKWebView` is no longer displayed. On windows configured with `transparent: true` (which is what surfaced this) the user sees an empty/transparent window and assumes the app crashed.

Unified-log signal at the moment the inspector is closed is benign — `WebProcessProxy::canTerminateAuxiliaryProcess: returns true → shutDown` for the inspector's auxiliary `WebContent` process (the inspector UI itself runs as its own WKWebView), no abort, no exception. The host `WebContent` process keeps running, just not painting.

This is **not** the same bug as #190 (hover crash via `toggleMirrorMode:` unrecognized selector). No exceptions are raised here.

Related but distinct: #357 documents another docked-DevTools regression (host webview content scrolls/shifts when the panel opens) — same root area (host view-hierarchy gets disturbed by docked-inspector split-view reparenting), and the workaround listed there (*"use undocked DevTools window"*) is exactly what this PR enforces by default.

## Root-cause hypothesis

`package/src/native/macos/nativeWrapper.mm` opens devtools via:

```objc
id inspector = [self.webView performSelector:@selector(_inspector)];
[inspector performSelector:@selector(show)];
```

Default `_WKInspector show` opens **docked** (attached) — WebKit reparents the host `WKWebView` into a split-view container alongside the inspector view to render them side-by-side in the same `NSWindow`. When the docked panel is dismissed, WebKit's restore path does not always put the host webview back at its original spot in the parent's `subviews` (especially when the host's container is the `NSWindow.contentView` of a transparent, layer-backed, full-size-content window). The host view is then orphaned in the hierarchy.

This matches the symptom precisely: process alive, no exception, no NSWindow gone, but no host content rendered.

The CEF path in this same file already guards against an analogous teardown problem with `RemoteDevToolsWindowDelegate.windowShouldClose:` returning `NO` and calling `orderOut:` — comment: *"Prevent NSWindow from actually closing to avoid CEF teardown crashes."* The WKWebView path has no equivalent guard.

## Fix

Force the inspector into its own `NSWindow` before showing by sending `detach` first. `_WKInspector` exposes `attach`/`detach` selectors (used internally by Safari for its docked/undocked toggle). Calling `detach` before `show` keeps the inspector in a separate window so the host's view hierarchy is never disturbed by reparenting.

```diff
 - (void)openDevTools {
     dispatch_async(dispatch_get_main_queue(), ^{
         if ([self.webView respondsToSelector:@selector(_inspector)]) {
             id inspector = [self.webView performSelector:@selector(_inspector)];
+            if ([inspector respondsToSelector:@selector(detach)]) {
+                [inspector performSelector:@selector(detach)];
+            }
             if ([inspector respondsToSelector:@selector(show)]) {
                 [inspector performSelector:@selector(show)];
             }
         }
     });
 }
```

`respondsToSelector:` guards keep this safe across macOS versions if Apple ever renames the private selector.

## Trade-off

Inspector always opens undocked. Users who previously relied on the docked layout lose that mode. Given the alternative is the host view silently going invisible, undocked-only is the safer default — and matches what other WKWebView-based desktop frameworks (e.g. Tauri) do.

If you want to preserve the docked option behind an opt-in, happy to wire it through the existing `BrowserWindow`/`BrowserView` config surface in a follow-up.

## Repro context

- macOS 15.x, arm64
- `transparent: true`, `titleBarStyle: "hiddenInset"`, `FullSizeContentView` on the host window
- `electrobun` ~1.16.x via npm in the downstream app

## Test plan (for reviewer with build env)

- [ ] Build `libNativeWrapper.dylib` with the patch
- [ ] Open a built sample app, hit `openDevTools` (or its keyboard binding)
- [ ] Confirm inspector appears in its own window
- [ ] Close the inspector window
- [ ] Confirm host window keeps rendering (was previously transparent/empty)
- [ ] Repeat with a non-transparent window to confirm no regression there
