### PR TITLE
Parse URI fragment, query, and percent-encoding in scheme handlers

### DIFF
--- a/package/src/native/linux/nativeWrapper.cpp
+++ b/package/src/native/linux/nativeWrapper.cpp
@@ -525,6 +525,47 @@ public:
     IMPLEMENT_REFCOUNTING(ElectrobunResponseFilter);
 };
 
+// Percent-decode a URI path component in place per RFC 3986 (UTF-8 byte-wise;
+// invalid escapes are passed through as-is, matching browser behavior).
+static inline void percentDecodeInPlace(std::string& s) {
+    std::string out;
+    out.reserve(s.size());
+    for (size_t i = 0; i < s.size(); ++i) {
+        if (s[i] == '%' && i + 2 < s.size()) {
+            auto hex = [](char c) -> int {
+                if (c >= '0' && c <= '9') return c - '0';
+                if (c >= 'a' && c <= 'f') return 10 + (c - 'a');
+                if (c >= 'A' && c <= 'F') return 10 + (c - 'A');
+                return -1;
+            };
+            int hi = hex(s[i + 1]);
+            int lo = hex(s[i + 2]);
+            if (hi >= 0 && lo >= 0) {
+                out.push_back(static_cast<char>((hi << 4) | lo));
+                i += 2;
+                continue;
+            }
+        }
+        out.push_back(s[i]);
+    }
+    s = std::move(out);
+}
+
+// Normalize a views:// relative path per RFC 3986: strip fragment (#...) and
+// query (?...) — which are URL metadata, not part of the resource path — and
+// percent-decode the remainder so it matches the on-disk filename.
+static inline void stripViewsUrlMeta(std::string& path) {
+    size_t fragmentPos = path.find('#');
+    if (fragmentPos != std::string::npos) {
+        path.resize(fragmentPos);
+    }
+    size_t queryPos = path.find('?');
+    if (queryPos != std::string::npos) {
+        path.resize(queryPos);
+    }
+    percentDecodeInPlace(path);
+}
+
 // CEF views:// scheme handler implementation
 class ViewsResourceHandler : public CefResourceHandler {
 public:
@@ -537,6 +578,7 @@ public:
         std::string fullPath = "index.html"; // default
         if (url.find("views://") == 0) {
             fullPath = url.substr(8); // Skip "views://"
+            stripViewsUrlMeta(fullPath);
             // Strip trailing slashes - WebKit may normalize URLs without folder components
             while (!fullPath.empty() && (fullPath.back() == '/' || fullPath.back() == '\\')) {
                 fullPath.pop_back();
@@ -5208,13 +5250,14 @@ static void handleViewsURIScheme(WebKitURISchemeRequest* request, gpointer user_
     
     // Parse the full URI to get everything after views://
     // For views://webviewtag/index.html, we want "webviewtag/index.html"
-    const char* fullPath = "index.html"; // default
+    std::string fullPath = "index.html"; // default
     if (uri && strncmp(uri, "views://", 8) == 0) {
         fullPath = uri + 8; // Skip "views://"
+        stripViewsUrlMeta(fullPath);
     }
-    
+
     // Check if this is the internal HTML request
-    if (strcmp(fullPath, "internal/index.html") == 0) {
+    if (fullPath == "internal/index.html") {
         fflush(stdout);
         
         // Resolve the webviewId by matching the requesting WebKitWebView to g_webviewMap
@@ -5277,7 +5320,7 @@ static void handleViewsURIScheme(WebKitURISchemeRequest* request, gpointer user_
         // If ASAR archive is loaded, try to read from it
         if (g_asarArchive) {
             // The ASAR contains the entire app directory, so prepend "views/" to the path
-            std::string asarFilePath = "views/" + std::string(fullPath);
+            std::string asarFilePath = "views/" + fullPath;
 
             size_t asarFileSize = 0;
             const uint8_t* fileData = nullptr;
@@ -5308,7 +5351,7 @@ static void handleViewsURIScheme(WebKitURISchemeRequest* request, gpointer user_
     // Fallback: Read from flat file system (for non-ASAR builds or missing files)
     if (!foundFile) {
         gchar* viewsDir = g_build_filename(resourcesDir, "app", "views", nullptr);
-        gchar* filePath = g_build_filename(viewsDir, fullPath, nullptr);
+        gchar* filePath = g_build_filename(viewsDir, fullPath.c_str(), nullptr);
 
         fflush(stdout);
 
@@ -5345,7 +5388,7 @@ static void handleViewsURIScheme(WebKitURISchemeRequest* request, gpointer user_
         g_object_unref(stream);
     } else {
         // Return 404 error
-        GError* responseError = g_error_new(G_IO_ERROR, G_IO_ERROR_NOT_FOUND, "File not found: %s", fullPath);
+        GError* responseError = g_error_new(G_IO_ERROR, G_IO_ERROR_NOT_FOUND, "File not found: %s", fullPath.c_str());
         webkit_uri_scheme_request_finish_error(request, responseError);
         g_error_free(responseError);
     }

--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -731,9 +731,25 @@ static NSString* normalizeViewsRelativePath(NSString *urlString) {
     while ([relativePath hasPrefix:@"/"]) {
         relativePath = [relativePath substringFromIndex:1];
     }
+    // Strip fragment (#...) and query (?...) per RFC 3986 — they are URL
+    // metadata, not part of the resource path, and must not be passed to
+    // the filesystem.
+    NSRange fragmentRange = [relativePath rangeOfString:@"#"];
+    if (fragmentRange.location != NSNotFound) {
+        relativePath = [relativePath substringToIndex:fragmentRange.location];
+    }
+    NSRange queryRange = [relativePath rangeOfString:@"?"];
+    if (queryRange.location != NSNotFound) {
+        relativePath = [relativePath substringToIndex:queryRange.location];
+    }
     // Strip trailing slashes - WebView may normalize URLs without folder components
     while ([relativePath hasSuffix:@"/"] && [relativePath length] > 0) {
         relativePath = [relativePath substringToIndex:[relativePath length] - 1];
+    }
+    // Percent-decode per RFC 3986 so the path matches the on-disk filename.
+    NSString *decoded = [relativePath stringByRemovingPercentEncoding];
+    if (decoded) {
+        relativePath = decoded;
     }
 
     return relativePath;
@@ -5777,9 +5793,24 @@ public:
                 NSLog(@"DEBUG CEF: Processing views:// URL: %s", urlStr.c_str());
                 // Remove the prefix (8 characters for "views://") - FIXED VERSION v2
                 std::string relativePath = urlStr.substr(8);
+                // Strip fragment (#...) and query (?...) per RFC 3986 — they
+                // are URL metadata, not part of the resource path.
+                size_t fragmentPos = relativePath.find('#');
+                if (fragmentPos != std::string::npos) {
+                    relativePath.resize(fragmentPos);
+                }
+                size_t queryPos = relativePath.find('?');
+                if (queryPos != std::string::npos) {
+                    relativePath.resize(queryPos);
+                }
                 // Strip trailing slashes - WebView may normalize URLs without folder components
                 while (!relativePath.empty() && (relativePath.back() == '/' || relativePath.back() == '\\')) {
                     relativePath.pop_back();
+                }
+                // Percent-decode per RFC 3986 so the path matches the on-disk filename.
+                NSString *decodedNS = [[NSString stringWithUTF8String:relativePath.c_str()] stringByRemovingPercentEncoding];
+                if (decodedNS) {
+                    relativePath = std::string([decodedNS UTF8String]);
                 }
                 NSLog(@"DEBUG CEF FIXED: relativePath = '%s'", relativePath.c_str());
                 

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -780,6 +780,47 @@ static void EnsureDevToolsWindowClassRegistered() {
 std::string loadViewsFile(const std::string& path);
 std::string getMimeTypeForFile(const std::string& path);
 
+// Percent-decode a URI path component in place per RFC 3986 (UTF-8 byte-wise;
+// invalid escapes are passed through as-is, matching browser behavior).
+static inline void percentDecodeInPlace(std::string& s) {
+    std::string out;
+    out.reserve(s.size());
+    for (size_t i = 0; i < s.size(); ++i) {
+        if (s[i] == '%' && i + 2 < s.size()) {
+            auto hex = [](char c) -> int {
+                if (c >= '0' && c <= '9') return c - '0';
+                if (c >= 'a' && c <= 'f') return 10 + (c - 'a');
+                if (c >= 'A' && c <= 'F') return 10 + (c - 'A');
+                return -1;
+            };
+            int hi = hex(s[i + 1]);
+            int lo = hex(s[i + 2]);
+            if (hi >= 0 && lo >= 0) {
+                out.push_back(static_cast<char>((hi << 4) | lo));
+                i += 2;
+                continue;
+            }
+        }
+        out.push_back(s[i]);
+    }
+    s = std::move(out);
+}
+
+// Normalize a views:// relative path per RFC 3986: strip fragment (#...) and
+// query (?...) — which are URL metadata, not part of the resource path — and
+// percent-decode the remainder so it matches the on-disk filename.
+static inline void stripViewsUrlMeta(std::string& path) {
+    size_t fragmentPos = path.find('#');
+    if (fragmentPos != std::string::npos) {
+        path.resize(fragmentPos);
+    }
+    size_t queryPos = path.find('?');
+    if (queryPos != std::string::npos) {
+        path.resize(queryPos);
+    }
+    percentDecodeInPlace(path);
+}
+
 // CEF Resource Handler for views:// scheme (based on Mac implementation)
 class ElectrobunSchemeHandler : public CefResourceHandler {
 public:
@@ -791,6 +832,7 @@ public:
 
         std::string url = request->GetURL();
         std::string path = url.substr(8); // Remove "views://" prefix
+        stripViewsUrlMeta(path);
         if (path.empty()) path = "index.html";
 
         std::string content;
@@ -6115,6 +6157,7 @@ static std::shared_ptr<WebView2View> createWebView2View(uint32_t webviewId,
                                         
                                         if (uriStr.substr(0, 8) == "views://") {
                                             std::string filePath = uriStr.substr(8);
+                                            stripViewsUrlMeta(filePath);
                                             // Strip trailing slashes - WebView2 may normalize URLs without folder components
                                             while (!filePath.empty() && (filePath.back() == '/' || filePath.back() == '\\')) {
                                                 filePath.pop_back();
@@ -11103,6 +11146,7 @@ void handleViewsSchemeRequest(ICoreWebView2WebResourceRequestedEventArgs* args,
     std::string path;
     if (uriStr.length() > 8) {
         path = uriStr.substr(8); // Remove "views://" prefix
+        stripViewsUrlMeta(path);
         // Strip trailing slashes - WebView2 may normalize URLs without folder components
         while (!path.empty() && (path.back() == '/' || path.back() == '\\')) {
             path.pop_back();


### PR DESCRIPTION
## Summary

The `views://` scheme handlers passed the raw URL substring (after stripping `views://`) directly to the file system. This treated URI metadata — fragment, query, and percent-encoding — as part of the filename, breaking standard URI semantics.

## What this fixes

Issue: https://github.com/blackboardsh/electrobun/issues/211

Strip `#fragment` and `?query`, then percent-decode the remaining path before resolving to disk. Applied across all five `views://` entry points:

- macOS WKWebView (`normalizeViewsRelativePath`)
- macOS CEF resource handler
- Windows CEF resource handler
- Windows WebView2 `WebResourceRequested` handler
- Windows `handleViewsSchemeRequest`
- Linux WebKitGTK URI scheme handler
- Linux CEF resource handler

## Examples

| URL | Before (file lookup) | After |
|---|---|---|
| `views://mainview/index.html#/settings` | `index.html#/settings` (404) | `index.html` ✓ |
| `views://mainview/data.json?v=2` | `data.json?v=2` (404) | `data.json` ✓ |
| `views://mainview/my%20file.html` | `my%20file.html` (404) | `my file.html` ✓ |
| `views://mainview/café.html` (encoded as `caf%C3%A9.html`) | `caf%C3%A9.html` (404) | `café.html` ✓ |

## Pitfall this resolves

Hash-based SPA routing was unusable. A standard setup —

```js
// router loads views://mainview/index.html, then navigates client-side
location.hash = '#/settings/sub-settings';
```

— worked on first paint, but refresh caused the webview to re-request `views://mainview/index.html#/settings/sub-settings`. The handler tried to open a file named `sub-settings` in the dirs `index.html#/settings` and 404'd, blanking the view. With this fix, refresh resolves to index.html and the router reads the fragment client-side as expected.

The same class of bug affected querystring cache-busting (?v=2) and any file with spaces or non-ASCII characters in the name.

## Test plan

- Load `views://mainview/index.html#/foo` and refresh — page still renders
- Load a view with a querystring — file resolves
- Place a file with a space or unicode char in views and load it
- Existing views without fragment/query still load (regression check)
- All native targets: WKWebView (mac), CEF (mac), WebView2 (win), CEF (win), WebKitGTK (linux), CEF (linux)