### PR TITLE
fix(macos): block OS title-bar drag on hiddenInset windows

### DIFF
--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -7195,6 +7195,14 @@ NSWindow *createNSWindowWithFrameAndStyle(uint32_t windowId,
     if (strcmp(config.titleBarStyle, "hiddenInset") == 0) {
         window.titlebarAppearsTransparent = YES;
         window.titleVisibility = NSWindowTitleHidden;
+        // With hiddenInset + FullSizeContentView, macOS still treats the
+        // title-bar strip (~28px under the traffic lights) as a drag region
+        // and clicks on host-app buttons positioned there start a window move
+        // before the webview ever sees the event. Disable OS-level
+        // background/title-bar drag and let the preload's
+        // electrobun-webkit-app-region-drag class drive window moves
+        // explicitly. setFrameOrigin: (used by startWindowMove) still works.
+        [window setMovable:NO];
     }
     objc_setAssociatedObject(window, kTrafficLightTitleBarStyleKey, [NSString stringWithUTF8String:config.titleBarStyle ?: "default"], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(window, kTrafficLightOffsetXKey, @(config.trafficLightOffsetX), OBJC_ASSOCIATION_RETAIN_NONATOMIC);


### PR DESCRIPTION
## Problem

With `titleBarStyle: "hiddenInset"` (which sets `titlebarAppearsTransparent` and `NSWindowStyleMaskFullSizeContentView`), macOS still treats the top ~28px of the window as a draggable title-bar region. Clicks on host-app buttons or other interactive UI placed in that strip start a window move before the webview's `mousedown` listener ever sees the event. The preload's `electrobun-webkit-app-region-drag` / `electrobun-webkit-app-region-no-drag` class detection becomes ineffective for any UI that overlaps the inset area, even though the rest of the chrome works correctly.

**Repro:** a 40px custom nav under `hiddenInset`, with `electrobun-webkit-app-region-no-drag` on every button — clicking and dragging on a button still moves the window.

## Root cause

`hiddenInset` only hides the title bar visually; the window's `isMovable` property defaults to `YES`, so AppKit continues to handle background/title-bar drag at the OS level for the inset strip. That path runs before any JavaScript and bypasses the preload entirely.

CEF doesn't help here either: `-webkit-app-region: drag/no-drag` is honored by Electron because of a custom Chromium patch plus an implementation of `CefDragHandler::OnDraggableRegionsChanged` that bridges Blink's draggable regions to the native `NSWindow`. Vanilla CEF (what Electrobun uses) does neither, so CSS-based opt-out is a no-op under CEF as well. For `hiddenInset`, the preload's class-based detection is effectively the only mechanism that controls drag.

## Fix

Call `[window setMovable:NO]` when `titleBarStyle == "hiddenInset"`. The OS no longer initiates window moves from background/title-bar clicks, so the preload's class-based detection is the sole driver of window drag — which is what the rest of the codebase already assumes. The explicit drag path (`startWindowMove` → `setFrameOrigin:`) is unaffected by `isMovable`, so empty regions of a nav tagged with `electrobun-webkit-app-region-drag` continue to move the window normally.

Scoped to `hiddenInset` only — `default` and `hidden` styles are untouched.

## Notes for reviewers

- I have not finished end-to-end verification yet on my side — the patch builds cleanly against the linked source checkout (`bun run build:dev` produces a fresh `libNativeWrapper.dylib`), and the reasoning above is based on reading the existing `createNSWindowWithFrameAndStyle` path plus AppKit's `isMovable` semantics.
- `setMovable:NO` only blocks user-initiated background drag; programmatic moves via `setFrameOrigin:` (which `startWindowMove` uses) are unaffected, so I don't expect regressions in the existing JS-driven drag path or in window restore / focus moves. Worth confirming on a stock template that uses `hiddenInset`.
- Traffic-light hit-testing should be unaffected since they're standard window buttons, not background drag.
