### PR TITLE
fix: use newline delimiter for file dialog paths instead of comma

### DIFF
--- a/package/src/bun/core/Utils.ts
+++ b/package/src/bun/core/Utils.ts
@@ -187,7 +187,7 @@ export const openFileDialog = async (
 		allowsMultipleSelection: optsWithDefault.allowsMultipleSelection,
 	});
 
-	const filePaths = result.split(",");
+	const filePaths = result.split("\n").filter(Boolean);
 	return filePaths;
 };
 

--- a/package/src/native/linux/nativeWrapper.cpp
+++ b/package/src/native/linux/nativeWrapper.cpp
@@ -9010,7 +9010,7 @@ ELECTROBUN_EXPORT const char* openFileDialog(const char* startingFolder, const c
                 
                 while (iter != nullptr) {
                     if (!resultString.empty()) {
-                        resultString += ","; // Separate multiple files with comma (like Mac)
+                        resultString += "\n"; // Separate multiple files with newline
                     }
                     resultString += (char*)iter->data;
                     g_free(iter->data);

--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -7806,7 +7806,7 @@ extern "C" const char *openFileDialog(const char *startingFolder,
             for (NSURL *u in selectedFileURLs) {
                 [pathStrings addObject:u.path];
             }
-            concatenatedPaths = [pathStrings componentsJoinedByString:@","];
+            concatenatedPaths = [pathStrings componentsJoinedByString:@"\n"];
         }        
     });
     

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -10105,9 +10105,9 @@ ELECTROBUN_EXPORT const char* openFileDialog(const char *startingFolder,
                 }
                 pShellItemArray->Release();
                 
-                // Join paths with comma
+                // Join paths with newline
                 for (size_t i = 0; i < paths.size(); i++) {
-                    if (i > 0) result += ",";
+                    if (i > 0) result += "\n";
                     result += paths[i];
                 }
             }


### PR DESCRIPTION
## Summary

File dialog paths were being joined with commas, which breaks when file paths themselves contain commas. This change uses newline as the delimiter across all platforms.

## Changes

- `package/src/native/linux/nativeWrapper.cpp` — Changed multi-file separator from `,` to `\n`
- `package/src/bun/core/Utils.ts` — Updated path parsing to split on `\n` instead of `,`
- `package/src/native/macos/nativeWrapper.mm` — Updated path separator to `\n` (untested)
- `package/src/native/win/nativeWrapper.cpp` — Updated path separator to `\n` (untested)

## Testing

- [x] Tested on Linux
- [ ] Needs testing on macOS
- [ ] Needs testing on Windows

**Note:** I only have a Linux machine available. The macOS and Windows native wrapper changes follow the same pattern but need to be verified by someone with access to those platforms.