### PR TITLE
Fix x86_64 launcher SIGSEGV by adding -Dcpu=baseline

### DIFF
--- a/package/build.ts
+++ b/package/build.ts
@@ -2034,13 +2034,13 @@ async function buildLauncher() {
 		if (ARCH === "arm64") {
 			zigArgs = ["-Dtarget=aarch64-linux"];
 		} else {
-			zigArgs = ["-Dtarget=x86_64-linux"];
+			zigArgs = ["-Dtarget=x86_64-linux", "-Dcpu=baseline"];
 		}
 	} else if (OS === "macos") {
 		if (ARCH === "arm64") {
 			zigArgs = ["-Dtarget=aarch64-macos"];
 		} else {
-			zigArgs = ["-Dtarget=x86_64-macos"];
+			zigArgs = ["-Dtarget=x86_64-macos", "-Dcpu=baseline"];
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Add `-Dcpu=baseline` to macOS and Linux x86_64 launcher Zig builds to prevent SIGSEGV crashes on Intel machines

## Problem

The x86_64 launcher binary crashes with `EXC_BAD_ACCESS (SIGSEGV)` on Intel Macs when built on ARM64 machines (via Rosetta or cross-compilation). The crash occurs in `fs.path.resolve` before any user code runs.

**Root cause:** The Zig build for macOS and Linux x86_64 launchers was missing the `-Dcpu=baseline` flag, allowing the compiler to emit CPU-specific instructions from the build machine. When the resulting binary runs on an Intel Mac with a different CPU feature set, it crashes.

## Fix

Add `-Dcpu=baseline` to the two missing x86_64 build configurations in `package/build.ts`:
- macOS x86_64 launcher (line ~2043)
- Linux x86_64 launcher (line ~2037)

This matches the existing pattern — Windows x86_64 launcher (line ~2032) and the self-extractor (line ~2081) already had `-Dcpu=baseline`.

## Testing

- Verified the fix resolves the SIGSEGV on an Intel Mac (x86_64) running an ElectroBun app built on ARM64
- No impact on ARM64 builds (flag only applies to x86_64 targets)

Fixes #415