### PR TITLE
win: enable WebView2 non-client region support and Aero Snap for hiddenInset windows

### DIFF
--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -6056,7 +6056,24 @@ static std::shared_ptr<WebView2View> createWebView2View(uint32_t webviewId,
                             
                             view->setController(ctrl);
                             view->setWebView(webview);
-                            
+
+                            // Enable native Win32 non-client region support so CSS `app-region: drag`
+                            // is honored by WebView2's WndProc on Chromium's thread (which already
+                            // owns input capture), letting the OS run its modal move loop natively.
+                            // This delivers Aero Snap, drag-from-maximized, double-click-to-maximize,
+                            // Aero Shake, and the right-click/Alt+Space system menu.
+                            // Requires WebView2 Runtime >= Edge 120 (SDK 1.0.2420.47).
+                            // QueryInterface silently no-ops on older runtimes.
+                            {
+                                ComPtr<ICoreWebView2Settings> settings;
+                                if (SUCCEEDED(webview->get_Settings(&settings)) && settings) {
+                                    ComPtr<ICoreWebView2Settings9> settings9;
+                                    if (SUCCEEDED(settings.As(&settings9)) && settings9) {
+                                        settings9->put_IsNonClientRegionSupportEnabled(TRUE);
+                                    }
+                                }
+                            }
+
                             // Try to get composition controller interface if available
                             ComPtr<ICoreWebView2CompositionController> compCtrl;
                             HRESULT compResult = ctrl->QueryInterface(IID_PPV_ARGS(&compCtrl));

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -9229,7 +9229,8 @@ ELECTROBUN_EXPORT HWND createWindowWithFrameAndStyleFromWorker(
             // We use WS_CAPTION | WS_THICKFRAME so the system treats it as a
             // standard framed window (giving us shadow and border resizing),
             // then remove the caption bar area in WM_NCCALCSIZE.
-            windowStyle = WS_VISIBLE | WS_CAPTION | WS_THICKFRAME | WS_CLIPCHILDREN | WS_CLIPSIBLINGS;
+            windowStyle = WS_VISIBLE | WS_CAPTION | WS_THICKFRAME | WS_CLIPCHILDREN | WS_CLIPSIBLINGS
+                        | WS_MAXIMIZEBOX | WS_MINIMIZEBOX | WS_SYSMENU;
             data->chromeStyle = ChromeStyle::HiddenInset;
         }
         // else: default titleBarStyle = WS_OVERLAPPEDWINDOW (standard window)


### PR DESCRIPTION
Partial fix for #395 (`hiddenInset` only — `hidden` uses `WS_POPUP` so these flags are no-ops there by Win32 design).

  Two changes:
  1. Enable `ICoreWebView2Settings9::put_IsNonClientRegionSupportEnabled(TRUE)` so WebView2 honors CSS `app-region: drag` on its own thread, letting the OS
  run the modal move loop natively. Gracefully no-ops on runtimes older than Edge 120 (SDK 1.0.2420.47).
  2. Add `WS_MAXIMIZEBOX | WS_MINIMIZEBOX | WS_SYSMENU` to the `hiddenInset` window style — without these, Aero Snap, Aero Shake, and the system menu
  silently fail even with #1 in place. `WM_NCCALCSIZE` still collapses the visible caption so no native caption strip is exposed.

  **Test**
  - [ ] Drag title bar to screen top/edges/corners → Aero Snap
  - [ ] Right-click title bar / Alt+Space → system menu
  - [ ] No native caption strip visible

# AI
Hello I wrote this using Claude as it was a problem I was experiencing making my own app using Electrobun. Used Claude cause its out of my depth to solve by myself. I hope this PR is helpful. Thanks :)