### PR TITLE
feature (WIN) / optional custom user agent support for webview2

### DIFF
--- a/package/src/browser/webviewtag.ts
+++ b/package/src/browser/webviewtag.ts
@@ -32,6 +32,7 @@ interface WebviewTagElement extends HTMLElement {
 	html: string | null;
 	preload: string | null;
 	renderer: "cef" | "native";
+	userAgent?: string | null;
 
 	// Mask management
 	addMaskSelector(selector: string): void;

--- a/package/src/bun/core/BrowserView.ts
+++ b/package/src/bun/core/BrowserView.ts
@@ -49,6 +49,8 @@ export type BrowserViewOptions<T = undefined> = {
 	startTransparent: boolean;
 	// Set passthrough on the AbstractView at creation (before first paint)
 	startPassthrough: boolean;
+	// Optional custom user agent for this webview
+	userAgent?: string | null;
 	// renderer:
 };
 
@@ -105,6 +107,7 @@ export class BrowserView<T extends RPCWithTransport = RPCWithTransport> {
 	// Sandbox mode disables RPC and only allows event emission (for untrusted content)
 	sandbox: boolean = false;
 	startTransparent: boolean = false;
+	userAgent: string | null;
 	startPassthrough: boolean = false;
 	isRemoved: boolean = false;
 
@@ -135,6 +138,7 @@ export class BrowserView<T extends RPCWithTransport = RPCWithTransport> {
 		this.sandbox = options.sandbox ?? false;
 		this.startTransparent = options.startTransparent ?? false;
 		this.startPassthrough = options.startPassthrough ?? false;
+		this.userAgent = options.userAgent ?? null;
 
 		BrowserViewMap[this.id] = this;
 		this.ptr = this.init() as Pointer;
@@ -176,6 +180,7 @@ export class BrowserView<T extends RPCWithTransport = RPCWithTransport> {
 			sandbox: this.sandbox,
 			startTransparent: this.startTransparent,
 			startPassthrough: this.startPassthrough,
+			userAgent: this.userAgent ?? null,
 			// transparent is looked up from parent window in native.ts
 		});
 	}
@@ -351,15 +356,15 @@ export class BrowserView<T extends RPCWithTransport = RPCWithTransport> {
 		delete BrowserViewMap[this.id];
 		removeSocketForWebview(this.id);
 		this.rpc?.setTransport({
-			send() {},
-			registerHandler() {},
-			unregisterHandler() {},
+			send() { },
+			registerHandler() { },
+			unregisterHandler() { },
 		});
 		this.rpcHandler = undefined;
-    
-    this.rpcHandler = undefined;
-    this.ptr = null;
-    native!.symbols.webviewRemove(ptr);
+
+		this.rpcHandler = undefined;
+		this.ptr = null;
+		native!.symbols.webviewRemove(ptr);
 	}
 
 	static getById(id: number) {

--- a/package/src/bun/preload/webviewTag.ts
+++ b/package/src/bun/preload/webviewTag.ts
@@ -85,6 +85,7 @@ export class ElectrobunWebviewTag extends HTMLElement {
 			| "native"
 			| "cef";
 		const masks = this.getAttribute("masks");
+		const userAgent = this.getAttribute("user-agent") || this.getAttribute("userAgent");
 		// Sandbox attribute: when present, the child webview is sandboxed (no RPC, events only)
 		const sandbox = this.hasAttribute("sandbox");
 		this.sandboxed = sandbox;
@@ -119,6 +120,7 @@ export class ElectrobunWebviewTag extends HTMLElement {
 				sandbox,
 				transparent,
 				passthrough,
+				userAgent,
 			})) as number;
 
 			this.webviewId = webviewId;

--- a/package/src/bun/proc/native.ts
+++ b/package/src/bun/proc/native.ts
@@ -186,18 +186,18 @@ export const native = (() => {
 				args: [FFIType.ptr],
 				returns: FFIType.bool,
 			},
-				setWindowPosition: {
-					args: [FFIType.ptr, FFIType.f64, FFIType.f64],
-					returns: FFIType.void,
-				},
-				setWindowButtonPosition: {
-					args: [FFIType.ptr, FFIType.f64, FFIType.f64],
-					returns: FFIType.void,
-				},
-				setWindowSize: {
-					args: [FFIType.ptr, FFIType.f64, FFIType.f64],
-					returns: FFIType.void,
-				},
+			setWindowPosition: {
+				args: [FFIType.ptr, FFIType.f64, FFIType.f64],
+				returns: FFIType.void,
+			},
+			setWindowButtonPosition: {
+				args: [FFIType.ptr, FFIType.f64, FFIType.f64],
+				returns: FFIType.void,
+			},
+			setWindowSize: {
+				args: [FFIType.ptr, FFIType.f64, FFIType.f64],
+				returns: FFIType.void,
+			},
 			setWindowFrame: {
 				args: [FFIType.ptr, FFIType.f64, FFIType.f64, FFIType.f64, FFIType.f64],
 				returns: FFIType.void,
@@ -227,6 +227,7 @@ export const native = (() => {
 					FFIType.cstring, // electrobunPreloadScript
 					FFIType.cstring, // customPreloadScript
 					FFIType.cstring, // viewsRoot
+					FFIType.cstring, // userAgent (optional)
 					FFIType.bool, // transparent
 					FFIType.bool, // sandbox - when true, bunBridge and internalBridge are not set up
 				],
@@ -1127,32 +1128,32 @@ const _ffiImpl = {
 			return native_.symbols.isWindowVisibleOnAllWorkspaces(windowPtr);
 		},
 
-			setWindowPosition: (params: { winId: number; x: number; y: number }) => {
-				const { winId, x, y } = params;
-				const windowPtr = getWindowPtr(winId);
+		setWindowPosition: (params: { winId: number; x: number; y: number }) => {
+			const { winId, x, y } = params;
+			const windowPtr = getWindowPtr(winId);
 
-				if (!windowPtr) {
-					throw `Can't set window position. Window no longer exists`;
-				}
+			if (!windowPtr) {
+				throw `Can't set window position. Window no longer exists`;
+			}
 
-				native_.symbols.setWindowPosition(windowPtr, x, y);
-			},
+			native_.symbols.setWindowPosition(windowPtr, x, y);
+		},
 
-			setWindowButtonPosition: (params: { winId: number; x: number; y: number }) => {
-				const { winId, x, y } = params;
-				const windowPtr = getWindowPtr(winId);
+		setWindowButtonPosition: (params: { winId: number; x: number; y: number }) => {
+			const { winId, x, y } = params;
+			const windowPtr = getWindowPtr(winId);
 
-				if (!windowPtr) {
-					throw `Can't set window button position. Window no longer exists`;
-				}
+			if (!windowPtr) {
+				throw `Can't set window button position. Window no longer exists`;
+			}
 
-				native_.symbols.setWindowButtonPosition(windowPtr, x, y);
-			},
+			native_.symbols.setWindowButtonPosition(windowPtr, x, y);
+		},
 
-			setWindowSize: (params: {
-				winId: number;
-				width: number;
-				height: number;
+		setWindowSize: (params: {
+			winId: number;
+			width: number;
+			height: number;
 		}) => {
 			const { winId, width, height } = params;
 			const windowPtr = getWindowPtr(winId);
@@ -1237,6 +1238,7 @@ const _ffiImpl = {
 			sandbox: boolean;
 			startTransparent: boolean;
 			startPassthrough: boolean;
+			userAgent?: string | null;
 		}): FFIType.ptr => {
 			const {
 				id,
@@ -1256,6 +1258,7 @@ const _ffiImpl = {
 				sandbox,
 				startTransparent,
 				startPassthrough,
+				userAgent,
 			} = params;
 
 			const parentWindow = BrowserWindow.getById(windowId);
@@ -1329,6 +1332,7 @@ window.__electrobunBunBridge = window.__electrobunBunBridge || window.webkit?.me
 				toCString(electrobunPreload),
 				toCString(customPreload || ""),
 				toCString(viewsRoot || ""),
+				toCString(userAgent || ""),
 				transparent,
 				sandbox, // When true, bunBridge and internalBridge are not set up in native code
 			);
@@ -2000,12 +2004,12 @@ const windowBlurCallback = new JSCallback(
 		const event = handler({
 			id,
 		});
-		
+
 		// global event
-        electrobunEventEmitter.emitEvent(event);
-        electrobunEventEmitter.emitEvent(event, id);
-  },
-  {
+		electrobunEventEmitter.emitEvent(event);
+		electrobunEventEmitter.emitEvent(event, id);
+	},
+	{
 		args: ["u32"],
 		returns: "void",
 		threadsafe: true,
@@ -2453,8 +2457,8 @@ const webviewEventHandler = (id: number, eventName: string, detail: string) => {
 	const mappedName = eventMap[eventName];
 	const handler = mappedName
 		? (electrobunEventEmitter.events.webview as Record<string, unknown>)[
-				mappedName
-			]
+		mappedName
+		]
 		: undefined;
 
 	if (!handler) {
@@ -2760,6 +2764,7 @@ type WebviewTagInitParams = {
 	sandbox: boolean;
 	transparent: boolean;
 	passthrough: boolean;
+	userAgent?: string | null;
 };
 
 type WgpuTagInitParams = {
@@ -2785,6 +2790,7 @@ export const internalRpcHandlers = {
 				sandbox,
 				transparent,
 				passthrough,
+				userAgent,
 			} = params;
 
 			const url = !params.url && !html ? "https://electrobun.dev" : params.url;
@@ -2803,6 +2809,7 @@ export const internalRpcHandlers = {
 				sandbox,
 				startTransparent: transparent,
 				startPassthrough: passthrough,
+				userAgent: userAgent ?? null,
 			});
 
 			return webviewForTag.id;
@@ -3177,40 +3184,40 @@ export const internalRpcHandlers = {
 export type MenuItemConfig =
 	| { type: "divider" | "separator" }
 	| {
-			type: "normal";
-			label: string;
-			tooltip?: string;
-			action?: string;
-			data?: any;
-			submenu?: Array<MenuItemConfig>;
-			enabled?: boolean;
-			checked?: boolean;
-			hidden?: boolean;
-	  };
+		type: "normal";
+		label: string;
+		tooltip?: string;
+		action?: string;
+		data?: any;
+		submenu?: Array<MenuItemConfig>;
+		enabled?: boolean;
+		checked?: boolean;
+		hidden?: boolean;
+	};
 
 export type ApplicationMenuItemConfig =
 	| { type: "divider" | "separator" }
 	| {
-			type?: "normal";
-			label: string;
-			tooltip?: string;
-			action?: string;
-			data?: any;
-			submenu?: Array<ApplicationMenuItemConfig>;
-			enabled?: boolean;
-			checked?: boolean;
-			hidden?: boolean;
-			accelerator?: string;
-	  }
+		type?: "normal";
+		label: string;
+		tooltip?: string;
+		action?: string;
+		data?: any;
+		submenu?: Array<ApplicationMenuItemConfig>;
+		enabled?: boolean;
+		checked?: boolean;
+		hidden?: boolean;
+		accelerator?: string;
+	}
 	| {
-			type?: "normal";
-			label?: string;
-			tooltip?: string;
-			role?: string;
-			data?: any;
-			submenu?: Array<ApplicationMenuItemConfig>;
-			enabled?: boolean;
-			checked?: boolean;
-			hidden?: boolean;
-			accelerator?: string;
-	  };
+		type?: "normal";
+		label?: string;
+		tooltip?: string;
+		role?: string;
+		data?: any;
+		submenu?: Array<ApplicationMenuItemConfig>;
+		enabled?: boolean;
+		checked?: boolean;
+		hidden?: boolean;
+		accelerator?: string;
+	};

--- a/package/src/native/linux/nativeWrapper.cpp
+++ b/package/src/native/linux/nativeWrapper.cpp
@@ -7010,6 +7010,7 @@ ELECTROBUN_EXPORT AbstractView* initWebview(uint32_t webviewId,
                          const char* electrobunPreloadScript,
                          const char* customPreloadScript,
                          const char* viewsRoot,
+                         const char* userAgent,
                          bool transparent,
                          bool sandbox) {
     // Read and clear pre-set flags

--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -6747,6 +6747,7 @@ extern "C" AbstractView* initWebview(uint32_t webviewId,
                         const char *electrobunPreloadScript,
                         const char *customPreloadScript,
                         const char *viewsRoot,
+                        const char *userAgent,
                         bool transparent,
                         bool sandbox ) {
 

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -5936,6 +5936,7 @@ static std::shared_ptr<WebView2View> createWebView2View(uint32_t webviewId,
                                                  HandlePostMessage internalBridgeHandler,
                                                  const char *electrobunPreloadScript,
                                                  const char *customPreloadScript,
+                                                 const char *userAgent,
                                                  bool transparent,
                                                  bool sandbox) {
     // Check if WebView2 runtime is available
@@ -5957,6 +5958,7 @@ static std::shared_ptr<WebView2View> createWebView2View(uint32_t webviewId,
     std::string electrobunScript = electrobunPreloadScript ? std::string(electrobunPreloadScript) : "";
     std::string customScript = customPreloadScript ? std::string(customPreloadScript) : "";
     std::string partitionStr = partitionIdentifier ? std::string(partitionIdentifier) : "";
+    std::string userAgentStr = userAgent ? std::string(userAgent) : "";
 
     auto view = std::make_shared<WebView2View>(webviewId, eventBridgeHandler, bunBridgeHandler, internalBridgeHandler, sandbox);
     view->hwnd = hwnd;
@@ -5969,7 +5971,7 @@ static std::shared_ptr<WebView2View> createWebView2View(uint32_t webviewId,
     view->customScript = customScript;
 
     // Create WebView2 on main thread
-    MainThreadDispatcher::dispatch_sync([view, urlString, x, y, width, height, hwnd, partitionStr, transparent]() {
+    MainThreadDispatcher::dispatch_sync([view, urlString, x, y, width, height, hwnd, partitionStr, userAgentStr, transparent]() {
         // Initialize COM for this thread
         HRESULT comResult = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
         if (FAILED(comResult) && comResult != RPC_E_CHANGED_MODE) {
@@ -6016,7 +6018,7 @@ static std::shared_ptr<WebView2View> createWebView2View(uint32_t webviewId,
         HWND parentHwnd = hwnd;
         
         auto environmentCompletedHandler = Callback<ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler>(
-            [view, container, x, y, width, height, transparent](HRESULT result, ICoreWebView2Environment* env) -> HRESULT {
+            [view, container, x, y, width, height, transparent, userAgentStr](HRESULT result, ICoreWebView2Environment* env) -> HRESULT {
                 if (FAILED(result)) {
                     char errorMsg[256];
                     sprintf_s(errorMsg, "ERROR: Failed to create WebView2 environment, HRESULT: 0x%08X", result);
@@ -6039,7 +6041,7 @@ static std::shared_ptr<WebView2View> createWebView2View(uint32_t webviewId,
 
                 return env->CreateCoreWebView2Controller(targetHwnd,
                     Callback<ICoreWebView2CreateCoreWebView2ControllerCompletedHandler>(
-                        [view, container, x, y, width, height, env, transparent](HRESULT result, ICoreWebView2Controller* controller) -> HRESULT {
+                        [view, container, x, y, width, height, env, transparent, userAgentStr](HRESULT result, ICoreWebView2Controller* controller) -> HRESULT {
                             if (FAILED(result)) {
                                 char errorMsg[256];
                                 sprintf_s(errorMsg, "ERROR: Failed to create WebView2 controller, HRESULT: 0x%08X", result);
@@ -6056,6 +6058,40 @@ static std::shared_ptr<WebView2View> createWebView2View(uint32_t webviewId,
                             
                             view->setController(ctrl);
                             view->setWebView(webview);
+
+                            // If a userAgent was provided, use DevTools Protocol to set it
+                            // and disable User-Agent Client Hints entirely
+                            if (!userAgentStr.empty()) {
+                                // Escape the user agent string for JSON
+                                std::string escapedUA;
+                                for (char c : userAgentStr) {
+                                    switch (c) {
+                                        case '"': escapedUA += "\\\""; break;
+                                        case '\\': escapedUA += "\\\\"; break;
+                                        default: escapedUA += c; break;
+                                    }
+                                }
+
+                                // Build the JSON parameters for Emulation.setUserAgentOverride
+                                // Setting userAgentMetadata to an empty object with empty fields
+                                // prevents Client Hints headers from being sent
+                                std::string jsonParams = "{\"userAgent\":\"" + escapedUA + "\"}";
+
+                                std::wstring wJsonParams(jsonParams.begin(), jsonParams.end());
+
+                                webview->CallDevToolsProtocolMethod(
+                                    L"Emulation.setUserAgentOverride",
+                                    wJsonParams.c_str(),
+                                    Callback<ICoreWebView2CallDevToolsProtocolMethodCompletedHandler>(
+                                        [](HRESULT errorCode, LPCWSTR returnObjectAsJson) -> HRESULT {
+                                            if (FAILED(errorCode)) {
+                                                char err[256];
+                                                sprintf_s(err, "ERROR: Emulation.setUserAgentOverride failed: 0x%08X", errorCode);
+                                                ::log(err);
+                                            }
+                                            return S_OK;
+                                        }).Get());
+                            }
                             
                             // Try to get composition controller interface if available
                             ComPtr<ICoreWebView2CompositionController> compCtrl;
@@ -6754,6 +6790,7 @@ static std::shared_ptr<CEFView> createCEFView(uint32_t webviewId,
                                        HandlePostMessage internalBridgeHandler,
                                        const char *electrobunPreloadScript,
                                        const char *customPreloadScript,
+                                       const char *userAgent,
                                        bool transparent,
                                        bool sandbox) {
     
@@ -7155,6 +7192,7 @@ ELECTROBUN_EXPORT AbstractView* initWebview(uint32_t webviewId,
                          const char *electrobunPreloadScript,
                          const char *customPreloadScript,
                          const char *viewsRoot,
+                         const char *userAgent,
                          bool transparent,
                          bool sandbox) {
 
@@ -7176,13 +7214,13 @@ ELECTROBUN_EXPORT AbstractView* initWebview(uint32_t webviewId,
         auto cefView = createCEFView(webviewId, hwnd, url, x, y, width, height, autoResize,
                                     partitionIdentifier, navigationCallback, webviewEventHandler,
                                     eventBridgeHandler, bunBridgeHandler, internalBridgeHandler,
-                                    electrobunPreloadScript, customPreloadScript, transparent, sandbox);
+                                    electrobunPreloadScript, customPreloadScript, userAgent, transparent, sandbox);
         view = cefView.get();
     } else {
         auto webview2View = createWebView2View(webviewId, hwnd, url, x, y, width, height, autoResize,
                                               partitionIdentifier, navigationCallback, webviewEventHandler,
                                               eventBridgeHandler, bunBridgeHandler, internalBridgeHandler,
-                                              electrobunPreloadScript, customPreloadScript, transparent, sandbox);
+                                              electrobunPreloadScript, customPreloadScript, userAgent, transparent, sandbox);
         view = webview2View.get();
     }
 


### PR DESCRIPTION
### Problem 
Current web view implementation does not support custom user agents for webview2, which in my case was required to load TV version of YouTube. 

### Summary
Sets custom User-Agent via the Dev-tools Protocol (Emulation.setUserAgentOverride) using `ICoreWebView2::CallDevToolsProtocolMethod` When a non-empty `user-agent` is provided, the web-view uses the Dev-tools level override so that the effective User-Agent header matches the provided string and User-Agent Client Hints (Sec-CH-UA* headers) are not sent.

Tested with my own YouTube app (not published) using local linking. 