### PR TITLE
fix: exit dev --watch process when app window closes

### DIFF
--- a/package/src/cli/index.ts
+++ b/package/src/cli/index.ts
@@ -4685,6 +4685,10 @@ usageDescriptions : ""}${urlTypes ? "\n" + urlTypes : ""}${documentTypes ?
 			appHandle = await runApp(config, {
 				onExit: () => {
 					appHandle = null;
+					if (!shuttingDown) {
+						cleanup();
+						process.exit(0);
+					}
 				},
 			});
 		} catch (error) {


### PR DESCRIPTION
## Problem

When running `electrobun dev --watch`, closing the app window leaves the dev server process running indefinitely. The terminal hangs with no output, requiring a manual `Ctrl+C` to terminate.

## Root Cause

The `onExit` callback in `runDevWatch()` only nulls the `appHandle` reference but never triggers the parent process to exit. Meanwhile `await new Promise(() => {})` at the end of the function keeps the event loop alive forever.

```ts
// Before — just nulls the handle, parent keeps running
appHandle = await runApp(config, {
    onExit: () => {
        appHandle = null;
    },
});
```

## Fix

When the app process exits (user closes the window), call `cleanup()` to stop watchers, then `process.exit(0)` to terminate the dev server.

```ts
// After — cleans up and exits
onExit: () => {
    appHandle = null;
    if (!shuttingDown) {
        cleanup();
        process.exit(0);
    }
},
```

The `!shuttingDown` guard prevents double-exit if the user also pressed `Ctrl+C`.

## Commits

| Commit | Description |
|--------|-------------|
| `53819995` | Call cleanup() + process.exit(0) in onExit callback |