### PR TITLE
fix: exit dev --watch process when app window closes

### DIFF
--- a/package/src/cli/index.ts
+++ b/package/src/cli/index.ts
@@ -4632,6 +4632,15 @@ usageDescriptions : ""}${urlTypes ? "\n" + urlTypes : ""}${documentTypes ?
 						appHandle = null;
 					},
 				});
+
+				if (appHandle) {
+					appHandle.exited.then((code) => {
+						if (!isBuilding && !shuttingDown) {
+							cleanup();
+							process.exit(code);
+						}
+					}).catch(() => {});
+				}
 			} catch (error) {
 				console.error("[electrobun dev --watch] Build failed:", error);
 				console.log("[electrobun dev --watch] Waiting for file changes...");
@@ -4687,6 +4696,15 @@ usageDescriptions : ""}${urlTypes ? "\n" + urlTypes : ""}${documentTypes ?
 					appHandle = null;
 				},
 			});
+
+			if (appHandle) {
+				appHandle.exited.then((code) => {
+					if (!shuttingDown) {
+						cleanup();
+						process.exit(code);
+					}
+				}).catch(() => {});
+			}
 		} catch (error) {
 			console.error("[electrobun dev --watch] Initial build failed:", error);
 			console.log("[electrobun dev --watch] Waiting for file changes...");


### PR DESCRIPTION
## Problem

When running `electrobun dev --watch`, closing the app window leaves the dev server process running indefinitely. The terminal appears to hang, requiring a manual `Ctrl+C` to terminate.

## Root Cause

The `onExit` callback in `runDevWatch()` only nulls the `appHandle` reference but never triggers the parent process to exit. Meanwhile `await new Promise(() => {})` keeps the event loop alive forever.

## Fix

The `onExit` callback is kept minimal (`appHandle = null` only). The actual exit logic lives in `appHandle.exited.then()` where the real exit code is available and rebuild state can be checked:

```ts
// Rebuild path — guards against watcher-driven restarts
appHandle.exited.then((code) => {
    if (!isBuilding && !shuttingDown) {
        cleanup();
        process.exit(code);
    }
}).catch(() => {});

// Initial launch path
appHandle.exited.then((code) => {
    if (!shuttingDown) {
        cleanup();
        process.exit(code);
    }
}).catch(() => {});
```

Key design decisions:
- **Exit code propagation** — uses the actual exit code from the app process instead of hardcoded `0`
- **Rebuild-safe** — the `!isBuilding` guard in the rebuild path ensures `appHandle.kill()` during rebuilds does NOT trigger cleanup or exit
- **Atomic cleanup+exit** — `cleanup()` and `process.exit()` happen together, so `shuttingDown` (set by cleanup) cannot block the exit
- **Unhandled rejection safety** — `.catch(() => {})` on the `exited` promise