### PR TITLE
fix: rcedit not found in ci/cd

### DIFF
--- a/package/src/cli/index.ts
+++ b/package/src/cli/index.ts
@@ -2745,7 +2745,7 @@ usageDescriptions : ""}${urlTypes ? "\n" + urlTypes : ""}${documentTypes ?
 		}
 
 		// Embed icon into launcher.exe on Windows
-		if (targetOS === "win" && config.build.win?.icon && RCEDIT_DEP_PATH) {
+		if (targetOS === "win" && config.build.win?.icon) {
 			const iconSourcePath =
 				config.build.win.icon.startsWith("/") ||
 				config.build.win.icon.match(/^[a-zA-Z]:/)
@@ -2852,7 +2852,7 @@ usageDescriptions : ""}${urlTypes ? "\n" + urlTypes : ""}${documentTypes ?
 			}
 
 			// Embed icon into bun.exe on Windows
-			if (targetOS === "win" && config.build.win?.icon && RCEDIT_DEP_PATH) {
+			if (targetOS === "win" && config.build.win?.icon) {
 				const iconSourcePath =
 					config.build.win.icon.startsWith("/") ||
 					config.build.win.icon.match(/^[a-zA-Z]:/)
@@ -5045,7 +5045,7 @@ usageDescriptions : ""}${urlTypes ? "\n" + urlTypes : ""}${documentTypes ?
 		writeFileSync(outputExePath, new Uint8Array(extractorExe));
 
 		// Embed icon into the wrapper EXE if provided
-		if (config.build.win?.icon && RCEDIT_DEP_PATH) {
+		if (config.build.win?.icon) {
 			const iconSourcePath =
 				config.build.win.icon.startsWith("/") ||
 				config.build.win.icon.match(/^[a-zA-Z]:/)

--- a/package/src/cli/index.ts
+++ b/package/src/cli/index.ts
@@ -87,8 +87,23 @@ function resolveElectrobunDir(): string {
 	return join(projectRoot, "node_modules", "electrobun");
 }
 
+// Walk up from projectRoot to find rcedit in node_modules (supports hoisted monorepo layouts)
+function resolveRceditDir(): string {
+	let dir = projectRoot;
+	while (dir !== dirname(dir)) {
+		const candidate = join(dir, "node_modules", "rcedit");
+		if (existsSync(join(candidate, "package.json"))) {
+			return candidate;
+		}
+		dir = dirname(dir);
+	}
+	return join(projectRoot, "node_modules", "rcedit");
+}
+
 const ELECTROBUN_DEP_PATH = resolveElectrobunDir();
 const ELECTROBUN_CACHE_PATH = join(dirname(ELECTROBUN_DEP_PATH), ".electrobun-cache");
+
+const RCEDIT_DEP_PATH = resolveRceditDir();
 
 // When debugging electrobun with the example app use the builds (dev or release) right from the source folder
 // For developers using electrobun cli via npm use the release versions in /dist
@@ -2730,7 +2745,7 @@ usageDescriptions : ""}${urlTypes ? "\n" + urlTypes : ""}${documentTypes ?
 		}
 
 		// Embed icon into launcher.exe on Windows
-		if (targetOS === "win" && config.build.win?.icon) {
+		if (targetOS === "win" && config.build.win?.icon && RCEDIT_DEP_PATH) {
 			const iconSourcePath =
 				config.build.win.icon.startsWith("/") ||
 				config.build.win.icon.match(/^[a-zA-Z]:/)
@@ -2756,10 +2771,8 @@ usageDescriptions : ""}${urlTypes ? "\n" + urlTypes : ""}${documentTypes ?
 
 					// Use rcedit to embed the icon into launcher.exe
 										const { execFileSync } = await import("child_process");
-					const rceditPkgPath = require.resolve("rcedit/package.json");
-					const rceditDir = dirname(rceditPkgPath);
-					const rceditX64 = join(rceditDir, "bin", "rcedit-x64.exe");
-					const rceditExe = existsSync(rceditX64) ? rceditX64 : join(rceditDir, "bin", "rcedit.exe");
+					const rceditX64 = join(RCEDIT_DEP_PATH, "bin", "rcedit-x64.exe");
+					const rceditExe = existsSync(rceditX64) ? rceditX64 : join(RCEDIT_DEP_PATH, "bin", "rcedit.exe");
 					execFileSync(rceditExe, [bunCliLauncherDestination, "--set-icon", iconPath]);
 					console.log(`Successfully embedded icon into launcher.exe`);
 
@@ -2839,7 +2852,7 @@ usageDescriptions : ""}${urlTypes ? "\n" + urlTypes : ""}${documentTypes ?
 			}
 
 			// Embed icon into bun.exe on Windows
-			if (targetOS === "win" && config.build.win?.icon) {
+			if (targetOS === "win" && config.build.win?.icon && RCEDIT_DEP_PATH) {
 				const iconSourcePath =
 					config.build.win.icon.startsWith("/") ||
 					config.build.win.icon.match(/^[a-zA-Z]:/)
@@ -2863,10 +2876,8 @@ usageDescriptions : ""}${urlTypes ? "\n" + urlTypes : ""}${documentTypes ?
 						}
 
 						const { execFileSync } = await import("child_process");
-						const rceditPkgPath = require.resolve("rcedit/package.json");
-						const rceditDir = dirname(rceditPkgPath);
-						const rceditX64 = join(rceditDir, "bin", "rcedit-x64.exe");
-						const rceditExe = existsSync(rceditX64) ? rceditX64 : join(rceditDir, "bin", "rcedit.exe");
+						const rceditX64 = join(RCEDIT_DEP_PATH, "bin", "rcedit-x64.exe");
+						const rceditExe = existsSync(rceditX64) ? rceditX64 : join(RCEDIT_DEP_PATH, "bin", "rcedit.exe");
 						execFileSync(rceditExe, [bunBinaryDestInBundlePath, "--set-icon", iconPath]);
 						console.log(`Successfully embedded icon into bun.exe`);
 
@@ -5034,7 +5045,7 @@ usageDescriptions : ""}${urlTypes ? "\n" + urlTypes : ""}${documentTypes ?
 		writeFileSync(outputExePath, new Uint8Array(extractorExe));
 
 		// Embed icon into the wrapper EXE if provided
-		if (config.build.win?.icon) {
+		if (config.build.win?.icon && RCEDIT_DEP_PATH) {
 			const iconSourcePath =
 				config.build.win.icon.startsWith("/") ||
 				config.build.win.icon.match(/^[a-zA-Z]:/)
@@ -5058,10 +5069,8 @@ usageDescriptions : ""}${urlTypes ? "\n" + urlTypes : ""}${documentTypes ?
 
 					// Use rcedit to embed the icon
 										const { execFileSync } = await import("child_process");
-					const rceditPkgPath = require.resolve("rcedit/package.json");
-					const rceditDir = dirname(rceditPkgPath);
-					const rceditX64 = join(rceditDir, "bin", "rcedit-x64.exe");
-					const rceditExe = existsSync(rceditX64) ? rceditX64 : join(rceditDir, "bin", "rcedit.exe");
+					const rceditX64 = join(RCEDIT_DEP_PATH, "bin", "rcedit-x64.exe");
+					const rceditExe = existsSync(rceditX64) ? rceditX64 : join(RCEDIT_DEP_PATH, "bin", "rcedit.exe");
 					execFileSync(rceditExe, [outputExePath, "--set-icon", iconPath]);
 					console.log(`Successfully embedded icon into ${setupFileName}`);
 


### PR DESCRIPTION
Copied some of the existing code to resolve the Rcedit directory in the projects node_modules instead of in Bun's node_modules.

This makes it more resilient in CI/CD runners.

Closes #429
Closes #235 
Closes #402 

Edit: Essentially the problem is that it tries to resolve `rcedit` from the bun binary's own temp location `B:\~BUN\root\electrobun` not from the user's project `node_modules`.

As you can see from this message:
```
Embedding icon into bun.exe: D:\a\StoryForge\StoryForge\assets\icon_512x512.ico
Warning: Failed to embed icon into bun.exe: ResolveMessage: Cannot find module 'D:\a\electrobun\electrobun\package\node_modules\rcedit\package.json' from 'B:\~BUN\root\electrobun'
```
It clearly tries to look in Electrobun's `node_modules` _(in the bun binary's temp location)_, instead of the projects `node_modules`.