### PR TITLE
fix(macos): bind default key equivalents for App/Window menu roles

### DIFF
--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -1170,6 +1170,21 @@ NSMenu *createMenuFromConfig(NSArray *menuConfig, StatusItemTarget *target) {
                     } else if ([role isEqualToString:@"selectAll"]) {
                         menuItem.keyEquivalent = @"a";
                         menuItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
+                    } else if ([role isEqualToString:@"hide"]) {
+                        menuItem.keyEquivalent = @"h";
+                        menuItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
+                    } else if ([role isEqualToString:@"hideOthers"]) {
+                        menuItem.keyEquivalent = @"h";
+                        menuItem.keyEquivalentModifierMask = NSEventModifierFlagCommand | NSEventModifierFlagOption;
+                    } else if ([role isEqualToString:@"quit"]) {
+                        menuItem.keyEquivalent = @"q";
+                        menuItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
+                    } else if ([role isEqualToString:@"minimize"]) {
+                        menuItem.keyEquivalent = @"m";
+                        menuItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
+                    } else if ([role isEqualToString:@"close"]) {
+                        menuItem.keyEquivalent = @"w";
+                        menuItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
                     }
                 }
             } else {


### PR DESCRIPTION
## Problem

Role-based menu items don't bind the standard macOS key equivalents on their own. `{ role: "hide" }`, `{ role: "hideOthers" }`, `{ role: "quit" }`, `{ role: "minimize" }`, `{ role: "close" }` all resolve to the correct selectors via `getMenuRoleToSelectorMap`, but the `if (!accelerator) { … }` ladder in `createMenuFromConfig` only assigns default `keyEquivalent`s for Edit-menu roles. So the menu items ship with `keyEquivalent = @""` and the system shortcuts (⌘H, ⌘⌥H, ⌘Q, ⌘M, ⌘W) don't fire.

Related to but narrower than #328 (which requests a JS-side `BrowserWindow.hide()` / `isVisible()` API). This PR doesn't add any JS surface; it just makes role-based menu items behave like the rest of macOS.

## Fix

Extend the existing role → default-keyEquivalent ladder with the five App/Window roles that have well-known system shortcuts. `showAll`, `zoom`, `bringAllToFront`, `toggleFullScreen`, etc. are intentionally left without defaults because there's no single Apple convention or the binding has shifted (e.g. fullscreen).

## Test plan

- [x] App menu `{ role: "hide" }` — ⌘H hides the app.
- [x] App menu `{ role: "hideOthers" }` — ⌘⌥H hides other apps.
- [x] App menu `{ role: "quit" }` — ⌘Q quits.
- [x] Window menu `{ role: "close" }` — ⌘W closes the focused window.
- [x] Existing Edit-menu roles (`undo`/`redo`/`cut`/`copy`/`paste`/`selectAll`/etc.) — no regression.
