### PR TITLE
fix: prevent WKWebsiteDataStore crash on older macOS versions

### DIFF
--- a/package/build.ts
+++ b/package/build.ts
@@ -1836,8 +1836,8 @@ async function buildNative() {
 		const wgpuIncludeFlag = existsSync(wgpuIncludeDir)
 			? `-I${wgpuIncludeDir}`
 			: "";
-		await $`mkdir -p src/native/macos/build && xcrun --sdk macosx clang++ -c src/native/macos/nativeWrapper.mm -o src/native/macos/build/nativeWrapper.o -fobjc-arc -fno-objc-msgsend-selector-stubs -I./vendors/cef ${wgpuIncludeFlag} -std=c++20`;
-		await $`mkdir -p src/native/build && xcrun --sdk macosx clang++ -o src/native/build/libNativeWrapper.dylib src/native/macos/build/nativeWrapper.o ./vendors/zig-asar/libasar.dylib -framework Cocoa -framework WebKit -framework QuartzCore -framework Metal -framework MetalKit -framework UserNotifications -F./vendors/cef/Release -weak_framework 'Chromium Embedded Framework' -L./vendors/cef/build/libcef_dll_wrapper -lcef_dll_wrapper -stdlib=libc++ -shared -install_name @executable_path/libNativeWrapper.dylib -Wl,-rpath,@executable_path`;
+		await $`mkdir -p src/native/macos/build && xcrun --sdk macosx clang++ -mmacosx-version-min=10.13 -c src/native/macos/nativeWrapper.mm -o src/native/macos/build/nativeWrapper.o -fobjc-arc -fno-objc-msgsend-selector-stubs -I./vendors/cef ${wgpuIncludeFlag} -std=c++20`;
+		await $`mkdir -p src/native/build && xcrun --sdk macosx clang++ -mmacosx-version-min=10.13 -o src/native/build/libNativeWrapper.dylib src/native/macos/build/nativeWrapper.o ./vendors/zig-asar/libasar.dylib -framework Cocoa -framework WebKit -framework QuartzCore -framework Metal -framework MetalKit -framework UserNotifications -F./vendors/cef/Release -weak_framework 'Chromium Embedded Framework' -L./vendors/cef/build/libcef_dll_wrapper -lcef_dll_wrapper -stdlib=libc++ -shared -install_name @executable_path/libNativeWrapper.dylib -Wl,-rpath,@executable_path`;
 	} else if (OS === "win") {
 		const webview2Include = `./vendors/webview2/Microsoft.Web.WebView2/build/native/include`;
 		// Always use x64 for Windows since we only build x64 Windows binaries

--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -707,13 +707,15 @@ WKWebsiteDataStore* createDataStoreForPartition(const char* partitionIdentifier)
         NSUUID *uuid = UUIDFromString(identifier);
         if (uuid) {
             // dataStoreForIdentifier is only available on macOS 14.0+
-            if (@available(macOS 14.0, *)) {
-                return [WKWebsiteDataStore dataStoreForIdentifier:uuid];
-            } else {
-                // Fallback to default data store on older macOS versions
-                NSLog(@"[Session] Partition-specific data stores require macOS 14.0+, using default store");
-                return [WKWebsiteDataStore defaultDataStore];
+            if ([WKWebsiteDataStore respondsToSelector:@selector(dataStoreForIdentifier:)]) {
+                if (@available(macOS 14.0, *)) {
+                    return [WKWebsiteDataStore dataStoreForIdentifier:uuid];
+                }
             }
+            
+            // Fallback to default data store on older macOS versions
+            NSLog(@"[Session] Partition-specific data stores require macOS 14.0+, using default store");
+            return [WKWebsiteDataStore defaultDataStore];
         } else {
             NSLog(@"Invalid UUID for identifier: %@", identifier);
             return [WKWebsiteDataStore defaultDataStore];


### PR DESCRIPTION
## Summary
- Added `-mmacosx-version-min=10.13` to `libNativeWrapper.dylib` compilation to ensure `@available` macros aren't overly optimized.
- Added a `respondsToSelector:` safeguard around `dataStoreForIdentifier:` to prevent an unrecognized selector crash on macOS < 14.

## Problem
Currently, the app instantly crashes on macOS 12 (and likely 13) with `+[WKWebsiteDataStore dataStoreForIdentifier:]: unrecognized selector sent to class`.

## Solution
This adds the required minimum deployment target to the compilation phase and adds a runtime method check to safely fallback to `defaultDataStore` on older macOS versions.