### PR TITLE
fix: update broken llms.txt documentation url in cli init message

### DIFF
--- a/package/src/cli/index.ts
+++ b/package/src/cli/index.ts
@@ -2222,7 +2222,7 @@ ${utiDecls}
 			console.log(
 				"Different architecture, different APIs. Do not use Electron patterns.",
 			);
-			console.log("Docs: https://docs.electrobunny.ai/electrobun/llms.txt");
+			console.log("Docs: https://electrobun.dev/llms.txt");
 			console.log(
 				"━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
 			);


### PR DESCRIPTION
## Summary
- Updated the `llms.txt` URL in the CLI init command output to point to the correct `https://electrobun.dev/llms.txt` domain.

Fixes #447