### PR TITLE
fix: change CEF partition path structure to avoid upstream nesting bug

### DIFF
--- a/package/src/native/shared/app_paths.h
+++ b/package/src/native/shared/app_paths.h
@@ -71,15 +71,17 @@ inline std::string buildPartitionPath(
 /**
  * Build a CEF partition-specific path under the renderer root.
  *
- * Partitions live in a `partitions/` subdirectory of the renderer cache root
- * rather than directly under it. The renderer root itself is CefSettings.cache_path,
+ * Partitions live in a `partition_<name>` directory immediately under the renderer cache root
+ * rather than nested deeper. The renderer root itself is CefSettings.cache_path,
  * which Chromium populates with auto-created profile directories such as
  * `Default`, `System Profile`, etc. On case-insensitive filesystems (Windows
  * NTFS, macOS APFS in default config) a partition literally named `default`
  * would collide with that auto-created `Default` folder; CEF then refuses to
  * bind a CefRequestContext to the colliding path and CreateBrowserSync
- * silently returns null. Nesting under `partitions/` keeps user partitions
- * cleanly separated from Chromium's own profile state.
+ * silently returns null. Using the `partition_` prefix keeps user partitions
+ * cleanly separated from Chromium's own profile state, while satisfying CEF's
+ * upstream requirement (CEF issue #3930) that partition cache paths be an
+ * immediate child of the root cache path.
  *
  * @param basePath The base application support/data path
  * @param identifier The app identifier
@@ -87,7 +89,7 @@ inline std::string buildPartitionPath(
  * @param renderer The renderer type (typically "CEF")
  * @param partitionName The partition name
  * @param pathSeparator The path separator to use
- * @return The full path: basePath/identifier/channel/renderer/partitions/partitionName
+ * @return The full path: basePath/identifier/channel/renderer/partition_partitionName
  */
 inline std::string buildCEFPartitionPath(
     const std::string& basePath,
@@ -99,8 +101,7 @@ inline std::string buildCEFPartitionPath(
 ) {
     std::string base = buildAppDataPath(basePath, identifier, channel, renderer, pathSeparator);
     base += pathSeparator;
-    base += "partitions";
-    base += pathSeparator;
+    base += "partition_";
     base += partitionName;
     return base;
 }

--- a/package/src/native/shared/cache_migration.h
+++ b/package/src/native/shared/cache_migration.h
@@ -57,7 +57,10 @@ namespace electrobun {
 //   v2: partitions moved from <root>/<name> to <root>/partitions/<name> to
 //       avoid case-insensitive collisions with Chromium's auto-created
 //       <root>/Default profile folder.
-constexpr uint32_t CEF_CACHE_FORMAT_VERSION = 2;
+//   v3: partitions moved from <root>/partitions/<name> to <root>/partition_<name>
+//       to fix CEF upstream issue #3930 where nested request contexts are no
+//       longer supported (chrome_browser_context.cc).
+constexpr uint32_t CEF_CACHE_FORMAT_VERSION = 3;
 
 inline const char* cacheSentinelFilename() {
     return ".electrobun_cef_cache_version";


### PR DESCRIPTION
## Summary
- Changed partition cache paths from `.../CEF/partitions/<name>` to `.../CEF/partition_<name>`
- Fixes #448 (Cannot create profile at path on Linux) caused by a CEF upstream regression (issue #3930) that prevents `CefRequestContext` cache paths from being nested more than one directory deep under the root cache path.
- Bumped `CEF_CACHE_FORMAT_VERSION` to `3` to seamlessly wipe old incompatible cache folders on first launch across all platforms.