### PR TITLE
feat: add will-close event to intercept X button before window is destroyed

### DIFF
--- a/package/src/bun/events/windowEvents.ts
+++ b/package/src/bun/events/windowEvents.ts
@@ -13,6 +13,8 @@ type KeyData = { id: number; keyCode: number; modifiers: number; isRepeat: boole
 
 export default {
 	close: (data: IdData) => new ElectrobunEvent<IdData, {}>("close", data),
+	willClose: (data: IdData) =>
+		new ElectrobunEvent<IdData, { allow: boolean }>("will-close", data),
 	resize: (data: ResizeData) =>
 		new ElectrobunEvent<ResizeData, {}>("resize", data),
 	move: (data: MoveData) => new ElectrobunEvent<MoveData, {}>("move", data),

--- a/package/src/bun/proc/native.ts
+++ b/package/src/bun/proc/native.ts
@@ -154,6 +154,7 @@ const core = (() => {
 					FFIType.function,
 					FFIType.function,
 					FFIType.function,
+					FFIType.function,
 				],
 				returns: FFIType.u32,
 			},
@@ -1247,6 +1248,7 @@ const _ffiImpl = {
 				windowFocusCallback,
 				windowBlurCallback,
 				windowKeyCallback,
+				windowShouldCloseCallback,
 			);
 
 			if (!windowId) {
@@ -2226,6 +2228,26 @@ const windowCloseCallback = new JSCallback(
 		// before the global handler (e.g. exitOnLastWindowClosed)
 		electrobunEventEmitter.emitEvent(event, id);
 		electrobunEventEmitter.emitEvent(event);
+	},
+	{
+		args: ["u32"],
+		returns: "void",
+		threadsafe: true,
+	},
+);
+
+// Handlers must be synchronous. To do async work (e.g. show a save dialog),
+// set event.response = { allow: false } immediately, then call win.close() once done.
+const windowShouldCloseCallback = new JSCallback(
+	(id) => {
+		const handler = electrobunEventEmitter.events.window.willClose;
+		const event = handler({ id });
+		electrobunEventEmitter.emitEvent(event, id);
+		electrobunEventEmitter.emitEvent(event);
+		// [window close] bypasses windowShouldClose: so this won't loop.
+		if (event.response?.allow !== false) {
+			core_.symbols.closeWindow(id as number);
+		}
 	},
 	{
 		args: ["u32"],

--- a/package/src/core/main.zig
+++ b/package/src/core/main.zig
@@ -15,6 +15,7 @@ const WindowResizeHandler = *const fn (u32, f64, f64, f64, f64) callconv(.C) voi
 const WindowFocusHandler = *const fn (u32) callconv(.C) void;
 const WindowBlurHandler = *const fn (u32) callconv(.C) void;
 const WindowKeyHandler = *const fn (u32, u32, u32, u32, u32) callconv(.C) void;
+const WindowShouldCloseHandler = *const fn (u32) callconv(.C) void;
 const DecideNavigationHandler = *const fn (u32, [*:0]const u8) callconv(.C) u32;
 const WebviewEventHandler = *const fn (u32, [*:0]const u8, [*:0]const u8) callconv(.C) void;
 const WebviewPostMessageHandler = *const fn (u32, [*:0]const u8) callconv(.C) void;
@@ -46,6 +47,7 @@ const WindowState = struct {
     ptr: WindowPtr,
     transparent: bool,
     close_handler: ?WindowCloseHandler,
+    should_close_handler: ?WindowShouldCloseHandler,
     move_handler: ?WindowMoveHandler,
     resize_handler: ?WindowResizeHandler,
     focus_handler: ?WindowFocusHandler,
@@ -1800,6 +1802,13 @@ fn windowKeyTrampoline(window_id: u32, key_code: u32, modifiers: u32, is_down: u
     }
 }
 
+fn windowShouldCloseTrampoline(window_id: u32) callconv(.C) void {
+    const state = lookupWindowState(window_id) orelse return;
+    if (state.should_close_handler) |handler| {
+        handler(window_id);
+    }
+}
+
 fn managedQuitRequestedTrampoline() callconv(.C) void {
     if (managed_quit_requested_handler) |handler| {
         handler();
@@ -1888,6 +1897,7 @@ export fn createWindow(
     focus_handler: ?WindowFocusHandler,
     blur_handler: ?WindowBlurHandler,
     key_handler: ?WindowKeyHandler,
+    should_close_handler: ?WindowShouldCloseHandler,
 ) u32 {
     clearLastError();
 
@@ -1908,6 +1918,7 @@ export fn createWindow(
         ?WindowFocusHandler,
         ?WindowBlurHandler,
         ?WindowKeyHandler,
+        ?WindowShouldCloseHandler,
     ) callconv(.C) WindowPtr;
     const SetWindowTitleFn = *const fn (WindowPtr, [*:0]const u8) callconv(.C) void;
     const ShowWindowFn = *const fn (WindowPtr, bool) callconv(.C) void;
@@ -1944,6 +1955,7 @@ export fn createWindow(
         .ptr = null,
         .transparent = transparent,
         .close_handler = close_handler,
+        .should_close_handler = should_close_handler,
         .move_handler = move_handler,
         .resize_handler = resize_handler,
         .focus_handler = focus_handler,
@@ -1973,6 +1985,7 @@ export fn createWindow(
         windowFocusTrampoline,
         windowBlurTrampoline,
         windowKeyTrampoline,
+        if (should_close_handler != null) windowShouldCloseTrampoline else null,
     );
 
     if (window_ptr == null) {

--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -1005,6 +1005,7 @@ static NSMutableDictionary<NSNumber *, AbstractView *> *globalAbstractViews = ni
 
 @interface WindowDelegate : NSObject <NSWindowDelegate>
     @property (nonatomic, assign) WindowCloseHandler closeHandler;
+    @property (nonatomic, assign) WindowShouldCloseHandler shouldCloseHandler;
     @property (nonatomic, assign) WindowMoveHandler moveHandler;
     @property (nonatomic, assign) WindowResizeHandler resizeHandler;
     @property (nonatomic, assign) WindowFocusHandler focusHandler;
@@ -6692,7 +6693,11 @@ CefRefPtr<CefRequestContext> CreateRequestContextForPartition(const char* partit
 
 @implementation WindowDelegate
     - (BOOL)windowShouldClose:(NSWindow *)sender {
-    return YES;
+        if (self.shouldCloseHandler) {
+            self.shouldCloseHandler(self.windowId);
+            return NO;
+        }
+        return YES;
     }
     - (void)windowWillClose:(NSNotification *)notification {
         NSWindow *window = [notification object];
@@ -7444,7 +7449,8 @@ NSWindow *createNSWindowWithFrameAndStyle(uint32_t windowId,
                                                      WindowResizeHandler zigResizeHandler,
                                                      WindowFocusHandler zigFocusHandler,
                                                      WindowBlurHandler zigBlurHandler,
-                                                     WindowKeyHandler zigKeyHandler) {
+                                                     WindowKeyHandler zigKeyHandler,
+                                                     WindowShouldCloseHandler zigShouldCloseHandler) {
     
     NSScreen *primaryScreen = [NSScreen screens][0];
     NSRect screenFrame = [primaryScreen frame];
@@ -7471,6 +7477,7 @@ NSWindow *createNSWindowWithFrameAndStyle(uint32_t windowId,
     objc_setAssociatedObject(window, kTrafficLightAppliedOffsetYKey, @(0), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     WindowDelegate *delegate = [[WindowDelegate alloc] init];
     delegate.closeHandler = zigCloseHandler;
+    delegate.shouldCloseHandler = zigShouldCloseHandler;
     delegate.resizeHandler = zigResizeHandler;
     delegate.moveHandler = zigMoveHandler;
     delegate.focusHandler = zigFocusHandler;
@@ -7511,7 +7518,8 @@ extern "C" NSWindow *createWindowWithFrameAndStyleFromWorker(
   WindowResizeHandler zigResizeHandler,
   WindowFocusHandler zigFocusHandler,
   WindowBlurHandler zigBlurHandler,
-  WindowKeyHandler zigKeyHandler
+  WindowKeyHandler zigKeyHandler,
+  WindowShouldCloseHandler zigShouldCloseHandler
   ) {
 
     // Validate frame values - use defaults if NaN or invalid
@@ -7542,7 +7550,8 @@ extern "C" NSWindow *createWindowWithFrameAndStyleFromWorker(
             zigResizeHandler,
             zigFocusHandler,
             zigBlurHandler,
-            zigKeyHandler
+            zigKeyHandler,
+            zigShouldCloseHandler
         );
 
         // Handle transparent window background

--- a/package/src/native/shared/callbacks.h
+++ b/package/src/native/shared/callbacks.h
@@ -29,6 +29,7 @@ typedef void (*WindowResizeHandler)(uint32_t windowId, double x, double y, doubl
 typedef void (*WindowFocusHandler)(uint32_t windowId);
 typedef void (*WindowBlurHandler)(uint32_t windowId);
 typedef void (*WindowKeyHandler)(uint32_t windowId, uint32_t keyCode, uint32_t modifiers, uint32_t isDown, uint32_t isRepeat);
+typedef void (*WindowShouldCloseHandler)(uint32_t windowId);
 
 // Tray and menu callbacks
 typedef void (*StatusItemHandler)(uint32_t trayId, const char* action);

--- a/package/src/zig-sdk/electrobun.zig
+++ b/package/src/zig-sdk/electrobun.zig
@@ -7,6 +7,7 @@ pub const WindowResizeHandler = *const fn (u32, f64, f64, f64, f64) callconv(.C)
 pub const WindowFocusHandler = *const fn (u32) callconv(.C) void;
 pub const WindowBlurHandler = *const fn (u32) callconv(.C) void;
 pub const WindowKeyHandler = *const fn (u32, u32, u32, u32, u32) callconv(.C) void;
+pub const WindowShouldCloseHandler = *const fn (u32) callconv(.C) void;
 pub const DecideNavigationHandler = *const fn (u32, [*:0]const u8) callconv(.C) u32;
 pub const WebviewEventHandler = *const fn (u32, [*:0]const u8, [*:0]const u8) callconv(.C) void;
 pub const WebviewPostMessageHandler = *const fn (u32, [*:0]const u8) callconv(.C) void;
@@ -76,6 +77,7 @@ pub const WindowStyle = struct {
 
 pub const WindowCallbacks = struct {
     close: ?WindowCloseHandler = null,
+    should_close: ?WindowShouldCloseHandler = null,
     move: ?WindowMoveHandler = null,
     resize: ?WindowResizeHandler = null,
     focus: ?WindowFocusHandler = null,
@@ -558,7 +560,7 @@ pub const Core = struct {
     const RunMainThreadFn = *const fn ([*:0]const u8, [*:0]const u8, [*:0]const u8, c_int) callconv(.C) c_int;
     const ConfigureWebviewRuntimeFn = *const fn (u32, [*:0]const u8, [*:0]const u8) callconv(.C) bool;
     const GetWindowStyleFn = *const fn (bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool) callconv(.C) u32;
-    const CreateWindowFn = *const fn (f64, f64, f64, f64, u32, [*:0]const u8, bool, [*:0]const u8, bool, bool, f64, f64, ?WindowCloseHandler, ?WindowMoveHandler, ?WindowResizeHandler, ?WindowFocusHandler, ?WindowBlurHandler, ?WindowKeyHandler) callconv(.C) u32;
+    const CreateWindowFn = *const fn (f64, f64, f64, f64, u32, [*:0]const u8, bool, [*:0]const u8, bool, bool, f64, f64, ?WindowCloseHandler, ?WindowMoveHandler, ?WindowResizeHandler, ?WindowFocusHandler, ?WindowBlurHandler, ?WindowKeyHandler, ?WindowShouldCloseHandler) callconv(.C) u32;
     const CreateWebviewFn = *const fn (u32, u32, [*:0]const u8, [*:0]const u8, f64, f64, f64, f64, bool, [*:0]const u8, ?DecideNavigationHandler, ?WebviewEventHandler, ?WebviewPostMessageHandler, ?WebviewPostMessageHandler, ?WebviewPostMessageHandler, [*:0]const u8, [*:0]const u8, [*:0]const u8, bool, bool, bool) callconv(.C) u32;
     const CreateWGPUViewFn = *const fn (u32, f64, f64, f64, f64, bool, bool, bool) callconv(.C) u32;
     const SetWindowTitleFn = *const fn (u32, [*:0]const u8) callconv(.C) void;
@@ -992,6 +994,7 @@ pub const Core = struct {
             options.callbacks.focus,
             options.callbacks.blur,
             options.callbacks.key,
+            options.callbacks.should_close,
         );
 
         if (window_id == 0) {


### PR DESCRIPTION
> **POC / suggested implementation** — not expecting a merge, opening to express the idea.

Closes #455

## Problem

The existing `close` event fires from `windowWillClose:` — after AppKit has already committed to destroying the window. Common patterns like "unsaved changes?" dialogs or saving state before quit are not possible at this point because the window is already gone.

## Approach

Hooks `windowShouldClose:` (AppKit's veto point, fires *before* `windowWillClose:`) to emit a `will-close` event while the window is still alive. If a handler sets `event.response = { allow: false }`, the close is cancelled. Otherwise the window closes normally — no behavior change for existing code.

## Usage

```typescript
win.on('will-close', (event) => {
    event.response = { allow: false }; // must be synchronous
    saveDocument().then(() => win.close());
});
```

**Handlers must be synchronous.** To do async work (show a dialog, save a file), set `allow: false` immediately to block the close, then call `win.close()` programmatically once done. `win.close()` calls `[window close]` directly, which bypasses `windowShouldClose:` — no loop. Same pattern Electron uses for its `close` event.

## Changes

- `callbacks.h` — `WindowShouldCloseHandler` typedef
- `nativeWrapper.mm` — `windowShouldClose:` calls handler and returns `NO`; returns `YES` when no handler is registered (no behavior change for existing code)
- `main.zig` — trampoline + `should_close_handler` in `WindowState`; trampoline only wired when handler is non-null
- `native.ts` — `windowShouldCloseCallback` JSCallback, passes as arg to `createWindow`
- `windowEvents.ts` — `willClose` event with `{ allow: boolean }` response type
- `zig-sdk/electrobun.zig` — `WindowShouldCloseHandler` type + `should_close` in `WindowCallbacks`