### PR TITLE
feat: add spellCheck option to WKWebView (macOS)

### DIFF
--- a/package/src/bun/core/BrowserView.ts
+++ b/package/src/bun/core/BrowserView.ts
@@ -44,6 +44,8 @@ export type BrowserViewOptions<T = undefined> = {
 	startTransparent: boolean;
 	// Set passthrough on the AbstractView at creation (before first paint)
 	startPassthrough: boolean;
+	// Enable macOS system spell checker for contenteditable elements (WKWebView only)
+	spellCheck?: boolean;
 	// renderer:
 };
 
@@ -92,6 +94,7 @@ export class BrowserView<T extends RPCWithTransport = RPCWithTransport> {
 	sandbox: boolean = false;
 	startTransparent: boolean = false;
 	startPassthrough: boolean = false;
+	spellCheck: boolean = false;
 	isRemoved: boolean = false;
 
 	get ptr(): Pointer | null {
@@ -125,6 +128,7 @@ export class BrowserView<T extends RPCWithTransport = RPCWithTransport> {
 		this.sandbox = options.sandbox ?? false;
 		this.startTransparent = options.startTransparent ?? false;
 		this.startPassthrough = options.startPassthrough ?? false;
+		this.spellCheck = options.spellCheck ?? false;
 
 		this.id = this.init() as number;
 		BrowserViewMap[this.id] = this;
@@ -162,6 +166,7 @@ export class BrowserView<T extends RPCWithTransport = RPCWithTransport> {
 			sandbox: this.sandbox,
 			startTransparent: this.startTransparent,
 			startPassthrough: this.startPassthrough,
+			spellCheck: this.spellCheck,
 			// transparent is looked up from parent window in native.ts
 		});
 	}
@@ -402,6 +407,7 @@ export class BrowserView<T extends RPCWithTransport = RPCWithTransport> {
 		view.sandbox = options.sandbox ?? false;
 		view.startTransparent = options.startTransparent ?? false;
 		view.startPassthrough = options.startPassthrough ?? false;
+		view.spellCheck = options.spellCheck ?? false;
 		view.isRemoved = false;
 		BrowserViewMap[id] = view as BrowserView<any>;
 		return view;

--- a/package/src/bun/core/BrowserWindow.ts
+++ b/package/src/bun/core/BrowserWindow.ts
@@ -46,6 +46,8 @@ export type WindowOptionsType<T = undefined> = {
 	// Use for untrusted content (remote URLs) to prevent malicious sites from
 	// accessing internal APIs, creating OOPIFs, or communicating with Bun
 	sandbox: boolean;
+	// Enable macOS system spell checker for contenteditable elements (WKWebView only)
+	spellCheck?: boolean;
 };
 
 const defaultOptions: WindowOptionsType = {
@@ -67,6 +69,7 @@ const defaultOptions: WindowOptionsType = {
 	hidden: false,
 	navigationRules: null,
 	sandbox: false,
+	spellCheck: false,
 };
 
 export const BrowserWindowMap: {
@@ -113,6 +116,7 @@ export class BrowserWindow<T extends RPCWithTransport = RPCWithTransport> {
 	navigationRules: string | null = null;
 	// Sandbox mode disables RPC and only allows event emission (for untrusted content)
 	sandbox: boolean = false;
+	spellCheck: boolean = false;
 	frame: {
 		x: number;
 		y: number;
@@ -150,6 +154,7 @@ export class BrowserWindow<T extends RPCWithTransport = RPCWithTransport> {
 		};
 		this.navigationRules = options.navigationRules || null;
 		this.sandbox = options.sandbox ?? false;
+		this.spellCheck = options.spellCheck ?? false;
 
 		this.init(options);
 	}
@@ -242,6 +247,7 @@ export class BrowserWindow<T extends RPCWithTransport = RPCWithTransport> {
 			navigationRules: this.navigationRules,
 			sandbox: this.sandbox,
 			startPassthrough: this.passthrough,
+			spellCheck: this.spellCheck,
 		});
 
 		this.webviewId = webview.id;

--- a/package/src/bun/proc/native.ts
+++ b/package/src/bun/proc/native.ts
@@ -283,6 +283,10 @@ const core = (() => {
 				],
 				returns: FFIType.u32,
 			},
+			setWebviewSpellCheck: {
+				args: [FFIType.u32, FFIType.bool],
+				returns: FFIType.void,
+			},
 			getWebviewPointer: {
 				args: [FFIType.u32],
 				returns: FFIType.ptr,
@@ -1558,6 +1562,7 @@ const _ffiImpl = {
 			sandbox: boolean;
 			startTransparent: boolean;
 			startPassthrough: boolean;
+			spellCheck: boolean;
 		}): number => {
 			const {
 				windowId,
@@ -1573,6 +1578,7 @@ const _ffiImpl = {
 				sandbox,
 				startTransparent,
 				startPassthrough,
+				spellCheck,
 			} = params;
 			ensureWebviewRuntimeConfigured();
 
@@ -1602,6 +1608,10 @@ const _ffiImpl = {
 
 			if (!webviewId) {
 				throw getCoreLastError() || "Failed to create webview";
+			}
+
+			if (spellCheck) {
+				core_.symbols.setWebviewSpellCheck(webviewId, true);
 			}
 
 			return webviewId;

--- a/package/src/core/main.zig
+++ b/package/src/core/main.zig
@@ -1331,6 +1331,7 @@ fn createManagedWebviewFromInternalRequest(params: std.json.Value) ?u32 {
     const sandbox = jsonBool(params_object.get("sandbox") orelse .{ .bool = false }) orelse false;
     const transparent = jsonBool(params_object.get("transparent") orelse .{ .bool = false }) orelse false;
     const passthrough = jsonBool(params_object.get("passthrough") orelse .{ .bool = false }) orelse false;
+    const spell_check = jsonBool(params_object.get("spellCheck") orelse .{ .bool = false }) orelse false;
     const url_value = params_object.get("url");
     const html_value = params_object.get("html");
     const preload_value = params_object.get("preload");
@@ -1397,6 +1398,10 @@ fn createManagedWebviewFromInternalRequest(params: std.json.Value) ?u32 {
 
     if (webview_id == 0) {
         return null;
+    }
+
+    if (spell_check) {
+        setWebviewSpellCheck(webview_id, true);
     }
 
     if (html_value) |value| {
@@ -2354,6 +2359,13 @@ export fn createWebview(
 export fn getWebviewPointer(webview_id: u32) WebviewPtr {
     clearLastError();
     return lookupWebviewPtr(webview_id);
+}
+
+export fn setWebviewSpellCheck(webview_id: u32, enabled: bool) void {
+    const webview_ptr = lookupWebviewPtr(webview_id) orelse return;
+    const SetWebviewSpellCheckForPtrFn = *const fn (WebviewPtr, bool) callconv(.C) void;
+    const set_spell_check = lookupNativeSymbol(SetWebviewSpellCheckForPtrFn, "setWebviewSpellCheckForPtr") orelse return;
+    set_spell_check(webview_ptr, enabled);
 }
 
 export fn resizeWebview(

--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -6,6 +6,7 @@
 
 #import <WebKit/WebKit.h>
 #import <objc/runtime.h>
+#import <objc/message.h>
 #import <Cocoa/Cocoa.h>
 #import <Foundation/Foundation.h>
 #import <CommonCrypto/CommonCrypto.h>
@@ -847,6 +848,7 @@ void releaseObjCObject(id objcObject) {
     @property (nonatomic, assign) BOOL isSandboxed;  // When true, only eventBridge is active (no RPC)
     @property (nonatomic, assign) BOOL pendingStartTransparent;
     @property (nonatomic, assign) BOOL pendingStartPassthrough;
+    @property (nonatomic, assign) BOOL pendingSpellCheck;
     @property (nonatomic, strong) CALayer *storedLayerMask;
     @property (nonatomic, strong) NSArray<NSString *> *navigationRules;
     @property (atomic, assign) uint32_t resizeGeneration;
@@ -944,6 +946,7 @@ static NSMutableDictionary<NSNumber *, AbstractView *> *globalAbstractViews = ni
     @property (nonatomic, assign) uint32_t webviewId;
     @property (nonatomic, strong) NSMutableDictionary<NSValue *, NSString *> *downloadPaths;
     @property (nonatomic, strong) NSMutableSet<WKDownload *> *observedDownloads;
+    @property (nonatomic, assign) BOOL spellCheckEnabled;
 @end
 
 @interface MyWebViewUIDelegate : NSObject <WKUIDelegate>
@@ -2164,6 +2167,12 @@ static void schedulePendingResizeDrain() {
         if (urlString.length > 0) {
             self.zigEventHandler(self.webviewId, strdup("did-navigate"), strdup(urlString.UTF8String));
         }
+        if (self.spellCheckEnabled) {
+            SEL spellSel = NSSelectorFromString(@"_setContinuousSpellCheckingEnabledForTesting:");
+            if ([webView respondsToSelector:spellSel]) {
+                ((void (*)(id, SEL, BOOL))objc_msgSend)(webView, spellSel, YES);
+            }
+        }
     }
     - (void)webView:(WKWebView *)webView didCommitNavigation:(WKNavigation *)navigation {
         NSString *urlString = webView.URL.absoluteString ?: @"";
@@ -2572,17 +2581,17 @@ runOpenPanelWithParameters:(WKOpenPanelParameters *)parameters
                 
                 configuration.websiteDataStore = createDataStoreForPartition(partitionIdentifier);
                 
-                [configuration.preferences setValue:@YES forKey:@"developerExtrasEnabled"];        
-                [configuration.preferences setValue:@YES forKey:@"elementFullscreenEnabled"];                                
-                [configuration.preferences setValue:@YES forKey:@"allowsPictureInPictureMediaPlayback"];                
-                
+                [configuration.preferences setValue:@YES forKey:@"developerExtrasEnabled"];
+                [configuration.preferences setValue:@YES forKey:@"elementFullscreenEnabled"];
+                [configuration.preferences setValue:@YES forKey:@"allowsPictureInPictureMediaPlayback"];
+
                 // Add scheme handler
                 MyURLSchemeHandler *assetSchemeHandler = [[MyURLSchemeHandler alloc] init];
-                // TODO: Consider storing views handler globally and not on each AbstractView                
+                // TODO: Consider storing views handler globally and not on each AbstractView
                 assetSchemeHandler.webviewId = webviewId;
                 assetSchemeHandler.viewsRoot = viewsRootString;
                 [configuration setURLSchemeHandler:assetSchemeHandler forURLScheme:@"views"];
-                
+
                 // create WKWebView
                 self.webView = [[WKWebView alloc] initWithFrame:frame configuration:configuration];
 
@@ -2608,9 +2617,10 @@ runOpenPanelWithParameters:(WKOpenPanelParameters *)parameters
 
                 // delegates
                 MyNavigationDelegate *navigationDelegate = [[MyNavigationDelegate alloc] init];
-                navigationDelegate.zigCallback = navigationCallback;                
+                navigationDelegate.zigCallback = navigationCallback;
                 navigationDelegate.zigEventHandler = webviewEventHandler;
                 navigationDelegate.webviewId = webviewId;
+                navigationDelegate.spellCheckEnabled = self.pendingSpellCheck;
                 self.webView.navigationDelegate = navigationDelegate;
                 objc_setAssociatedObject(self.webView, "NavigationDelegate", navigationDelegate, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
@@ -6955,6 +6965,25 @@ static struct {
 extern "C" void setNextWebviewFlags(bool startTransparent, bool startPassthrough) {
     g_nextWebviewFlags.startTransparent = startTransparent;
     g_nextWebviewFlags.startPassthrough = startPassthrough;
+}
+
+extern "C" void setWebviewSpellCheckForPtr(void* viewPtr, bool enabled) {
+    if (!viewPtr) return;
+    WKWebViewImpl* view = (__bridge WKWebViewImpl*)viewPtr;
+    if (![view isKindOfClass:[WKWebViewImpl class]]) return;
+    // Set the flag immediately so the deferred init block picks it up if webView isn't ready yet.
+    view.pendingSpellCheck = (BOOL)enabled;
+    BOOL enabledObjC = (BOOL)enabled;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        SEL spellSel = NSSelectorFromString(@"_setContinuousSpellCheckingEnabledForTesting:");
+        if (view.webView && [view.webView respondsToSelector:spellSel]) {
+            ((void (*)(id, SEL, BOOL))objc_msgSend)(view.webView, spellSel, enabledObjC);
+        }
+        id navDelegate = objc_getAssociatedObject(view.webView, "NavigationDelegate");
+        if ([navDelegate isKindOfClass:[MyNavigationDelegate class]]) {
+            ((MyNavigationDelegate*)navDelegate).spellCheckEnabled = enabledObjC;
+        }
+    });
 }
 
 extern "C" AbstractView* initWebview(uint32_t webviewId,


### PR DESCRIPTION
> POC / suggested implementation — not expecting a merge, opening to express the idea.

Closes #456

## Problem

There is no way to enable the macOS system spell checker for `contenteditable` elements in a WKWebView. The native spell-check underlines users expect in text fields are absent.

## Approach

Adds a `spellCheck?: boolean` option to `BrowserView` and `BrowserWindow`. When enabled, calls `_setContinuousSpellCheckingEnabledForTesting:` (a private WKWebView selector) via `objc_msgSend` after `didFinishNavigation:`, which is the earliest point the webview content is ready to accept it.

A `pendingSpellCheck` flag on `AbstractView` handles the case where `setWebviewSpellCheck` is called before the webview finishes loading — the navigation delegate picks it up on `didFinishNavigation:`.

## Usage

\`\`\`ts
new BrowserView({
    spellCheck: true,
    url: 'views://main/index.html',
});
\`\`\`

## Changes

- **BrowserView.ts / BrowserWindow.ts** — `spellCheck?: boolean` option, wired through to `createWebview`
- **native.ts** — passes `spellCheck` param; adds `setWebviewSpellCheck` FFI binding
- **main.zig** — reads `spellCheck` from JSON params; exports `setWebviewSpellCheck` calling into native
- **nativeWrapper.mm** — `setWebviewSpellCheckForPtr` sets `pendingSpellCheck` on the view and updates the navigation delegate; delegate applies the selector in `didFinishNavigation:`