### PR TITLE
fix(linux): use CefRunMessageLoop() instead of gtk_main() to stop 100% CPU spin

### DIFF
--- a/package/src/native/linux/nativeWrapper.cpp
+++ b/package/src/native/linux/nativeWrapper.cpp
@@ -6408,18 +6408,35 @@ void runCEFEventLoop() {
     initializeGTK();
     printf("=== ELECTROBUN NATIVE WRAPPER VERSION 1.0.2 === CEF EVENT LOOP STARTED ===\n");
     fflush(stdout);
-        
-    // Set up a timer to periodically call CefDoMessageLoopWork()
-    // This integrates CEF message loop with GTK main loop
-    g_timeout_add(10, cef_timer_callback, nullptr); // 10ms interval
-        
-    
+
     // Set up X11 event processing
     g_timeout_add(10, process_x11_events, nullptr); // Process X11 events every 10ms
 
     sleep(1); // Give time for output to flush
-    gtk_main();
-    
+
+    // Initialize CEF eagerly so CefRunMessageLoop() below has a loop to run. CEF
+    // was previously initialized lazily on first webview creation; calling
+    // CefRunMessageLoop() before CefInitialize() returns immediately and the
+    // process exits. Eager init is safe — CEF needs no browser to initialize and
+    // the lazy call sites are guarded by g_cefInitialized so they become no-ops.
+    if (!g_cefInitialized.load()) {
+        initializeCEF();
+    }
+
+    // Drive the loop with CEF's own CefRunMessageLoop() rather than a raw
+    // gtk_main(). On Linux CEF installs its MessagePumpGlib work source and the
+    // Ozone X11 event source on the default GMainContext. Their prepare() returns
+    // a 0ms timeout unless MessagePumpGlib::Run has set up its RunState; a vanilla
+    // g_main_loop_run (gtk_main) iterates those sources WITHOUT that state, so
+    // prepare keeps reporting "work ready, timeout 0", the loop never blocks in
+    // poll(), and one CPU core pins at 100% continuously (even idle/hidden/blank
+    // page). CefRunMessageLoop runs MessagePumpGlib::Run, which blocks correctly
+    // when idle while still servicing the default context, so GTK dialogs/tray
+    // and the X11 timer above keep working. The old 10ms cef_timer_callback that
+    // manually called CefDoMessageLoopWork() is no longer needed and is removed.
+    // Torn down via CefQuitMessageLoop() in stopEventLoop().
+    CefRunMessageLoop();
+
     // Cleanup CEF on shutdown
 
     if (g_cefInitialized) {
@@ -9772,8 +9789,15 @@ ELECTROBUN_EXPORT void stopEventLoop() {
     g_shuttingDown.store(true);
     printf("[stopEventLoop] Initiating clean event loop exit\n");
 
+    // Quit on the main loop thread. In CEF mode the loop is CefRunMessageLoop()
+    // (MessagePumpGlib), so it must be torn down with CefQuitMessageLoop();
+    // gtk_main_quit() would no-op there and shutdown would hang.
     runOnMainThreadAsyncVoid([]() {
-        gtk_main_quit();
+        if (isCEFAvailable()) {
+            CefQuitMessageLoop();
+        } else {
+            gtk_main_quit();
+        }
     });
 }
 


### PR DESCRIPTION
## Symptom

On Linux, the CEF browser process pins one CPU core at ~100% continuously — even when the app is idle, the window is hidden, and the page is blank.

## Root cause

`runCEFEventLoop()` drives the event loop with a raw `gtk_main()` and pokes CEF with a 10 ms `CefDoMessageLoopWork()` timer (`g_timeout_add(10, cef_timer_callback, …)`). But CEF installs its own GLib sources on the default `GMainContext`: Chromium's `MessagePumpGlib` work source and Ozone's X11 event source (`ui::XSourcePrepare` / `x11::Connection::HasPendingResponses`).

Those sources' `prepare()` returns a **0 ms timeout** unless `MessagePumpGlib::Run` has set up its internal run-state. A vanilla `g_main_loop_run` (which is what `gtk_main()` is) iterates those sources **without** that run-state, so `prepare()` keeps reporting "work ready, timeout 0", the loop never blocks in `poll()`, and the core spins.

Confirmed with `perf`: the hot path is pure `g_main_context_prepare`/`check` with ~0 `ppoll` and ~0 dispatch; `/proc/<pid>/syscall` is empty (the thread never enters a syscall — a pure userspace busy-loop).

## Why neither obvious workaround helps

- This is **not** GDK's X11 source. GDK's and dbus's `prepare()` are called every iteration but never dispatched, so they aren't the culprit.
- It is **not** fixable via `external_message_pump = true` + `OnScheduleMessagePumpWork` — that was tried and the spin persisted, because the spinning sources are CEF's own and they're being iterated by the wrong loop driver.

## Fix

Drive the loop with CEF's own `CefRunMessageLoop()` instead of `gtk_main()`. `CefRunMessageLoop()` runs `MessagePumpGlib::Run`, which establishes the run-state and blocks correctly in `poll()` when idle, while still servicing the default `GMainContext` — so GTK dialogs/tray and the existing X11 event timer keep working.

Two supporting changes:

- **CEF is now initialized eagerly in `runCEFEventLoop()`.** It was previously initialized lazily on first webview creation; calling `CefRunMessageLoop()` before `CefInitialize()` returns immediately (no loop to run) and the process exits. Eager init is safe — CEF needs no browser to initialize, and the lazy init call sites remain guarded by `g_cefInitialized`, so they become no-ops.
- **`stopEventLoop()` now tears the loop down with `CefQuitMessageLoop()` in CEF mode** (`gtk_main_quit()` would no-op under CEF's loop and hang shutdown).
- The unconditional 10 ms `cef_timer_callback` timer is removed (no longer needed).

## Verification

Tested on a Linux/X11 handheld (gamescope/X11): idle CPU drops from ~100% to ~0% (the main thread now blocks in `poll`), the webview renders, windows map/unmap correctly, and shutdown is clean. No regressions observed.

## Scope

Linux only; macOS and Windows code paths are untouched. The change has been exercised with windowless rendering + transparent X11 windows; maintainers may want to also verify windowed (`SetAsChild`) and multi-window configurations.