### PR TITLE
fix(linux): stop CEF window move/resize crash (Xlib threading + ConfigureNotify storm)

### DIFF
--- a/package/src/native/linux/nativeWrapper.cpp
+++ b/package/src/native/linux/nativeWrapper.cpp
@@ -5757,6 +5757,18 @@ void initializeGTK() {
     {
         std::unique_lock<std::mutex> lock(g_gtkInitMutex);
         if (!g_gtkInitialized) {
+            // Xlib is driven from multiple threads: ElectrobunClient::OnPaint
+            // (CEF UI thread) does XCreateImage/XPutImage/XFlush on the OSR
+            // buffer using the SAME Display* that process_x11_events (the
+            // main/GTK thread) drains events from. Without XInitThreads()
+            // those concurrent Xlib calls corrupt Xlib's internal request
+            // buffer during a window move/resize event storm, and the
+            // corruption later surfaces as a SIGSEGV/SIGABRT in an unrelated
+            // thread (typically the JS engine's GC) — see the linked issues.
+            // XInitThreads() must run before gtk_init() and any XOpenDisplay(),
+            // so it is the very first call here.
+            XInitThreads();
+
             // Force X11 backend on Wayland systems
             setenv("GDK_BACKEND", "x11", 1);
             
@@ -6320,35 +6332,49 @@ gboolean process_x11_events(gpointer data) {
                     }
                     break;
                     
-                case ConfigureNotify:
+                case ConfigureNotify: {
                     // Only process ConfigureNotify events for the actual main window, not CEF child windows
                     if (event.xconfigure.window != x11win->window) {
                         break;
                     }
-                    
-                    if (event.xconfigure.width != x11win->width || event.xconfigure.height != x11win->height ||
-                        event.xconfigure.x != x11win->x || event.xconfigure.y != x11win->y) {
-                        
-                        
-                        x11win->x = event.xconfigure.x;
-                        x11win->y = event.xconfigure.y;
-                        x11win->width = event.xconfigure.width;
-                        x11win->height = event.xconfigure.height;
-                        
-                        // Call move callback when position changes
-                        if (x11win->moveCallback) {
-                            x11win->moveCallback(x11win->windowId, x11win->x, x11win->y);
-                        }
-                        
+
+                    // A drag (resize from a corner, or moving the window between
+                    // monitors) emits a STORM of ConfigureNotify events. Firing
+                    // the JS move/resize callbacks and a CEF WasResized()/OSR
+                    // re-render for every one floods the JS side and the OSR
+                    // paint pipeline. Coalesce the whole pending burst down to
+                    // the LATEST geometry first.
+                    XEvent latest = event;
+                    XEvent peek;
+                    while (XCheckTypedWindowEvent(x11win->display, x11win->window, ConfigureNotify, &peek)) {
+                        latest = peek;
+                    }
+
+                    bool moved   = (latest.xconfigure.x != x11win->x) || (latest.xconfigure.y != x11win->y);
+                    bool resized = (latest.xconfigure.width != x11win->width) || (latest.xconfigure.height != x11win->height);
+
+                    x11win->x = latest.xconfigure.x;
+                    x11win->y = latest.xconfigure.y;
+                    x11win->width = latest.xconfigure.width;
+                    x11win->height = latest.xconfigure.height;
+
+                    // Fire the move callback only when the position changed.
+                    if (moved && x11win->moveCallback) {
+                        x11win->moveCallback(x11win->windowId, x11win->x, x11win->y);
+                    }
+
+                    // Fire the resize callback + OSR re-layout only when the
+                    // SIZE actually changed. A pure move (same w/h) must not
+                    // trigger a CEF WasResized()/OnPaint storm.
+                    if (resized) {
                         if (x11win->resizeCallback) {
-                            x11win->resizeCallback(x11win->windowId, x11win->x, x11win->y, 
+                            x11win->resizeCallback(x11win->windowId, x11win->x, x11win->y,
                                                     x11win->width, x11win->height);
                         }
-                        
-                        // Auto-resize webviews in this window
                         resizeAutoSizingWebviewsInWindow(x11win->windowId, x11win->width, x11win->height);
                     }
                     break;
+                }
                     
                 case Expose:
                     // Handle expose events if needed


### PR DESCRIPTION
## Problem

On Linux, dragging a CEF `BrowserWindow` — **resizing from a corner** or **moving it between monitors** — crashes the app with `Signal 11` (sometimes `SIGABRT`), with seemingly **random backtraces**, often deep inside the JS engine's GC (`JSC::MarkingConstraint::execute`, etc.). Reproducible in a fresh `electrobun init` CEF app on a multi-monitor X11 setup. Affects 1.16.0 through current `main` (1.18.4-beta.6).

This appears to be the cause behind several open reports:
- Closes #426 (Crash on linux, mostly on resize) — same `Signal 11` + random JSC-GC backtrace.
- Related #281 (GLXBadWindow / Signal 11 on Wayland/CEF).
- Related #145 (window move handling — `startWindowMove`).
- Related #371 (Linux resize issues).

## Root cause

**Xlib is driven from two threads with no `XInitThreads()`.**

- `ElectrobunClient::OnPaint` runs on the **CEF UI thread** and calls `XCreateImage` / `XPutImage` / `XFlush` on the OSR buffer.
- `process_x11_events` runs on the **main / GTK thread** and calls `XPending` / `XNextEvent`.
- Both use the **same `Display*` connection** (`EnableOSR(x11win->window, x11win->display, …)`).

Xlib is not thread-safe unless `XInitThreads()` is called before the first Xlib call. Without it, the two threads racing on one `Display` during a move/resize **event storm** corrupt Xlib's internal request buffer; the corruption surfaces later as a crash in an unrelated thread (usually the JS GC) — which is exactly why the reported backtraces look random and unrelated to windowing.

I confirmed the crashing thread was inside `process_x11_events` via coredump symbol resolution, and that `XInitThreads()` alone makes resize stop crashing.

## Fix

1. **`XInitThreads()`** as the first call in `initializeGTK()` (before `gtk_init()` and any `XOpenDisplay()`), so Xlib serializes cross-thread access.
2. **Coalesce the `ConfigureNotify` storm**: a drag emits many per second. Collapse the pending burst to the latest geometry with `XCheckTypedWindowEvent`, then fire the JS move/resize callbacks + CEF `WasResized()`/OSR re-render **at most once per drain**, and only when the position (move) or size (resize) actually changed. A pure move no longer triggers an OSR repaint storm. This also removes a redundant `resizeCallback` firing on position-only changes.

## Testing

Dual-monitor X11 with mismatched DPI (a 430-DPI panel + a 157-DPI 4K display — the config that reproduced it most reliably). Before: corner-resize or cross-monitor drag crashed within seconds. After: aggressive corner-resizing and repeated cross-monitor dragging no longer crash; the process stays up. Built against CEF 145.0.23.

Both changes are confined to the Linux native wrapper.