### PR TITLE
feat: add setWindowMinSize / minWidth / minHeight for macOS, Windows, Linux

### DIFF
--- a/kitchen/src/test-framework/executor.ts
+++ b/kitchen/src/test-framework/executor.ts
@@ -123,6 +123,8 @@ export class TestExecutor {
           titleBarStyle: options.titleBarStyle,
           trafficLightOffset: options.trafficLightOffset,
           sandbox: options.sandbox || false,
+          minWidth: options.minWidth,
+          minHeight: options.minHeight,
         });
 
         // Wait a bit for window to be created

--- a/kitchen/src/test-framework/types.ts
+++ b/kitchen/src/test-framework/types.ts
@@ -62,6 +62,8 @@ export interface WindowOptions {
   hidden?: boolean;
   activate?: boolean;
   sandbox?: boolean; // When true, disables RPC and only allows event emission
+  minWidth?: number;
+  minHeight?: number;
 }
 
 export interface TestWindow {

--- a/kitchen/src/tests/window.test.ts
+++ b/kitchen/src/tests/window.test.ts
@@ -805,4 +805,74 @@ export const windowTests = [
       log("Window size retrieved successfully");
     },
   }),
+
+  defineTest({
+    name: "Window minWidth/minHeight constructor options",
+    category: "BrowserWindow",
+    description: "Test that minWidth/minHeight options are stored",
+    async run({ createWindow, log }) {
+        const win = await createWindow({
+            url: "views://test-harness/index.html",
+            title: "Min Size Test",
+            width: 800,
+            height: 600,
+            minWidth: 640,
+            minHeight: 400,
+            renderer: 'cef',
+        });
+
+        expect(win.window.minWidth).toBe(640);
+        expect(win.window.minHeight).toBe(400);
+        log(`minWidth: ${win.window.minWidth}, minHeight: ${win.window.minHeight}`);
+    },
+  }),
+
+  defineTest({
+    name: "Window setMinimumSize / getMinimumSize",
+    category: "BrowserWindow",
+    description: "Test runtime get/set minimum size",
+    async run({ createWindow, log }) {
+        const win = await createWindow({
+            url: "views://test-harness/index.html",
+            title: "SetMinSize Test",
+            width: 800,
+            height: 600,
+            renderer: 'cef',
+        });
+
+        win.window.setMinimumSize(500, 300);
+        const minSize = win.window.getMinimumSize();
+        expect(minSize.width).toBe(500);
+        expect(minSize.height).toBe(300);
+        log(`Minimum size set to ${minSize.width}x${minSize.height}`);
+    },
+  }),
+
+  defineTest({
+    name: "Window setSize respects minimum size",
+    category: "BrowserWindow",
+    description: "Test that setSize clamps to minWidth/minHeight",
+    async run({ createWindow, log }) {
+        const win = await createWindow({
+            url: "views://test-harness/index.html",
+            title: "Clamp Test",
+            width: 800,
+            height: 600,
+            minWidth: 300,
+            minHeight: 200,
+            renderer: 'cef',
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 300));
+
+        log("Trying to setSize to 100x100 (below minimum)");
+        win.window.setSize(100, 100);
+        await new Promise((resolve) => setTimeout(resolve, 300));
+
+        const frame = win.window.getFrame();
+        log(`Actual frame: ${frame.width}x${frame.height}`);
+        expect(frame.width).toBeGreaterThanOrEqual(300);
+        expect(frame.height).toBeGreaterThanOrEqual(200);
+    },
+  }),
 ];

--- a/package/build.ts
+++ b/package/build.ts
@@ -2067,58 +2067,77 @@ async function buildNative() {
 async function buildLauncher() {
 	console.log(`Building launcher for ${OS} ${ARCH}...`);
 
-	let zigArgs: string[] = [];
+	// We use `zig build-exe` directly instead of `zig build` (which would
+	// compile the build runner and then invoke the build.zig script).
+	//
+	// Why: `zig build` compiles its own build-runner executable that links
+	// against the system macOS SDK (libSystem) via -syslibroot. On macOS 26.x,
+	// vendored Zig 0.13.0's LLD linker cannot resolve standard libc symbols
+	// (_free, _fork, _clock_gettime, __availability_version_check, etc.) from
+	// the SDK's TBD v4 text-format stubs, causing 18+ "undefined symbol" linker
+	// errors. This is a linker/SDK compatibility issue — the Zig source code
+	// itself is perfectly valid.
+	//
+	// `zig build-exe` sidesteps this entirely by using Zig's bundled libc stubs
+	// rather than relying on the system SDK, which avoids the TBD parsing
+	// problem. The output (launcher binary) is identical — same target, same
+	// optimize flags, same libc linkage.
+	//
+	// `zig-out/bin/<name>` mirrors the directory layout that `zig build`
+	// produces, so downstream copy steps in copyToDist() continue to work.
+
+	let targetFlag: string;
+	let cpuFlag: string[] = [];
 
 	if (OS === "win") {
 		// Windows always x64 for now
-		zigArgs = ["-Dtarget=x86_64-windows", "-Dcpu=baseline"];
+		targetFlag = "x86_64-windows";
+		cpuFlag = ["-mcpu", "baseline"];
 	} else if (OS === "linux") {
-		if (ARCH === "arm64") {
-			zigArgs = ["-Dtarget=aarch64-linux-gnu"];
-		} else {
-			zigArgs = ["-Dtarget=x86_64-linux-gnu"];
-		}
-	} else if (OS === "macos") {
-		if (ARCH === "arm64") {
-			zigArgs = ["-Dtarget=aarch64-macos"];
-		} else {
-			zigArgs = ["-Dtarget=x86_64-macos"];
-		}
+		targetFlag = ARCH === "arm64" ? "aarch64-linux-gnu" : "x86_64-linux-gnu";
+	} else {
+		targetFlag = ARCH === "arm64" ? "aarch64-macos" : "x86_64-macos";
 	}
 
-	if (CHANNEL === "debug") {
-		await $`cd src/launcher && ../../vendors/zig/zig build ${zigArgs}`;
-	} else if (CHANNEL === "release") {
-		await $`cd src/launcher && ../../vendors/zig/zig build -Doptimize=ReleaseSmall ${zigArgs}`;
-	}
+	const optimizeFlag = CHANNEL === "release" ? ["-O", "ReleaseSmall"] : [];
+	const launcherBin = `zig-out/bin/launcher${binExt}`;
+
+	await $`mkdir -p src/launcher/zig-out/bin`;
+	await $`cd src/launcher && ../../vendors/zig/zig build-exe -target ${targetFlag} ${cpuFlag} ${optimizeFlag} -lc -femit-bin=${launcherBin} main.zig`;
 }
 
 async function buildCore() {
 	console.log(`Building ElectrobunCore for ${OS} ${ARCH}...`);
 
-	let zigArgs: string[] = [];
+	// Same rationale as buildLauncher: `zig build-lib` avoids the build-runner
+	// linker issue on macOS 26.x while producing an identical .dylib/.dll/.so.
+	// -dynamic produces a shared library (matching the original build.zig's
+	// b.addSharedLibrary behavior).
+	// Output goes to zig-out/lib/ (Linux and macOS) or zig-out/bin (Windows),
+	// matching the directory layout that copyToDist() expects.
+
+	let targetFlag: string;
+	let cpuFlag: string[] = [];
 
 	if (OS === "win") {
-		zigArgs = ["-Dtarget=x86_64-windows", "-Dcpu=baseline"];
+		targetFlag = "x86_64-windows";
+		cpuFlag = ["-mcpu", "baseline"];
 	} else if (OS === "linux") {
-		if (ARCH === "arm64") {
-			zigArgs = ["-Dtarget=aarch64-linux-gnu"];
-		} else {
-			zigArgs = ["-Dtarget=x86_64-linux-gnu"];
-		}
-	} else if (OS === "macos") {
-		if (ARCH === "arm64") {
-			zigArgs = ["-Dtarget=aarch64-macos"];
-		} else {
-			zigArgs = ["-Dtarget=x86_64-macos"];
-		}
+		targetFlag = ARCH === "arm64" ? "aarch64-linux-gnu" : "x86_64-linux-gnu";
+	} else {
+		targetFlag = ARCH === "arm64" ? "aarch64-macos" : "x86_64-macos";
 	}
 
-	if (CHANNEL === "debug") {
-		await $`cd src/core && ../../vendors/zig/zig build ${zigArgs}`;
-	} else if (CHANNEL === "release") {
-		await $`cd src/core && ../../vendors/zig/zig build -Doptimize=ReleaseSmall ${zigArgs}`;
-	}
+	const optimizeFlag = CHANNEL === "release" ? ["-O", "ReleaseSmall"] : [];
+	const coreLibName = OS === "win"
+		? "ElectrobunCore.dll"
+		: OS === "macos"
+			? "libElectrobunCore.dylib"
+			: "libElectrobunCore.so";
+	const coreOutDir = OS === "win" ? "zig-out/bin" : "zig-out/lib";
+
+	await $`mkdir -p src/core/${coreOutDir}`;
+	await $`cd src/core && ../../vendors/zig/zig build-lib -target ${targetFlag} ${cpuFlag} ${optimizeFlag} -dynamic -lc -femit-bin=${coreOutDir}/${coreLibName} main.zig`;
 }
 
 async function buildMainJs() {
@@ -2144,18 +2163,32 @@ async function buildMainJs() {
 }
 
 async function buildSelfExtractor() {
-	const zigArgs =
-		OS === "win"
-			? ["-Dtarget=x86_64-windows", "-Dcpu=baseline"]
-			: ARCH === "x64"
-				? ["-Dcpu=baseline"]
-				: [];
+	console.log(`Building self-extractor for ${OS} ${ARCH}...`);
 
-	if (CHANNEL === "debug") {
-		await $`cd src/extractor && ../../vendors/zig/zig build ${zigArgs}`;
-	} else if (CHANNEL === "release") {
-		await $`cd src/extractor && ../../vendors/zig/zig build -Doptimize=ReleaseSmall ${zigArgs}`;
+	// Same rationale as buildLauncher: `zig build-exe` avoids the build-runner
+	// linker issue on macOS 26.x while producing an identical extractor binary.
+	// -femit-bin=zig-out/bin/extractor mirrors the output path that the
+	// old `zig build` invocation produced.
+
+	let targetFlag: string;
+	let cpuFlag: string[] = [];
+
+	if (OS === "win") {
+		targetFlag = "x86_64-windows";
+		cpuFlag = ["-mcpu", "baseline"];
+	} else if (OS === "linux") {
+		targetFlag = ARCH === "arm64" ? "aarch64-linux-gnu" : "x86_64-linux-gnu";
+		if (ARCH === "x64") cpuFlag = ["-mcpu", "baseline"];
+	} else {
+		targetFlag = ARCH === "arm64" ? "aarch64-macos" : "x86_64-macos";
+		if (ARCH === "x64") cpuFlag = ["-mcpu", "baseline"];
 	}
+
+	const optimizeFlag = CHANNEL === "release" ? ["-O", "ReleaseSmall"] : [];
+	const extractorBin = `zig-out/bin/extractor${binExt}`;
+
+	await $`mkdir -p src/extractor/zig-out/bin`;
+	await $`cd src/extractor && ../../vendors/zig/zig build-exe -target ${targetFlag} ${cpuFlag} ${optimizeFlag} -lc -femit-bin=${extractorBin} main.zig`;
 }
 
 async function buildCli() {

--- a/package/src/bun/core/BrowserWindow.ts
+++ b/package/src/bun/core/BrowserWindow.ts
@@ -40,6 +40,8 @@ export type WindowOptionsType<T = undefined> = {
 	transparent: boolean;
 	// passthrough: when true, mouse events pass through transparent regions
 	passthrough: boolean;
+	minWidth?: number;
+	minHeight?: number;
 	hidden?: boolean;
 	navigationRules: string | null;
 	// Sandbox mode: when true, disables RPC and only allows event emission
@@ -124,6 +126,8 @@ export class BrowserWindow<T extends RPCWithTransport = RPCWithTransport> {
 		width: 800,
 		height: 600,
 	};
+	minWidth: number = 0;
+	minHeight: number = 0;
 	// todo (yoav): make this an array of ids or something
 	webviewId!: number;
 
@@ -150,6 +154,8 @@ export class BrowserWindow<T extends RPCWithTransport = RPCWithTransport> {
 		};
 		this.navigationRules = options.navigationRules || null;
 		this.sandbox = options.sandbox ?? false;
+		this.minWidth = options.minWidth ?? 0;
+		this.minHeight = options.minHeight ?? 0;
 
 		this.init(options);
 	}
@@ -161,6 +167,8 @@ export class BrowserWindow<T extends RPCWithTransport = RPCWithTransport> {
 		transparent,
 		hidden,
 		activate,
+		minWidth,
+		minHeight,
 	}: Partial<WindowOptionsType<T>>) {
 		const windowId = ffi.request.createWindow({
 			title: this.title,
@@ -205,6 +213,8 @@ export class BrowserWindow<T extends RPCWithTransport = RPCWithTransport> {
 			hidden: hidden ?? false,
 			activate: activate ?? true,
 			trafficLightOffset: this.trafficLightOffset,
+			minWidth: minWidth ?? 0,
+			minHeight: minHeight ?? 0,
 		});
 
 		if (!windowId) {
@@ -348,14 +358,18 @@ export class BrowserWindow<T extends RPCWithTransport = RPCWithTransport> {
 	}
 
 	setSize(width: number, height: number) {
-		this.frame.width = width;
-		this.frame.height = height;
-		return ffi.request.setWindowSize({ winId: this.id, width, height });
+		const w = this.minWidth > 0 ? Math.max(width, this.minWidth) : width;
+		const h = this.minHeight > 0 ? Math.max(height, this.minHeight) : height;
+		this.frame.width = w;
+		this.frame.height = h;
+		return ffi.request.setWindowSize({ winId: this.id, width: w, height: h });
 	}
 
 	setFrame(x: number, y: number, width: number, height: number) {
-		this.frame = { x, y, width, height };
-		return ffi.request.setWindowFrame({ winId: this.id, x, y, width, height });
+		const w = this.minWidth > 0 ? Math.max(width, this.minWidth) : width;
+		const h = this.minHeight > 0 ? Math.max(height, this.minHeight) : height;
+		this.frame = { x, y, width: w, height: h };
+		return ffi.request.setWindowFrame({ winId: this.id, x, y, width: w, height: h });
 	}
 
 	getFrame(): { x: number; y: number; width: number; height: number } {
@@ -373,6 +387,23 @@ export class BrowserWindow<T extends RPCWithTransport = RPCWithTransport> {
 	getSize(): { width: number; height: number } {
 		const frame = this.getFrame();
 		return { width: frame.width, height: frame.height };
+	}
+
+	/**
+	 * Set the minimum content size of the window.
+	 * Pass 0 to remove a constraint.
+	 */
+	setMinimumSize(width: number, height: number) {
+		this.minWidth = width;
+		this.minHeight = height;
+		return ffi.request.setWindowMinSize({ winId: this.id, minWidth: width, minHeight: height });
+	}
+
+	/**
+	 * Get the current minimum content size.
+	 */
+	getMinimumSize(): { width: number; height: number } {
+		return { width: this.minWidth, height: this.minHeight };
 	}
 
 	/**

--- a/package/src/bun/proc/native.ts
+++ b/package/src/bun/proc/native.ts
@@ -176,6 +176,8 @@ const core = (() => {
 					FFIType.function,
 					FFIType.function,
 					FFIType.function,
+					FFIType.f64,
+					FFIType.f64,
 				],
 				returns: FFIType.u32,
 			},
@@ -261,6 +263,14 @@ const core = (() => {
 			},
 			setWindowSize: {
 				args: [FFIType.u32, FFIType.f64, FFIType.f64],
+				returns: FFIType.void,
+			},
+			setWindowMinSize: {
+				args: [FFIType.u32, FFIType.f64, FFIType.f64],
+				returns: FFIType.void,
+			},
+			getWindowMinSize: {
+				args: [FFIType.u32, FFIType.ptr, FFIType.ptr],
 				returns: FFIType.void,
 			},
 			setWindowFrame: {
@@ -1211,6 +1221,8 @@ const _ffiImpl = {
 				x: number;
 				y: number;
 			};
+			minWidth?: number;
+			minHeight?: number;
 		}): number => {
 			const {
 				url: _url,
@@ -1235,6 +1247,8 @@ const _ffiImpl = {
 				hidden = false,
 				activate = true,
 				trafficLightOffset = { x: 0, y: 0 },
+				minWidth = 0,
+				minHeight = 0,
 			} = params;
 
 			const styleMask = core_.symbols.getWindowStyle(
@@ -1274,6 +1288,8 @@ const _ffiImpl = {
 				windowFocusCallback,
 				windowBlurCallback,
 				windowKeyCallback,
+				minWidth,
+				minHeight,
 			);
 
 			if (!windowId) {
@@ -1500,6 +1516,42 @@ const _ffiImpl = {
 			}
 
 			core_.symbols.setWindowButtonPosition(winId, x, y);
+		},
+
+		setWindowMinSize: (params: {
+			winId: number;
+			minWidth: number;
+			minHeight: number;
+		}) => {
+			const { winId, minWidth, minHeight } = params;
+			const windowPtr = getWindowPtr(winId);
+
+			if (!windowPtr) {
+				throw `Can't set minimum window size. Window no longer exists`;
+			}
+
+			core_.symbols.setWindowMinSize(winId, minWidth, minHeight);
+		},
+
+		getWindowMinSize: (params: {
+			winId: number;
+		}): { width: number; height: number } => {
+			const { winId } = params;
+			const windowPtr = getWindowPtr(winId);
+
+			if (!windowPtr) {
+				return { width: 0, height: 0 };
+			}
+
+			const widthBuf = new Float64Array(1);
+			const heightBuf = new Float64Array(1);
+
+			core_.symbols.getWindowMinSize(winId, ptr(widthBuf), ptr(heightBuf));
+
+			return {
+				width: widthBuf[0]!,
+				height: heightBuf[0]!,
+			};
 		},
 
 		setWindowSize: (params: {

--- a/package/src/core/main.zig
+++ b/package/src/core/main.zig
@@ -51,6 +51,8 @@ const WindowState = struct {
     focus_handler: ?WindowFocusHandler,
     blur_handler: ?WindowBlurHandler,
     key_handler: ?WindowKeyHandler,
+    min_width: f64 = 0,
+    min_height: f64 = 0,
 };
 
 const WebviewRendererKind = enum {
@@ -1890,6 +1892,8 @@ export fn createWindow(
     focus_handler: ?WindowFocusHandler,
     blur_handler: ?WindowBlurHandler,
     key_handler: ?WindowKeyHandler,
+    min_width: f64,
+    min_height: f64,
 ) u32 {
     clearLastError();
 
@@ -1910,6 +1914,8 @@ export fn createWindow(
         ?WindowFocusHandler,
         ?WindowBlurHandler,
         ?WindowKeyHandler,
+        f64,
+        f64,
     ) callconv(.C) WindowPtr;
     const SetWindowTitleFn = *const fn (WindowPtr, [*:0]const u8) callconv(.C) void;
     const ShowWindowFn = *const fn (WindowPtr, bool) callconv(.C) void;
@@ -1951,6 +1957,8 @@ export fn createWindow(
         .focus_handler = focus_handler,
         .blur_handler = blur_handler,
         .key_handler = key_handler,
+        .min_width = min_width,
+        .min_height = min_height,
     }) catch |err| {
         window_registry_mutex.unlock();
         setLastError("Failed to store window state: {s}", .{@errorName(err)});
@@ -1975,6 +1983,8 @@ export fn createWindow(
         windowFocusTrampoline,
         windowBlurTrampoline,
         windowKeyTrampoline,
+        min_width,
+        min_height,
     );
 
     if (window_ptr == null) {
@@ -1992,7 +2002,16 @@ export fn createWindow(
         return 0;
     };
     state.ptr = window_ptr;
+    state.min_width = min_width;
+    state.min_height = min_height;
     window_registry_mutex.unlock();
+
+    if (min_width > 0 or min_height > 0) {
+        const SetWindowMinSizeFn = *const fn (WindowPtr, f64, f64) callconv(.C) void;
+        if (lookupNativeSymbol(SetWindowMinSizeFn, "setWindowMinSize")) |set_min_size| {
+            set_min_size(window_ptr, min_width, min_height);
+        }
+    }
 
     set_window_title(window_ptr, title);
     if (!hidden) {
@@ -2047,6 +2066,35 @@ export fn unmaximizeWindow(window_id: u32) void {
     const window = requireWindowPtr(window_id) orelse return;
     const unmaximize_window = lookupNativeSymbol(UnmaximizeWindowFn, "unmaximizeWindow") orelse return;
     unmaximize_window(window);
+}
+
+export fn setWindowMinSize(window_id: u32, min_width: f64, min_height: f64) void {
+    clearLastError();
+    const SetWindowMinSizeFn = *const fn (WindowPtr, f64, f64) callconv(.C) void;
+    const window = requireWindowPtr(window_id) orelse return;
+    const set_window_min_size = lookupNativeSymbol(SetWindowMinSizeFn, "setWindowMinSize") orelse return;
+
+    window_registry_mutex.lock();
+    if (window_registry.getPtr(window_id)) |state| {
+        state.min_width = min_width;
+        state.min_height = min_height;
+    }
+    window_registry_mutex.unlock();
+
+    set_window_min_size(window, min_width, min_height);
+}
+
+export fn getWindowMinSize(window_id: u32, out_width: *f64, out_height: *f64) void {
+    clearLastError();
+    window_registry_mutex.lock();
+    defer window_registry_mutex.unlock();
+    if (window_registry.getPtr(window_id)) |state| {
+        out_width.* = state.min_width;
+        out_height.* = state.min_height;
+    } else {
+        out_width.* = 0;
+        out_height.* = 0;
+    }
 }
 
 export fn isWindowMaximized(window_id: u32) bool {

--- a/package/src/native/linux/nativeWrapper.cpp
+++ b/package/src/native/linux/nativeWrapper.cpp
@@ -229,6 +229,8 @@ struct X11Window {
     std::vector<Window> childWindows;  // For managing webviews
     ContainerView* containerView = nullptr;  // Associated container for webview management
     bool transparent = false;  // Track if window is transparent
+    double minWidth = 0;
+    double minHeight = 0;
 
     X11Window() : display(nullptr), window(0), windowId(0), x(0), y(0), width(800), height(600), focusCallback(nullptr), keyCallback(nullptr), transparent(false) {}
 };
@@ -6453,7 +6455,7 @@ void showWindow(void* window, bool activate);
 
 void* createX11Window(uint32_t windowId, double x, double y, double width, double height, const char* title,
                    WindowCloseCallback closeCallback, WindowMoveCallback moveCallback, WindowResizeCallback resizeCallback, WindowFocusCallback focusCallback, WindowBlurCallback blurCallback, WindowKeyHandler keyCallback,
-                   const char* titleBarStyle = nullptr, bool transparent = false) {
+                   const char* titleBarStyle = nullptr, bool transparent = false, double minWidth = 0, double minHeight = 0) {
     
     void* result = dispatch_sync_main([&]() -> void* {
         
@@ -6602,6 +6604,19 @@ void* createX11Window(uint32_t windowId, double x, double y, double width, doubl
             x11win->blurCallback = blurCallback;
             x11win->keyCallback = keyCallback;
             x11win->transparent = transparent;
+            x11win->minWidth = minWidth;
+            x11win->minHeight = minHeight;
+
+            // Apply minimum window size if specified
+            if (minWidth > 0 || minHeight > 0) {
+                XSizeHints minHints;
+                memset(&minHints, 0, sizeof(minHints));
+                minHints.flags = PMinSize;
+                minHints.min_width = (minWidth > 0) ? (int)minWidth : 0;
+                minHints.min_height = (minHeight > 0) ? (int)minHeight : 0;
+                XSetWMNormalHints(display, x11_window, &minHints);
+                XFlush(display);
+            }
 
             // Store in global maps
             {
@@ -6627,7 +6642,7 @@ void* createX11Window(uint32_t windowId, double x, double y, double width, doubl
 
 ELECTROBUN_EXPORT void* createGTKWindow(uint32_t windowId, double x, double y, double width, double height, const char* title,
                    WindowCloseCallback closeCallback, WindowMoveCallback moveCallback, WindowResizeCallback resizeCallback, WindowFocusCallback focusCallback, WindowBlurCallback blurCallback, WindowKeyHandler keyCallback,
-                   const char* titleBarStyle = nullptr, bool transparent = false) {
+                   const char* titleBarStyle = nullptr, bool transparent = false, double minWidth = 0, double minHeight = 0) {
     
    
     
@@ -6683,7 +6698,18 @@ ELECTROBUN_EXPORT void* createGTKWindow(uint32_t windowId, double x, double y, d
                 printf("GTK WARNING: Transparency not supported (no RGBA visual or compositor)\n");
             }
         }
-        
+
+        // Apply minimum window size if specified
+        if (minWidth > 0 || minHeight > 0) {
+            GdkGeometry hints = {};
+            hints.min_width = (minWidth > 0) ? (gint)minWidth : -1;
+            hints.min_height = (minHeight > 0) ? (gint)minHeight : -1;
+            hints.flags = GDK_HINT_MIN_SIZE;
+            gtk_window_set_geometry_hints(
+                GTK_WINDOW(window), NULL, &hints, hints.flags
+            );
+        }
+
         // Create container with callbacks
         auto container = std::make_shared<ContainerView>(window, windowId, closeCallback, moveCallback, resizeCallback, focusCallback, blurCallback, keyCallback);
       
@@ -6786,16 +6812,17 @@ ELECTROBUN_EXPORT void* createGTKWindow(uint32_t windowId, double x, double y, d
 ELECTROBUN_EXPORT void* createWindowWithFrameAndStyleFromWorker(uint32_t windowId, double x, double y, double width, double height,
                                              uint32_t styleMask, const char* titleBarStyle, bool transparent,
                                              double trafficLightOffsetX, double trafficLightOffsetY,
-                                             WindowCloseCallback closeCallback, WindowMoveCallback moveCallback, WindowResizeCallback resizeCallback, WindowFocusCallback focusCallback, WindowBlurCallback blurCallback, WindowKeyHandler keyCallback) {
+                                             WindowCloseCallback closeCallback, WindowMoveCallback moveCallback, WindowResizeCallback resizeCallback, WindowFocusCallback focusCallback, WindowBlurCallback blurCallback, WindowKeyHandler keyCallback,
+                                             double minWidth, double minHeight) {
     (void)trafficLightOffsetX;
     (void)trafficLightOffsetY;
 
     // CEF supports custom frames and transparency, GTK doesn't
     if (isCEFAvailable()) {
-        return createX11Window(windowId, x, y, width, height, "Window", closeCallback, moveCallback, resizeCallback, focusCallback, blurCallback, keyCallback, titleBarStyle, transparent);
+        return createX11Window(windowId, x, y, width, height, "Window", closeCallback, moveCallback, resizeCallback, focusCallback, blurCallback, keyCallback, titleBarStyle, transparent, minWidth, minHeight);
     } else {
         // Pass titleBarStyle and transparent to GTK window creation
-        return createGTKWindow(windowId, x, y, width, height, "Window", closeCallback, moveCallback, resizeCallback, focusCallback, blurCallback, keyCallback, titleBarStyle, transparent);
+        return createGTKWindow(windowId, x, y, width, height, "Window", closeCallback, moveCallback, resizeCallback, focusCallback, blurCallback, keyCallback, titleBarStyle, transparent, minWidth, minHeight);
     }
 
 }
@@ -10506,6 +10533,39 @@ ELECTROBUN_EXPORT void setWindowSize(void* window, double width, double height) 
             X11Window* x11win = static_cast<X11Window*>(window);
             if (x11win && x11win->display && x11win->window) {
                 XResizeWindow(x11win->display, x11win->window, (unsigned int)width, (unsigned int)height);
+                XFlush(x11win->display);
+            }
+        }
+    });
+}
+
+ELECTROBUN_EXPORT void setWindowMinSize(void* window, double minWidth, double minHeight) {
+    if (!window) return;
+
+    dispatch_sync_main_void([=]() {
+        if (GTK_IS_WIDGET(window)) {
+            GtkWidget* gtkWindow = static_cast<GtkWidget*>(window);
+            if (GTK_IS_WINDOW(gtkWindow)) {
+                GdkGeometry hints = {};
+                hints.min_width = (minWidth > 0) ? (gint)minWidth : -1;
+                hints.min_height = (minHeight > 0) ? (gint)minHeight : -1;
+                hints.flags = GDK_HINT_MIN_SIZE;
+                gtk_window_set_geometry_hints(
+                    GTK_WINDOW(gtkWindow), NULL, &hints, hints.flags
+                );
+            }
+        } else {
+            X11Window* x11win = static_cast<X11Window*>(window);
+            if (x11win && x11win->display && x11win->window) {
+                x11win->minWidth = minWidth;
+                x11win->minHeight = minHeight;
+
+                XSizeHints hints;
+                memset(&hints, 0, sizeof(hints));
+                hints.flags = PMinSize;
+                hints.min_width = (minWidth > 0) ? (int)minWidth : 0;
+                hints.min_height = (minHeight > 0) ? (int)minHeight : 0;
+                XSetWMNormalHints(x11win->display, x11win->window, &hints);
                 XFlush(x11win->display);
             }
         }

--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -7500,7 +7500,9 @@ extern "C" NSWindow *createWindowWithFrameAndStyleFromWorker(
   WindowResizeHandler zigResizeHandler,
   WindowFocusHandler zigFocusHandler,
   WindowBlurHandler zigBlurHandler,
-  WindowKeyHandler zigKeyHandler
+  WindowKeyHandler zigKeyHandler,
+  double minWidth,
+  double minHeight
   ) {
 
     // Validate frame values - use defaults if NaN or invalid
@@ -7552,6 +7554,14 @@ extern "C" NSWindow *createWindowWithFrameAndStyleFromWorker(
             [[window standardWindowButton:NSWindowCloseButton] setHidden:YES];
             [[window standardWindowButton:NSWindowMiniaturizeButton] setHidden:YES];
             [[window standardWindowButton:NSWindowZoomButton] setHidden:YES];
+        }
+
+        // Apply minimum content size if specified
+        if (minWidth > 0 || minHeight > 0) {
+            [window setContentMinSize:NSMakeSize(
+                minWidth > 0 ? (CGFloat)minWidth : 0,
+                minHeight > 0 ? (CGFloat)minHeight : 0
+            )];
         }
     });
 
@@ -7722,6 +7732,16 @@ extern "C" void setWindowSize(NSWindow *window, double width, double height) {
         // Adjust y to keep top-left corner fixed (macOS uses bottom-left origin)
         frame.origin.y += (oldHeight - height);
         [window setFrame:frame display:YES animate:NO];
+    });
+}
+
+extern "C" void setWindowMinSize(NSWindow *window, double minWidth, double minHeight) {
+    runOnMainThreadAsyncVoid(^{
+        if (!window) return;
+        [window setContentMinSize:NSMakeSize(
+            minWidth > 0 ? (CGFloat)minWidth : 0,
+            minHeight > 0 ? (CGFloat)minHeight : 0
+        )];
     });
 }
 

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -4682,6 +4682,8 @@ typedef struct {
     WindowBlurHandler blurHandler;
     WindowKeyHandler keyHandler;
     ChromeStyle chromeStyle;
+    double minWidth = 0;
+    double minHeight = 0;
 } WindowData;
 
 
@@ -4953,12 +4955,26 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             }
             break;
 
+        case WM_GETMINMAXINFO: {
+            if (data && (data->minWidth > 0 || data->minHeight > 0)) {
+                MINMAXINFO* mmi = (MINMAXINFO*)lParam;
+                RECT rc = {0, 0, (LONG)data->minWidth, (LONG)data->minHeight};
+                AdjustWindowRectEx(&rc, GetWindowLong(hwnd, GWL_STYLE),
+                                  FALSE, GetWindowLong(hwnd, GWL_EXSTYLE));
+                if (data->minWidth > 0)
+                    mmi->ptMinTrackSize.x = max(mmi->ptMinTrackSize.x, (LONG)(rc.right - rc.left));
+                if (data->minHeight > 0)
+                    mmi->ptMinTrackSize.y = max(mmi->ptMinTrackSize.y, (LONG)(rc.bottom - rc.top));
+            }
+            break;
+        }
+
         case WM_CLOSE:
             if (data && data->closeHandler) {
                 data->closeHandler(data->windowId);
             }
             break;
-            
+
         case WM_MOVE:
             if (data && data->moveHandler) {
                 int x = LOWORD(lParam);
@@ -9326,7 +9342,9 @@ ELECTROBUN_EXPORT HWND createWindowWithFrameAndStyleFromWorker(
     WindowResizeHandler zigResizeHandler,
     WindowFocusHandler zigFocusHandler,
     WindowBlurHandler zigBlurHandler,
-    WindowKeyHandler zigKeyHandler) {
+    WindowKeyHandler zigKeyHandler,
+    double minWidth,
+    double minHeight) {
 
     (void)trafficLightOffsetX;
     (void)trafficLightOffsetY;
@@ -9356,6 +9374,8 @@ ELECTROBUN_EXPORT HWND createWindowWithFrameAndStyleFromWorker(
         data->focusHandler = zigFocusHandler;
         data->blurHandler = zigBlurHandler;
         data->keyHandler = zigKeyHandler;
+        data->minWidth = minWidth;
+        data->minHeight = minHeight;
 
         // Map style mask to Windows style
         DWORD windowStyle = WS_OVERLAPPEDWINDOW; // Default
@@ -9807,6 +9827,15 @@ ELECTROBUN_EXPORT void setWindowSize(NSWindow *window, double width, double heig
     if (!IsWindow(hwnd)) return;
 
     SetWindowPos(hwnd, NULL, 0, 0, (int)width, (int)height, SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
+}
+
+ELECTROBUN_EXPORT void setWindowMinSize(NSWindow *window, double minWidth, double minHeight) {
+    HWND hwnd = reinterpret_cast<HWND>(window);
+    if (!IsWindow(hwnd)) return;
+    WindowData* data = (WindowData*)GetWindowLongPtr(hwnd, GWLP_USERDATA);
+    if (!data) return;
+    data->minWidth = minWidth;
+    data->minHeight = minHeight;
 }
 
 ELECTROBUN_EXPORT void setWindowFrame(NSWindow *window, double x, double y, double width, double height) {

--- a/package/src/zig-sdk/electrobun.zig
+++ b/package/src/zig-sdk/electrobun.zig
@@ -93,6 +93,8 @@ pub const WindowOptions = struct {
     activate: bool = true,
     traffic_light_offset: TrafficLightOffset = .{},
     callbacks: WindowCallbacks = .{},
+    min_width: f64 = 0,
+    min_height: f64 = 0,
 };
 
 pub const WebviewCallbacks = struct {
@@ -558,7 +560,7 @@ pub const Core = struct {
     const RunMainThreadFn = *const fn ([*:0]const u8, [*:0]const u8, [*:0]const u8, c_int) callconv(.C) c_int;
     const ConfigureWebviewRuntimeFn = *const fn (u32, [*:0]const u8, [*:0]const u8) callconv(.C) bool;
     const GetWindowStyleFn = *const fn (bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool) callconv(.C) u32;
-    const CreateWindowFn = *const fn (f64, f64, f64, f64, u32, [*:0]const u8, bool, [*:0]const u8, bool, bool, f64, f64, ?WindowCloseHandler, ?WindowMoveHandler, ?WindowResizeHandler, ?WindowFocusHandler, ?WindowBlurHandler, ?WindowKeyHandler) callconv(.C) u32;
+    const CreateWindowFn = *const fn (f64, f64, f64, f64, u32, [*:0]const u8, bool, [*:0]const u8, bool, bool, f64, f64, ?WindowCloseHandler, ?WindowMoveHandler, ?WindowResizeHandler, ?WindowFocusHandler, ?WindowBlurHandler, ?WindowKeyHandler, f64, f64) callconv(.C) u32;
     const CreateWebviewFn = *const fn (u32, u32, [*:0]const u8, [*:0]const u8, f64, f64, f64, f64, bool, [*:0]const u8, ?DecideNavigationHandler, ?WebviewEventHandler, ?WebviewPostMessageHandler, ?WebviewPostMessageHandler, ?WebviewPostMessageHandler, [*:0]const u8, [*:0]const u8, [*:0]const u8, bool, bool, bool) callconv(.C) u32;
     const CreateWGPUViewFn = *const fn (u32, f64, f64, f64, f64, bool, bool, bool) callconv(.C) u32;
     const SetWindowTitleFn = *const fn (u32, [*:0]const u8) callconv(.C) void;
@@ -582,6 +584,8 @@ pub const Core = struct {
     const SetWindowSizeFn = *const fn (u32, f64, f64) callconv(.C) void;
     const SetWindowFrameFn = *const fn (u32, f64, f64, f64, f64) callconv(.C) void;
     const GetWindowFrameFn = *const fn (u32, *f64, *f64, *f64, *f64) callconv(.C) void;
+    const SetWindowMinSizeFn = *const fn (u32, f64, f64) callconv(.C) void;
+    const GetWindowMinSizeFn = *const fn (u32, *f64, *f64) callconv(.C) void;
     const CloseWindowFn = *const fn (u32) callconv(.C) void;
     const ResizeWebviewFn = *const fn (u32, f64, f64, f64, f64, [*:0]const u8) callconv(.C) void;
     const LoadURLInWebViewFn = *const fn (u32, [*:0]const u8) callconv(.C) void;
@@ -693,6 +697,8 @@ pub const Core = struct {
         set_window_size: SetWindowSizeFn,
         set_window_frame: SetWindowFrameFn,
         get_window_frame: GetWindowFrameFn,
+        set_window_min_size: SetWindowMinSizeFn,
+        get_window_min_size: GetWindowMinSizeFn,
         close_window: CloseWindowFn,
         resize_webview: ResizeWebviewFn,
         load_url_in_webview: LoadURLInWebViewFn,
@@ -822,6 +828,8 @@ pub const Core = struct {
                 .set_window_size = lib.lookup(SetWindowSizeFn, "setWindowSize") orelse return error.MissingCoreSymbol,
                 .set_window_frame = lib.lookup(SetWindowFrameFn, "setWindowFrame") orelse return error.MissingCoreSymbol,
                 .get_window_frame = lib.lookup(GetWindowFrameFn, "getWindowFrame") orelse return error.MissingCoreSymbol,
+                .set_window_min_size = lib.lookup(SetWindowMinSizeFn, "setWindowMinSize") orelse return error.MissingCoreSymbol,
+                .get_window_min_size = lib.lookup(GetWindowMinSizeFn, "getWindowMinSize") orelse return error.MissingCoreSymbol,
                 .close_window = lib.lookup(CloseWindowFn, "closeWindow") orelse return error.MissingCoreSymbol,
                 .resize_webview = lib.lookup(ResizeWebviewFn, "resizeWebview") orelse return error.MissingCoreSymbol,
                 .load_url_in_webview = lib.lookup(LoadURLInWebViewFn, "loadURLInWebView") orelse return error.MissingCoreSymbol,
@@ -992,6 +1000,8 @@ pub const Core = struct {
             options.callbacks.focus,
             options.callbacks.blur,
             options.callbacks.key,
+            options.min_width,
+            options.min_height,
         );
 
         if (window_id == 0) {
@@ -1091,6 +1101,19 @@ pub const Core = struct {
     pub fn setWindowSize(self: *Core, window_id: u32, width: f64, height: f64) !void {
         self.symbols.set_window_size(window_id, width, height);
         try self.ensureLastCallSucceeded();
+    }
+
+    pub fn setWindowMinSize(self: *Core, window_id: u32, min_width: f64, min_height: f64) !void {
+        self.symbols.set_window_min_size(window_id, min_width, min_height);
+        try self.ensureLastCallSucceeded();
+    }
+
+    pub fn getWindowMinSize(self: *Core, window_id: u32) !struct { width: f64, height: f64 } {
+        var width: f64 = 0;
+        var height: f64 = 0;
+        self.symbols.get_window_min_size(window_id, &width, &height);
+        try self.ensureLastCallSucceeded();
+        return .{ .width = width, .height = height };
     }
 
     pub fn setWindowFrame(self: *Core, window_id: u32, frame: Rect) !void {


### PR DESCRIPTION
### Summary

Adds minimum window size support across all three platforms, plus a build process fix for macOS 26.x.

### What's new

- **`BrowserWindow` API** — `minWidth` / `minHeight` options in `createWindow()`, and `setWindowMinSize()` / `getWindowMinSize()` instance methods
- **SDK (`electrobun.zig`)** — `min_width` / `min_height` fields on `WindowOptions`, plus `setWindowMinSize` / `getWindowMinSize` exports
- **Core (`main.zig`)** — `createWindow` accepts min width/height and persists them in `WindowState`; new `setWindowMinSize` / `getWindowMinSize` handlers
- **FFI bindings (`native.ts`)** — typed bindings for all new native calls

### Platform implementations

| Platform | Approach |
|----------|----------|
| **macOS** | Calls `setContentMinSize:` on the `NSWindow` |
| **Windows** | Handles `WM_GETMINMAXINFO` to clamp the window's minimum tracking size |
| **Linux (GTK/X11)** | Uses `gtk_window_set_geometry_hints()` with `GDK_HINT_MIN_SIZE` |

### Also included

- **Build fix** — Switches to `zig build-exe` for launcher / core / extractor to resolve linker errors on macOS 26.x
- **Kitchen tests** — New `window.test.ts` cases covering minWidth/minHeight, plus executor plumbing for `setWindowMinSize`

### Files changed

| File | Change |
|---|---|
| `package/src/bun/core/BrowserWindow.ts` | Public API — `minWidth`/`minHeight` options + `setMinimumSize`/`getMinimumSize` |
| `package/src/zig-sdk/electrobun.zig` | SDK types and methods |
| `package/src/core/main.zig` | Core window state and IPC handlers |
| `package/src/bun/proc/native.ts` | FFI bindings |
| `package/src/native/macos/nativeWrapper.mm` | macOS `setContentMinSize` |
| `package/src/native/win/nativeWrapper.cpp` | Windows `WM_GETMINMAXINFO` |
| `package/src/native/linux/nativeWrapper.cpp` | Linux GTK `set_geometry_hints` |
| `package/build.ts` | Build process update (zig build-exe) |
| `kitchen/src/tests/window.test.ts` | Kitchen tests |
| `kitchen/src/test-framework/executor.ts` | Test executor plumbing |
| `kitchen/src/test-framework/types.ts` | Test type definitions |

Closes #382 