### PR TITLE
add macOS tray length option

### DIFF
--- a/docs/src/content/docs/electrobun/apis/tray.mdx
+++ b/docs/src/content/docs/electrobun/apis/tray.mdx
@@ -15,6 +15,8 @@ const tray = new Tray({
   template: true,
   width: 32,
   height: 32,
+  // macOS only: fixed status item width, or "square"
+  length: "square",
 });
 
 // map action names to clicked state
@@ -96,6 +98,10 @@ tray.on("tray-clicked", (e) => {
 ### width and height
 
               <p>Set the dimensions of the image used in the system tray</p>
+
+### length
+
+              <p>On macOS, set the status item width in points or use <code>"square"</code> for the system square width. Omit it to keep variable system sizing.</p>
 
 ## Methods
 

--- a/kitchen/src/tests/tray-api.test.ts
+++ b/kitchen/src/tests/tray-api.test.ts
@@ -16,6 +16,7 @@ export const trayApiTests = [
         template: true,
         width: 32,
         height: 32,
+        length: process.platform === "darwin" ? 18 : undefined,
       });
 
       try {
@@ -30,6 +31,9 @@ export const trayApiTests = [
         expect(typeof bounds.y).toBe("number");
         expect(typeof bounds.width).toBe("number");
         expect(typeof bounds.height).toBe("number");
+        if (process.platform === "darwin") {
+          expect(bounds.width).toBe(18);
+        }
         log(
           `Tray bounds returned: x=${bounds.x}, y=${bounds.y}, width=${bounds.width}, height=${bounds.height}`,
         );

--- a/package/src/core/main.zig
+++ b/package/src/core/main.zig
@@ -34,6 +34,7 @@ const TrayState = struct {
     title: [:0]u8,
     image: [:0]u8,
     menu_config: ?[:0]u8,
+    length: ?f64 = null,
     is_template: bool,
     width: u32,
     height: u32,
@@ -1339,6 +1340,7 @@ fn createNativeTrayForState(tray_id: u32, state: *TrayState) bool {
         ?StatusItemHandler,
     ) callconv(.C) TrayPtr;
     const SetNativeTrayMenuFn = *const fn (TrayPtr, [*:0]const u8) callconv(.C) void;
+    const SetNativeTrayLengthFn = *const fn (TrayPtr, f64) callconv(.C) void;
 
     const create_native_tray = lookupNativeSymbol(CreateNativeTrayFn, "createTray") orelse return false;
     const tray_ptr = create_native_tray(
@@ -1358,6 +1360,13 @@ fn createNativeTrayForState(tray_id: u32, state: *TrayState) bool {
 
     state.ptr = tray_ptr;
     state.visible = true;
+
+    if (builtin.os.tag == .macos) {
+        if (state.length) |length| {
+            const set_native_tray_length = lookupNativeSymbol(SetNativeTrayLengthFn, "setTrayLength") orelse return false;
+            set_native_tray_length(tray_ptr, length);
+        }
+    }
 
     if (state.menu_config) |menu_config| {
         const set_native_tray_menu = lookupNativeSymbol(SetNativeTrayMenuFn, "setTrayMenu") orelse return false;
@@ -3274,6 +3283,23 @@ export fn setTrayTitle(tray_id: u32, title: [*:0]const u8) void {
     if (state.ptr) |tray_ptr| {
         const set_native_tray_title = lookupNativeSymbol(SetNativeTrayTitleFn, "setTrayTitle") orelse return;
         set_native_tray_title(tray_ptr, state.title.ptr);
+    }
+}
+
+export fn setTrayLength(tray_id: u32, length: f64) void {
+    clearLastError();
+
+    const SetNativeTrayLengthFn = *const fn (TrayPtr, f64) callconv(.C) void;
+    const state = tray_registry.getPtr(tray_id) orelse return;
+    state.length = length;
+
+    if (builtin.os.tag != .macos) {
+        return;
+    }
+
+    if (state.ptr) |tray_ptr| {
+        const set_native_tray_length = lookupNativeSymbol(SetNativeTrayLengthFn, "setTrayLength") orelse return;
+        set_native_tray_length(tray_ptr, length);
     }
 }
 

--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -8337,6 +8337,14 @@ extern "C" void setTrayTitle(NSStatusItem *statusItem, const char *title) {
     }
 }
 
+extern "C" void setTrayLength(NSStatusItem *statusItem, double length) {
+    if (statusItem) {
+        runOnMainThreadSyncVoid(^{
+            statusItem.length = length;
+        });
+    }
+}
+
 extern "C" void setTrayImage(NSStatusItem *statusItem, const char *image) {
     if (statusItem) {
         NSString *imgPath = [NSString stringWithUTF8String:image ?: ""];

--- a/package/src/sdks/bun/core/Tray.ts
+++ b/package/src/sdks/bun/core/Tray.ts
@@ -2,6 +2,7 @@ import { ffi, type MenuItemConfig, type Rectangle } from "../proc/native";
 import electrobunEventEmitter from "../events/eventEmitter";
 import { VIEWS_FOLDER } from "./Paths";
 import { join } from "path";
+import { resolveTrayLength } from "./TrayLength";
 
 type NonDividerMenuItem = Exclude<
 	MenuItemConfig,
@@ -16,6 +17,8 @@ export type TrayOptions = {
 	template?: boolean;
 	width?: number;
 	height?: number;
+	/** macOS status item width in points, or the system square width. */
+	length?: number | "square";
 };
 
 export class Tray {
@@ -26,6 +29,7 @@ export class Tray {
 	template = true;
 	width = 16;
 	height = 16;
+	length: number | undefined;
 	menu: Array<MenuItemConfig> | null = null;
 
 	constructor({
@@ -34,12 +38,14 @@ export class Tray {
 		template = true,
 		width = 16,
 		height = 16,
+		length,
 	}: TrayOptions = {}) {
 		this.title = title;
 		this.image = image;
 		this.template = template;
 		this.width = width;
 		this.height = height;
+		this.length = resolveTrayLength(length);
 
 		if (this.createNativeTray()) {
 			TrayMap[this.id] = this;
@@ -61,6 +67,9 @@ export class Tray {
 			}
 
 			this.id = trayId;
+			if (this.length !== undefined) {
+				ffi.request.setTrayLength({ id: trayId, length: this.length });
+			}
 			this.visible = true;
 			return true;
 		} catch (error) {

--- a/package/src/sdks/bun/core/TrayLength.test.ts
+++ b/package/src/sdks/bun/core/TrayLength.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "bun:test";
+import { resolveTrayLength } from "./TrayLength";
+
+describe("resolveTrayLength", () => {
+	it("resolves fixed and square lengths", () => {
+		expect(resolveTrayLength(18)).toBe(18);
+		expect(resolveTrayLength("square")).toBe(-2);
+		expect(resolveTrayLength()).toBeUndefined();
+	});
+
+	it("rejects invalid fixed lengths", () => {
+		for (const length of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+			expect(() => resolveTrayLength(length)).toThrow(RangeError);
+		}
+	});
+});

--- a/package/src/sdks/bun/core/TrayLength.ts
+++ b/package/src/sdks/bun/core/TrayLength.ts
@@ -1,0 +1,12 @@
+const appKitSquareLength = -2;
+
+export function resolveTrayLength(
+	length?: number | "square",
+): number | undefined {
+	if (length === undefined) return undefined;
+	if (length === "square") return appKitSquareLength;
+	if (!Number.isFinite(length) || length <= 0) {
+		throw new RangeError("Tray length must be a positive number or 'square'");
+	}
+	return length;
+}

--- a/package/src/sdks/bun/proc/native.ts
+++ b/package/src/sdks/bun/proc/native.ts
@@ -508,6 +508,10 @@ const core = (() => {
 				args: [FFIType.u32, FFIType.cstring],
 				returns: FFIType.void,
 			},
+			setTrayLength: {
+				args: [FFIType.u32, FFIType.f64],
+				returns: FFIType.void,
+			},
 			setTrayImage: {
 				args: [FFIType.u32, FFIType.cstring],
 				returns: FFIType.void,
@@ -1898,6 +1902,9 @@ const _ffiImpl = {
 		setTrayTitle: (params: { id: number; title: string }): void => {
 			const { id, title } = params;
 			core_.symbols.setTrayTitle(id, toCString(title));
+		},
+		setTrayLength: (params: { id: number; length: number }): void => {
+			core_.symbols.setTrayLength(params.id, params.length);
 		},
 		setTrayImage: (params: { id: number; image: string }): void => {
 			const { id, image } = params;


### PR DESCRIPTION
Adds `TrayOptions.length?: number | "square"` for macOS status items.

- `number`: fixed width in points
- `"square"`: system square width
- omitted: existing variable sizing

The value is preserved when the tray is recreated.

Tested on macOS 26.5:

- `18`: `18×22`, including after hide/show
- `"square"`: `22×22`
- unit tests, typecheck, docs check, Zig/core and native builds
