### PR TITLE
fix: isolate sandboxed webview events

### DIFF
--- a/package/src/core/main.zig
+++ b/package/src/core/main.zig
@@ -1514,16 +1514,16 @@ fn buildHostWebviewEventJavascript(
     const encoded_event_name = quoteJavascriptString(event_name) orelse return null;
     defer allocator.free(encoded_event_name);
 
+    const encoded_detail = quoteJavascriptString(detail) orelse return null;
+    defer allocator.free(encoded_detail);
+
     const event_name_slice = std.mem.span(event_name);
     if (std.mem.eql(u8, event_name_slice, "new-window-open") or std.mem.eql(u8, event_name_slice, "host-message")) {
         return allocateOwnedJavascriptString(
-            "document.querySelector('#electrobun-webview-{d}').emit({s}, {s});",
-            .{ webview_id, encoded_event_name, std.mem.span(detail) },
+            "document.querySelector('#electrobun-webview-{d}').emit({s}, (() => {{ try {{ return JSON.parse({s}); }} catch {{ return {s}; }} }})());",
+            .{ webview_id, encoded_event_name, encoded_detail, encoded_detail },
         );
     }
-
-    const encoded_detail = quoteJavascriptString(detail) orelse return null;
-    defer allocator.free(encoded_detail);
 
     return allocateOwnedJavascriptString(
         "document.querySelector('#electrobun-webview-{d}').emit({s}, {s});",
@@ -3732,4 +3732,24 @@ export fn wgpuSurfacePresentMainThread(surface_ptr: ?*anyopaque) i32 {
         "wgpuSurfacePresentMainThread",
     ) orelse return -1;
     return wgpu_surface_present_main_thread(surface_ptr);
+}
+
+test "host webview JSON events encode detail as data" {
+    const js = buildHostWebviewEventJavascript(
+        7,
+        "host-message",
+        "null); globalThis.pwned = \"yes\"; //",
+    ) orelse return error.OutOfMemory;
+    defer allocator.free(js);
+
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        js,
+        "JSON.parse(\"null); globalThis.pwned = \\\"yes\\\"; //\")",
+    ) != null);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        js,
+        "catch { return \"null); globalThis.pwned = \\\"yes\\\"; //\"; }",
+    ) != null);
 }

--- a/package/src/sdks/bun/proc/eventBridge.test.ts
+++ b/package/src/sdks/bun/proc/eventBridge.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import { parseWebviewEventBridgeMessage } from "./eventBridge";
+
+describe("parseWebviewEventBridgeMessage", () => {
+	it("uses the native sender id instead of the payload id", () => {
+		expect(
+			parseWebviewEventBridgeMessage(
+				17,
+				JSON.stringify({
+					id: "webviewEvent",
+					payload: {
+						id: 99,
+						eventName: "host-message",
+						detail: "{\"message\":\"hello\"}",
+					},
+				}),
+			),
+		).toEqual({
+			id: 17,
+			eventName: "host-message",
+			detail: "{\"message\":\"hello\"}",
+		});
+	});
+
+	it("ignores malformed event payloads", () => {
+		expect(parseWebviewEventBridgeMessage(1, "[]")).toBeNull();
+		expect(parseWebviewEventBridgeMessage(1, "{not-json")).toBeNull();
+		expect(
+			parseWebviewEventBridgeMessage(
+				1,
+				'{"id":"webviewEvent","payload":{"eventName":"host-message"}}',
+			),
+		).toBeNull();
+	});
+});

--- a/package/src/sdks/bun/proc/eventBridge.ts
+++ b/package/src/sdks/bun/proc/eventBridge.ts
@@ -1,0 +1,41 @@
+type JsonRecord = Record<string, unknown>;
+
+export type WebviewEventBridgeMessage = {
+	id: number;
+	eventName: string;
+	detail: string;
+};
+
+function isJsonRecord(value: unknown): value is JsonRecord {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function parseWebviewEventBridgeMessage(
+	sourceId: number,
+	rawMessage: string,
+): WebviewEventBridgeMessage | null {
+	if (!rawMessage.startsWith("{")) {
+		return null;
+	}
+
+	let message: unknown;
+	try {
+		message = JSON.parse(rawMessage);
+	} catch {
+		return null;
+	}
+	if (
+		!isJsonRecord(message) ||
+		message.id !== "webviewEvent" ||
+		!isJsonRecord(message.payload)
+	) {
+		return null;
+	}
+
+	const { eventName, detail } = message.payload;
+	if (typeof eventName !== "string" || typeof detail !== "string") {
+		return null;
+	}
+
+	return { id: sourceId, eventName, detail };
+}

--- a/package/src/sdks/bun/proc/native.ts
+++ b/package/src/sdks/bun/proc/native.ts
@@ -69,6 +69,7 @@ import {
 	toArrayBuffer,
 	type Pointer,
 } from "bun:ffi";
+import { parseWebviewEventBridgeMessage } from "./eventBridge";
 
 function getElectrobunLibraryPathCandidates(fileName: string) {
 	const candidates = new Set<string>();
@@ -2900,17 +2901,10 @@ const eventBridgeHandler = new JSCallback(
 		try {
 			const message = new CString(msg as unknown as Pointer);
 			const rawMessage = message.toString().trim();
-			if (!rawMessage || (rawMessage[0] !== "{" && rawMessage[0] !== "[")) {
-				return;
+			const event = parseWebviewEventBridgeMessage(_id, rawMessage);
+			if (event) {
+				webviewEventHandler(event.id, event.eventName, event.detail);
 			}
-			const jsonMessage = JSON.parse(rawMessage);
-
-			// Only handle webviewEvent messages - no RPC
-			if (jsonMessage.id === "webviewEvent") {
-				const { payload } = jsonMessage;
-				webviewEventHandler(payload.id, payload.eventName, payload.detail);
-			}
-			// Silently ignore any other message types - sandboxed webviews shouldn't send them
 		} catch (err) {
 			console.error("error in eventBridgeHandler: ", err);
 		}


### PR DESCRIPTION
## Summary

- bind sandbox event dispatch to the native sender id
- serialize special event detail as data while preserving JSON and string fallback behavior
- add focused regressions for spoofed ids and encoded host events

## Root cause

Sandboxed content could select another webview through its payload id, and special event detail was embedded directly in a JavaScript expression evaluated by the host webview.

## Checks

- bun test src/shared/naming.test.ts src/sdks/bun/proc/eventBridge.test.ts
- bunx tsc --noEmit for eventBridge source and test
- runtime JavaScript regression for encoded special event detail
