### PR TITLE
Add BrowserView.setFrame method

### DIFF
--- a/docs/src/content/docs/electrobun/apis/browser-view.mdx
+++ b/docs/src/content/docs/electrobun/apis/browser-view.mdx
@@ -383,6 +383,22 @@ const myWebviewRPC = BrowserView.defineRPC<MyWebviewRPCType>({
 
 ## Methods
 
+### setFrame
+  <p>Update the BrowserView's position and dimensions relative to its window. All frame values must be finite numbers. Negative width or height values are rejected.</p>
+
+```typescript
+const view = new BrowserView({
+  url: "https://example.com",
+  frame: { x: 0, y: 0, width: 800, height: 600 },
+});
+
+view.setFrame({ x: 240, y: 0, width: 1040, height: 720 });
+```
+
+  <Aside type="note">
+    <p>Calling <code>setFrame()</code> does not change <code>autoResize</code>. When <code>autoResize</code> is enabled, a later parent-window resize can replace the explicit frame.</p>
+  </Aside>
+
 ### executeJavascript
   <p>Execute arbitrary JavaScript in the webview. Unlike a `preload` script that you would typically set as a <a href="/electrobun/apis/browser-window">BrowserWindow</a> configuration option, `executeJavascript()` can be called at any time. This is a fire-and-forget method &mdash; it does not return a result.</p>
 
@@ -813,4 +829,3 @@ webview.on("download-failed", (event) => {
   console.log("Error:", event.detail.error);
 });
 ```
-

--- a/package/src/sdks/bun/core/BrowserView.test.ts
+++ b/package/src/sdks/bun/core/BrowserView.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, expect, mock, test } from "bun:test";
+
+type ResizeRequest = {
+	id: number;
+	frame: { x: number; y: number; width: number; height: number };
+};
+
+const resizeRequests: ResizeRequest[] = [];
+let resizeFailure: Error | null = null;
+const resizeWebview = mock((request: ResizeRequest) => {
+	resizeRequests.push(request);
+	if (resizeFailure) {
+		throw resizeFailure;
+	}
+});
+
+mock.module("../proc/native", () => ({
+	ffi: {
+		request: {
+			resizeWebview,
+		},
+	},
+}));
+
+const { BrowserView } = await import("./BrowserView");
+
+function createView(autoResize = false) {
+	const view = Object.create(BrowserView.prototype) as InstanceType<
+		typeof BrowserView
+	>;
+	view.id = 42;
+	view.frame = { x: 0, y: 0, width: 800, height: 600 };
+	view.autoResize = autoResize;
+	view.isRemoved = false;
+	Object.defineProperty(view, "ptr", {
+		get() {
+			throw new Error("ptr accessed");
+		},
+	});
+	return view;
+}
+
+beforeEach(() => {
+	resizeRequests.length = 0;
+	resizeFailure = null;
+	resizeWebview.mockClear();
+});
+
+test("setFrame resizes by ID, updates state, and copies input", () => {
+	const view = createView();
+	const frame = { x: 20, y: -10, width: 640, height: 480 };
+
+	view.setFrame(frame);
+
+	expect(resizeRequests).toEqual([
+		{ id: 42, frame: { x: 20, y: -10, width: 640, height: 480 } },
+	]);
+	expect(view.frame).toEqual(frame);
+	expect(view.frame).not.toBe(frame);
+
+	frame.width = 1;
+	expect(view.frame.width).toBe(640);
+});
+
+test("setFrame applies repeated updates and preserves autoResize", () => {
+	for (const autoResize of [false, true]) {
+		const view = createView(autoResize);
+		view.setFrame({ x: 1, y: 2, width: 300, height: 200 });
+		view.setFrame({ x: 3, y: 4, width: 500, height: 400 });
+
+		expect(view.frame).toEqual({ x: 3, y: 4, width: 500, height: 400 });
+		expect(view.autoResize).toBe(autoResize);
+	}
+
+	expect(resizeRequests.map(({ frame }) => frame)).toEqual([
+		{ x: 1, y: 2, width: 300, height: 200 },
+		{ x: 3, y: 4, width: 500, height: 400 },
+		{ x: 1, y: 2, width: 300, height: 200 },
+		{ x: 3, y: 4, width: 500, height: 400 },
+	]);
+});
+
+test("setFrame rejects invalid values without resizing or mutating state", () => {
+	const invalidFrames = [
+		{ x: Number.NaN, y: 0, width: 100, height: 100 },
+		{ x: Number.POSITIVE_INFINITY, y: 0, width: 100, height: 100 },
+		{ x: 0, y: Number.NEGATIVE_INFINITY, width: 100, height: 100 },
+		{ x: 0, y: 0, width: -1, height: 100 },
+		{ x: 0, y: 0, width: 100, height: -1 },
+	];
+
+	for (const frame of invalidFrames) {
+		const view = createView();
+		const previousFrame = view.frame;
+		expect(() => view.setFrame(frame)).toThrow();
+		expect(view.frame).toBe(previousFrame);
+	}
+
+	expect(resizeRequests).toHaveLength(0);
+});
+
+test("setFrame leaves state unchanged when native resize fails", () => {
+	const view = createView();
+	const previousFrame = view.frame;
+	resizeFailure = new Error("resize failed");
+
+	expect(() =>
+		view.setFrame({ x: 10, y: 20, width: 300, height: 200 }),
+	).toThrow("resize failed");
+	expect(view.frame).toBe(previousFrame);
+});
+
+test("setFrame is a no-op after remove", () => {
+	const view = createView();
+	const previousFrame = view.frame;
+	view.isRemoved = true;
+
+	view.setFrame({ x: 10, y: 20, width: 300, height: 200 });
+
+	expect(resizeRequests).toHaveLength(0);
+	expect(view.frame).toBe(previousFrame);
+});

--- a/package/src/sdks/bun/core/BrowserView.ts
+++ b/package/src/sdks/bun/core/BrowserView.ts
@@ -18,6 +18,13 @@ const BrowserViewMap: {
 	[id: number]: BrowserView<any>;
 } = {};
 
+export type BrowserViewFrame = {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+};
+
 export type BrowserViewOptions<T = undefined> = {
 	url: string | null;
 	html: string | null;
@@ -25,12 +32,7 @@ export type BrowserViewOptions<T = undefined> = {
 	viewsRoot: string | null;
 	renderer: "native" | "cef";
 	partition: string | null;
-	frame: {
-		x: number;
-		y: number;
-		width: number;
-		height: number;
-	};
+	frame: BrowserViewFrame;
 	rpc: T;
 	hostWebviewId: number;
 	autoResize: boolean;
@@ -73,12 +75,7 @@ export class BrowserView<T extends RPCWithTransport = RPCWithTransport> {
 	viewsRoot: string | null = null;
 	partition: string | null = null;
 	autoResize: boolean = true;
-	frame: {
-		x: number;
-		y: number;
-		width: number;
-		height: number;
-	} = {
+	frame: BrowserViewFrame = {
 		x: 0,
 		y: 0,
 		width: 800,
@@ -276,6 +273,26 @@ export class BrowserView<T extends RPCWithTransport = RPCWithTransport> {
 	 */
 	getPageZoom(): number {
 		return ffi.request.webviewGetPageZoom({ id: this.id }) as number;
+	}
+
+	setFrame(frame: BrowserViewFrame): void {
+		if (this.isRemoved) {
+			return;
+		}
+
+		const { x, y, width, height } = frame;
+		if (![x, y, width, height].every(Number.isFinite)) {
+			throw new TypeError("BrowserView frame values must be finite numbers");
+		}
+		if (width < 0 || height < 0) {
+			throw new RangeError(
+				"BrowserView frame dimensions must be greater than or equal to zero",
+			);
+		}
+
+		const nextFrame = { x, y, width, height };
+		ffi.request.resizeWebview({ id: this.id, frame: nextFrame });
+		this.frame = nextFrame;
 	}
 
 	// todo (yoav): move this to a class that also has off, append, prepend, etc.

--- a/package/src/sdks/bun/index.ts
+++ b/package/src/sdks/bun/index.ts
@@ -1,6 +1,10 @@
 import electobunEventEmmitter from "./events/eventEmitter";
 import { BrowserWindow, type WindowOptionsType } from "./core/BrowserWindow";
-import { BrowserView, type BrowserViewOptions } from "./core/BrowserView";
+import {
+	BrowserView,
+	type BrowserViewFrame,
+	type BrowserViewOptions,
+} from "./core/BrowserView";
 import { GpuWindow, type GpuWindowOptionsType } from "./core/GpuWindow";
 import { WGPUView, type WGPUViewOptions } from "./core/WGPUView";
 import { Tray, type TrayOptions } from "./core/Tray";
@@ -225,6 +229,7 @@ export {
 	type ElectrobunConfig,
 	type BuildConfigType,
 	type WindowOptionsType,
+	type BrowserViewFrame,
 	type BrowserViewOptions,
 	type GpuWindowOptionsType,
 	type WGPUViewOptions,


### PR DESCRIPTION
Adds a public `BrowserView.setFrame()` method for updating a view’s position and size after it has been created.

It uses the existing native `resizeWebview` request, keeps the local `frame` state in sync after a successful resize, and does not change `autoResize`.

Also included:

- a reusable exported `BrowserViewFrame` type
- unit tests for resizing, validation, removal, and native failures
- API documentation

