### PR TITLE
fix(win): read LOCALAPPDATA as wide string for WebView2 userDataFolder

### DIFF
--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -6746,9 +6746,12 @@ static std::shared_ptr<WebView2View> createWebView2View(uint32_t webviewId,
             // Create user data folder path based on partition
             // Build path with identifier/channel structure (consistent with CLI and updater)
             std::wstring userDataFolder;
-            char* localAppData = getenv("LOCALAPPDATA");
+            // Read via the wide CRT API: getenv() returns active-code-page bytes
+            // (e.g. CP949 on Korean Windows), which corrupt non-ASCII profile
+            // paths when converted as UTF-8 below.
+            wchar_t* localAppData = _wgetenv(L"LOCALAPPDATA");
             if (localAppData) {
-                std::string userDataPath = buildAppDataPath(localAppData, g_electrobunIdentifier, g_electrobunChannel, "WebView2", '\\');
+                std::string userDataPath = buildAppDataPath(WStringToString(localAppData), g_electrobunIdentifier, g_electrobunChannel, "WebView2", '\\');
 
                 // Handle partition-specific storage
                 if (!partitionStr.empty()) {


### PR DESCRIPTION
Fixes #505.

## Problem

`createWebView2View` builds the WebView2 user data folder from `getenv("LOCALAPPDATA")`, which returns **active-code-page** bytes (CP949 on Korean Windows), then converts the assembled path with `MultiByteToWideChar(CP_UTF8, ...)`. For any non-ASCII Windows username the bytes are invalid UTF-8, the path is mangled (`김종환` → `◆◆◆◆ø`), folder creation fails, and `CreateCoreWebView2EnvironmentWithOptions` never succeeds — the app launches but renders nothing. This hits the default (system webview) config for every user with a CJK/Cyrillic/accented profile path.

## Fix

Read the variable with `_wgetenv(L"LOCALAPPDATA")` and convert wide → UTF-8 with the file's existing `WStringToString()` helper. The downstream UTF-8 → wide conversion then round-trips correctly. 5 lines changed, no new helpers, no behavior change for ASCII paths.

The two CEF-path occurrences of the same pattern are intentionally left out to keep this reviewable — they need accompanying narrow-API changes (`CreateDirectoryA`, a naive `char`→`wchar_t` widen) and are documented in #505.

## Verification

Failure reproduced on a Korean-locale Windows 11 machine with a Hangul username (mojibake path visible in the WebView2 error dialog; `WebView2\` directory never created; manual `mkdir` of the same path succeeds, ruling out permissions). The patched path logic mirrors the `WStringToString` usage already present elsewhere in this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)