### PR TITLE
fix(linux): scale nested CEF webviews on HiDPI displays

### DIFF
--- a/package/dash.config.ts
+++ b/package/dash.config.ts
@@ -26,10 +26,11 @@ export default {
 		"push:stable": "hutch check:release && node scripts/push-version.js stable",
 		"build:push:artifacts": "node scripts/build-and-upload-artifacts.js",
 		"test:dialog-paths-native": "hutch scripts/test-dialog-paths-native.js",
+		"test:linux-dpi-native": "hutch scripts/test-linux-dpi-native.js",
 		"test:windows-ui-native": "hutch scripts/test-windows-ui-native.js",
 		"test:windows-ui-native-integration":
 			"hutch scripts/test-windows-ui-native.js --require-native-wrapper",
-		"test:unit": "node scripts/run-cottontail-test.js src/shared src/sdks/bun src/config src/preload && hutch test:dialog-paths-native && hutch test:webview2-permissions && hutch test:windows-ui-native",
+		"test:unit": "node scripts/run-cottontail-test.js src/shared src/sdks/bun src/config src/preload && hutch test:dialog-paths-native && hutch test:linux-dpi-native && hutch test:webview2-permissions && hutch test:windows-ui-native",
 		"test:linux-native-dialog":
 			"node scripts/run-cottontail-test.js src/shared/linux-native-file-dialog.test.ts && scripts/test-linux-native-file-dialog.sh",
 		"test:cef-debug": "scripts/test-cef-remote-debugging.ts",

--- a/package/scripts/test-linux-dpi-native.js
+++ b/package/scripts/test-linux-dpi-native.js
@@ -1,0 +1,67 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const packageRoot = resolve(import.meta.dirname, "..");
+const executableSuffix = process.platform === "win32" ? ".exe" : "";
+const zig =
+	process.env["ZIG_BINARY"] ??
+	join(packageRoot, "vendors", "zig", `zig${executableSuffix}`);
+const source = join(
+	packageRoot,
+	"src",
+	"native",
+	"shared",
+	"linux_dpi_test.cpp",
+);
+
+if (!existsSync(zig)) {
+	throw new Error(`Vendored Zig was not found at ${zig}`);
+}
+
+const temporaryDirectory = mkdtempSync(join(tmpdir(), "electrobun-linux-dpi-"));
+const binary = join(temporaryDirectory, `linux-dpi-test${executableSuffix}`);
+const cleanupWaiter = new Int32Array(new SharedArrayBuffer(4));
+
+function removeTemporaryDirectory(directory) {
+	for (let attempt = 0; attempt < 20; attempt += 1) {
+		try {
+			rmSync(directory, { recursive: true, force: true });
+			return;
+		} catch (error) {
+			const code = error?.code;
+			if (
+				process.platform !== "win32" ||
+				!["EACCES", "EPERM", "EBUSY", "ENOTEMPTY"].includes(code)
+			) {
+				throw error;
+			}
+			if (attempt === 19) throw error;
+			// Windows scanners can briefly retain a just-executed binary.
+			Atomics.wait(cleanupWaiter, 0, 0, 50 * (attempt + 1));
+		}
+	}
+}
+
+try {
+	const compile = spawnSync(
+		zig,
+		["c++", "-std=c++17", source, "-o", binary],
+		{ stdio: "inherit" },
+	);
+	if (compile.error) throw compile.error;
+	if (compile.status !== 0) {
+		throw new Error(
+			`Linux DPI native test compilation exited with ${compile.status ?? 1}`,
+		);
+	}
+
+	const test = spawnSync(binary, [], { stdio: "inherit" });
+	if (test.error) throw test.error;
+	if (test.status !== 0) {
+		throw new Error(`Linux DPI native test exited with ${test.status ?? 1}`);
+	}
+} finally {
+	removeTemporaryDirectory(temporaryDirectory);
+}

--- a/package/src/native/linux/nativeWrapper.cpp
+++ b/package/src/native/linux/nativeWrapper.cpp
@@ -68,6 +68,7 @@
 #include "native_file_dialog.h"
 #include "../shared/dialog_paths.h"
 #include "../shared/cef_find_session.h"
+#include "../shared/linux_dpi.h"
 
 using namespace electrobun;
 
@@ -109,6 +110,7 @@ using electrobun::OperationGuard;
 #include "include/cef_app.h"
 #include "include/cef_browser.h"
 #include "include/cef_client.h"
+#include "include/views/cef_display.h"
 #include "include/cef_load_handler.h"
 #include "include/cef_request_handler.h"
 #include "include/cef_context_menu_handler.h"
@@ -4420,6 +4422,7 @@ public:
     
     // For popup reparenting approach
     unsigned long parentXWindow = 0;
+    Display* parentXDisplay = nullptr;
     CefRect targetBounds;
     
     // For deferred browser creation
@@ -4465,6 +4468,11 @@ public:
           customPreloadScript(customPreloadScript ? customPreloadScript : ""),
           partition(partitionIdentifier ? partitionIdentifier : "")
     {
+        // Full-size BrowserViews are resized from raw X11 ConfigureNotify
+        // dimensions. Fixed child views, including <electrobun-webview>, use
+        // public DIP geometry and are converted at the X11 boundary.
+        this->fullSize = autoResize;
+
         // Set initial state flags
         this->pendingStartTransparent = startTransparent;
         this->pendingStartPassthrough = startPassthrough;
@@ -4510,6 +4518,68 @@ public:
             osr_window_id_ = 0;
         }
     }
+
+    double parentDeviceScaleFactor() const {
+        if (!parentXDisplay || !parentXWindow) {
+            return 1.0;
+        }
+
+        XWindowAttributes attributes = {};
+        int rootX = 0;
+        int rootY = 0;
+        Window child = 0;
+        CefRefPtr<CefDisplay> display;
+
+        if (XGetWindowAttributes(parentXDisplay, parentXWindow, &attributes) &&
+            XTranslateCoordinates(
+                parentXDisplay,
+                parentXWindow,
+                DefaultRootWindow(parentXDisplay),
+                0,
+                0,
+                &rootX,
+                &rootY,
+                &child
+            )) {
+            const CefRect physicalBounds(
+                rootX,
+                rootY,
+                attributes.width,
+                attributes.height);
+            display = CefDisplay::GetDisplayMatchingBounds(
+                physicalBounds, true);
+        }
+
+        if (!display) {
+            display = CefDisplay::GetPrimaryDisplay();
+        }
+
+        return electrobun::normalizeLinuxScaleFactor(
+            display ? display->GetDeviceScaleFactor() : 1.0);
+    }
+
+    electrobun::LinuxPhysicalRect toPhysicalOverlayRect(
+        double x,
+        double y,
+        double width,
+        double height
+    ) const {
+        return electrobun::logicalToLinuxPhysicalRect(
+            x, y, width, height, parentDeviceScaleFactor());
+    }
+
+    electrobun::LinuxPhysicalRect toX11BoundsRect(
+        double x,
+        double y,
+        double width,
+        double height
+    ) const {
+        if (fullSize) {
+            return electrobun::logicalToLinuxPhysicalRect(
+                x, y, width, height, 1.0);
+        }
+        return toPhysicalOverlayRect(x, y, width, height);
+    }
     
     void createCEFBrowser(GtkWidget* window, const char* url, double x, double y, double width, double height) {
         // NO GTK widget needed - CEF will be a direct child of the X11 window
@@ -4525,6 +4595,7 @@ public:
         
         // Store the parent X11 window handle for later window association
         this->parentXWindow = x11win->window;
+        this->parentXDisplay = x11win->display;
         
         // Store the parameters
         this->deferredUrl = url ? url : "";
@@ -4539,8 +4610,14 @@ public:
         // external X11 parent. Alloy is still used automatically for OSR.
         window_info.runtime_style = CEF_RUNTIME_STYLE_CHROME;
         
-        // For child windows, position should be relative to parent (0,0 for fullscreen)
-        CefRect cef_rect((int)x, (int)y, (int)width, (int)height);
+        // Public webview geometry is expressed in DIPs. X11 child bounds are
+        // physical pixels, so convert exactly once at the native boundary.
+        const auto physicalRect = toX11BoundsRect(x, y, width, height);
+        CefRect cef_rect(
+            physicalRect.x,
+            physicalRect.y,
+            std::max(1, physicalRect.width),
+            std::max(1, physicalRect.height));
         
         // Use SetAsChild with the X11 window
         window_info.SetAsChild(x11win->window, cef_rect);
@@ -4749,21 +4826,17 @@ public:
             return;
         }
         
-        // Check current window state before modifying
-        XWindowAttributes currentAttrs;
-        bool isCurrentlyMapped = false;
-        if (XGetWindowAttributes(display, (Window)cefWindow, &currentAttrs) != 0) {
-            isCurrentlyMapped = (currentAttrs.map_state != IsUnmapped);
-        }
-        
-        // For mapped windows, configure position/size without changing stacking order
-        if (isCurrentlyMapped) {
-            // Simply move and resize without changing z-order
-            XMoveResizeWindow(display, (Window)cefWindow, frame.x, frame.y, frame.width, frame.height);
-        } else {
-            // Window is unmapped (transparent), just move/resize without mapping
-            XMoveResizeWindow(display, (Window)cefWindow, frame.x, frame.y, frame.width, frame.height);
-        }
+        const auto physicalRect = toX11BoundsRect(
+            frame.x, frame.y, frame.width, frame.height);
+
+        // Configure the child without changing stacking or mapping state.
+        XMoveResizeWindow(
+            display,
+            (Window)cefWindow,
+            physicalRect.x,
+            physicalRect.y,
+            std::max(1, physicalRect.width),
+            std::max(1, physicalRect.height));
         XFlush(display);
                 
         // Check if the resize actually took effect
@@ -5109,14 +5182,17 @@ public:
         // Get the X11 display
         Display* display = gdk_x11_get_default_xdisplay();
         
-        // Create X11 rectangles for the mask regions
+        // Create X11 rectangles for the mask regions. Mask geometry arrives in
+        // the same DIP coordinate space as the webview bounds.
         std::vector<XRectangle> xrects;
         for (const auto& mask : masks) {
+            const auto physicalMask = toPhysicalOverlayRect(
+                mask.x, mask.y, mask.width, mask.height);
             XRectangle rect = {
-                static_cast<short>(mask.x),
-                static_cast<short>(mask.y),
-                static_cast<unsigned short>(mask.width),
-                static_cast<unsigned short>(mask.height)
+                static_cast<short>(physicalMask.x),
+                static_cast<short>(physicalMask.y),
+                static_cast<unsigned short>(physicalMask.width),
+                static_cast<unsigned short>(physicalMask.height)
             };
             xrects.push_back(rect);
         }
@@ -5126,10 +5202,12 @@ public:
         if (!xrects.empty()) {
             
             // First, create the base shape (full window rectangle)
+            const auto physicalBounds = toX11BoundsRect(
+                0, 0, visualBounds.width, visualBounds.height);
             XRectangle baseRect = {
-                0, 0, 
-                static_cast<unsigned short>(visualBounds.width),
-                static_cast<unsigned short>(visualBounds.height)
+                0, 0,
+                static_cast<unsigned short>(physicalBounds.width),
+                static_cast<unsigned short>(physicalBounds.height)
             };
             
             // Set the base shape to the full window

--- a/package/src/native/shared/linux_dpi.h
+++ b/package/src/native/shared/linux_dpi.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+
+namespace electrobun {
+
+struct LinuxPhysicalRect {
+    int x;
+    int y;
+    int width;
+    int height;
+};
+
+inline double normalizeLinuxScaleFactor(double scaleFactor) {
+    return std::isfinite(scaleFactor) && scaleFactor > 0 ? scaleFactor : 1.0;
+}
+
+inline int logicalToLinuxPhysicalPixel(double logical, double scaleFactor) {
+    return static_cast<int>(
+        std::lround(logical * normalizeLinuxScaleFactor(scaleFactor)));
+}
+
+// Scale both edges instead of scaling the size independently. This keeps
+// adjacent rectangles adjacent at fractional scale factors.
+inline LinuxPhysicalRect logicalToLinuxPhysicalRect(
+    double x,
+    double y,
+    double width,
+    double height,
+    double scaleFactor
+) {
+    const int left = logicalToLinuxPhysicalPixel(x, scaleFactor);
+    const int top = logicalToLinuxPhysicalPixel(y, scaleFactor);
+    const int right = logicalToLinuxPhysicalPixel(x + width, scaleFactor);
+    const int bottom = logicalToLinuxPhysicalPixel(y + height, scaleFactor);
+    return {
+        left,
+        top,
+        std::max(0, right - left),
+        std::max(0, bottom - top),
+    };
+}
+
+} // namespace electrobun

--- a/package/src/native/shared/linux_dpi_test.cpp
+++ b/package/src/native/shared/linux_dpi_test.cpp
@@ -1,0 +1,35 @@
+#include "linux_dpi.h"
+
+#include <cassert>
+
+int main() {
+    const auto dpr150 =
+        electrobun::logicalToLinuxPhysicalRect(100, 40, 800, 600, 1.5);
+    assert(dpr150.x == 150);
+    assert(dpr150.y == 60);
+    assert(dpr150.width == 1200);
+    assert(dpr150.height == 900);
+
+    const auto dpr200 =
+        electrobun::logicalToLinuxPhysicalRect(100, 40, 800, 600, 2.0);
+    assert(dpr200.x == 200);
+    assert(dpr200.y == 80);
+    assert(dpr200.width == 1600);
+    assert(dpr200.height == 1200);
+
+    const auto fractional =
+        electrobun::logicalToLinuxPhysicalRect(1, 1, 2, 2, 1.25);
+    assert(fractional.x == 1);
+    assert(fractional.y == 1);
+    assert(fractional.width == 3);
+    assert(fractional.height == 3);
+
+    const auto invalid =
+        electrobun::logicalToLinuxPhysicalRect(2, 3, 4, 5, 0.0);
+    assert(invalid.x == 2);
+    assert(invalid.y == 3);
+    assert(invalid.width == 4);
+    assert(invalid.height == 5);
+
+    return 0;
+}

--- a/package/src/shared/linux-cef-dpi.test.ts
+++ b/package/src/shared/linux-cef-dpi.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const linuxWrapper = readFileSync(
+	join(import.meta.dirname, "../native/linux/nativeWrapper.cpp"),
+	"utf8",
+);
+const overlaySync = readFileSync(
+	join(import.meta.dirname, "../preload/overlaySync.ts"),
+	"utf8",
+);
+const cefWrapper = linuxWrapper.slice(
+	linuxWrapper.indexOf("class CEFWebViewImpl : public AbstractView"),
+);
+
+function sourceBetween(start: string, end: string) {
+	const startIndex = cefWrapper.indexOf(start);
+	const endIndex = cefWrapper.indexOf(end, startIndex + start.length);
+	if (startIndex < 0 || endIndex < 0) {
+		throw new Error(`Could not find native source section: ${start} ... ${end}`);
+	}
+	return cefWrapper.slice(startIndex, endIndex);
+}
+
+describe("Linux CEF child-view DPI bounds", () => {
+	it("keeps overlay geometry in DIPs until the native boundary", () => {
+		expect(overlaySync).not.toContain("devicePixelRatio");
+		expect(overlaySync).toContain(
+			"this.options.onSync(newRect, JSON.stringify(masks))",
+		);
+	});
+
+	it("uses the CEF display scale for the X11 parent", () => {
+		const scaleFactor = sourceBetween(
+			"double parentDeviceScaleFactor() const",
+			"electrobun::LinuxPhysicalRect toPhysicalOverlayRect(",
+		);
+
+		expect(scaleFactor).toContain("XTranslateCoordinates(");
+		expect(scaleFactor).toContain("GetDisplayMatchingBounds(");
+		expect(scaleFactor).toContain("physicalBounds, true");
+		expect(scaleFactor).toContain("GetDeviceScaleFactor()");
+	});
+
+	it("converts initial, resized, and mask bounds to X11 pixels", () => {
+		const boundsConversion = sourceBetween(
+			"electrobun::LinuxPhysicalRect toX11BoundsRect(",
+			"void createCEFBrowser(",
+		);
+		const creation = sourceBetween(
+			"void createCEFBrowser(",
+			"void syncCEFPositionWithFrame(",
+		);
+		const resize = sourceBetween(
+			"void syncCEFPositionWithFrame(",
+			"void syncCEFPositionWithWidget()",
+		);
+		const masks = sourceBetween(
+			"void applyVisualMask() override",
+			"void removeMasks() override",
+		);
+
+		expect(boundsConversion).toContain("if (fullSize)");
+		expect(boundsConversion).toContain("x, y, width, height, 1.0");
+		expect(boundsConversion).toContain(
+			"return toPhysicalOverlayRect(x, y, width, height)",
+		);
+		expect(creation).toContain("const auto physicalRect = toX11BoundsRect(");
+		expect(creation).toContain("window_info.SetAsChild(x11win->window, cef_rect)");
+		expect(resize).toContain("const auto physicalRect = toX11BoundsRect(");
+		expect(resize).toContain("XMoveResizeWindow(");
+		expect(resize).toContain("physicalRect.width");
+		expect(masks).toContain(
+			"const auto physicalMask = toPhysicalOverlayRect(",
+		);
+		expect(masks).toContain(
+			"const auto physicalBounds = toX11BoundsRect(",
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- resolve the CEF display scale for the X11 parent window using physical monitor coordinates
- convert nested CEF child bounds from public DIPs to X11 physical pixels during initial creation and subsequent resizes
- scale visual/input mask rectangles through the same native boundary
- preserve the existing raw-X11 sizing path for full-size BrowserViews to avoid double scaling
- add edge-based fractional-scale conversion tests and source-contract coverage

Fixes #510.

## Why the conversion is native

`overlaySync` already defines the cross-platform contract correctly: DOM geometry stays in CSS/DIP pixels. Windows performs its DIP-to-native conversion in the native wrapper. Doing the Linux conversion beside `SetAsChild`, `XMoveResizeWindow`, and XShape handling keeps that contract consistent and prevents extensions/apps from applying renderer-specific DPR workarounds.

The helper scales both rectangle edges instead of independently rounding origin and size, so adjacent elements remain adjacent at fractional scale factors.

## Testing

- `bun test src/shared src/sdks/bun src/config src/preload` — 169 passed
- native C++ conversion test compiled and passed with `g++ -std=c++17`
- manually verified in Butler on Ubuntu/GNOME at 200% display scaling: a grid/flex-hosted `<electrobun-webview>` now fills the complete workspace to the right of the sidebar and below the title bar

## Related work

This is intentionally separate from #302 (full-window tiling-WM resize synchronization) and #477 (Xlib thread safety and configure-event coalescing). This patch targets fixed/nested child geometry and leaves full-size X11 dimensions unscaled.