### PR TITLE
fix(main): isolate macOS-only native FFI symbols

### DIFF
--- a/package/src/sdks/main/proc/native.ts
+++ b/package/src/sdks/main/proc/native.ts
@@ -680,6 +680,57 @@ const core = (() => {
 	}
 })();
 
+// These exports currently exist only in the macOS native wrapper. Keep them in
+// a separate optional handle because Bun's dlopen resolves the whole symbol
+// table eagerly. A missing platform extension must not disable core native APIs.
+const macOSNative = (() => {
+	if (process.platform !== "darwin") return null;
+	try {
+		return tryDlopenCandidates(`libNativeWrapper.${suffix}`, {
+			wgpuViewSetAlphaBlending: {
+				args: [FFIType.ptr, FFIType.bool],
+				returns: FFIType.void,
+			},
+			setWGPUPointerHandler: {
+				args: [FFIType.ptr],
+				returns: FFIType.void,
+			},
+			setWGPUKeyHandler: {
+				args: [FFIType.ptr],
+				returns: FFIType.void,
+			},
+			uiMeasureText: {
+				args: [
+					FFIType.cstring,
+					FFIType.cstring,
+					FFIType.f64,
+					FFIType.ptr,
+					FFIType.ptr,
+					FFIType.ptr,
+				],
+				returns: FFIType.void,
+			},
+			uiRasterizeText: {
+				args: [
+					FFIType.cstring,
+					FFIType.cstring,
+					FFIType.f64,
+					FFIType.f64,
+					FFIType.ptr,
+					FFIType.ptr,
+				],
+				returns: FFIType.ptr,
+			},
+			uiFreeTextBitmap: {
+				args: [FFIType.ptr],
+				returns: FFIType.void,
+			},
+		});
+	} catch {
+		return null;
+	}
+})();
+
 export const native = (() => {
 	try {
 		const nativeWrapperFileName = `libNativeWrapper.${suffix}`;
@@ -754,48 +805,6 @@ export const native = (() => {
 					FFIType.f64, // height
 					FFIType.cstring, // maskJson
 				],
-				returns: FFIType.void,
-			},
-
-			wgpuViewSetAlphaBlending: {
-				args: [FFIType.ptr, FFIType.bool],
-				returns: FFIType.void,
-			},
-
-			setWGPUPointerHandler: {
-				args: [FFIType.ptr],
-				returns: FFIType.void,
-			},
-
-			setWGPUKeyHandler: {
-				args: [FFIType.ptr],
-				returns: FFIType.void,
-			},
-
-			uiMeasureText: {
-				args: [
-					FFIType.cstring,
-					FFIType.cstring,
-					FFIType.f64,
-					FFIType.ptr,
-					FFIType.ptr,
-					FFIType.ptr,
-				],
-				returns: FFIType.void,
-			},
-			uiRasterizeText: {
-				args: [
-					FFIType.cstring,
-					FFIType.cstring,
-					FFIType.f64,
-					FFIType.f64,
-					FFIType.ptr,
-					FFIType.ptr,
-				],
-				returns: FFIType.ptr,
-			},
-			uiFreeTextBitmap: {
-				args: [FFIType.ptr],
 				returns: FFIType.void,
 			},
 
@@ -1941,9 +1950,12 @@ const _ffiImpl = {
 		},
 
 		wgpuViewSetAlphaBlending: (params: { id: number; enabled: boolean }) => {
+			const setAlphaBlending =
+				macOSNative?.symbols.wgpuViewSetAlphaBlending;
+			if (typeof setAlphaBlending !== "function") return;
 			const ptr = core_.symbols.getWGPUViewPointer(params.id);
 			if (!ptr) return;
-			native_.symbols.wgpuViewSetAlphaBlending(ptr, params.enabled);
+			setAlphaBlending(ptr, params.enabled);
 		},
 
 		wgpuViewSetPassthrough: (params: {
@@ -2573,7 +2585,7 @@ const wgpuKeyCallback = new JSCallback(
 export const nativeText = {
 	available(): boolean {
 		return Boolean(
-			hasFFI && typeof native_.symbols.uiMeasureText === "function",
+			hasFFI && typeof macOSNative?.symbols.uiMeasureText === "function",
 		);
 	},
 	measure(
@@ -2581,10 +2593,14 @@ export const nativeText = {
 		fontName: string,
 		size: number,
 	): { w: number; h: number; ascent: number } {
+		const measureText = macOSNative?.symbols.uiMeasureText;
+		if (typeof measureText !== "function") {
+			return { w: 0, h: 0, ascent: 0 };
+		}
 		const w = new Float64Array(1);
 		const h = new Float64Array(1);
 		const ascent = new Float64Array(1);
-		native_.symbols.uiMeasureText(
+		measureText(
 			toCString(text),
 			toCString(fontName),
 			size,
@@ -2600,8 +2616,16 @@ export const nativeText = {
 		size: number,
 		scale: number,
 	): { width: number; height: number; data: Uint8Array } | null {
+		const rasterizeText = macOSNative?.symbols.uiRasterizeText;
+		const freeTextBitmap = macOSNative?.symbols.uiFreeTextBitmap;
+		if (
+			typeof rasterizeText !== "function" ||
+			typeof freeTextBitmap !== "function"
+		) {
+			return null;
+		}
 		const dims = new Int32Array(2);
-		const pixelsPtr = native_.symbols.uiRasterizeText(
+		const pixelsPtr = rasterizeText(
 			toCString(text),
 			toCString(fontName),
 			size,
@@ -2615,7 +2639,7 @@ export const nativeText = {
 		const data = new Uint8Array(
 			toArrayBuffer(pixelsPtr as Pointer, 0, width * height * 4).slice(0),
 		);
-		native_.symbols.uiFreeTextBitmap(pixelsPtr);
+		freeTextBitmap(pixelsPtr);
 		return { width, height, data };
 	},
 };
@@ -2626,10 +2650,11 @@ export function enableWGPUKeyEvents(): boolean {
 	if (wgpuKeyEventsEnabled) return true;
 	if (!hasFFI) return false;
 	try {
-		if (typeof native_.symbols.setWGPUKeyHandler !== "function") {
+		const setKeyHandler = macOSNative?.symbols.setWGPUKeyHandler;
+		if (typeof setKeyHandler !== "function") {
 			return false;
 		}
-		native_.symbols.setWGPUKeyHandler(wgpuKeyCallback.ptr);
+		setKeyHandler(wgpuKeyCallback.ptr);
 		wgpuKeyEventsEnabled = true;
 		return true;
 	} catch {
@@ -2647,10 +2672,11 @@ export function enableWGPUPointerEvents(): boolean {
 	if (wgpuPointerEventsEnabled) return true;
 	if (!hasFFI) return false;
 	try {
-		if (typeof native_.symbols.setWGPUPointerHandler !== "function") {
+		const setPointerHandler = macOSNative?.symbols.setWGPUPointerHandler;
+		if (typeof setPointerHandler !== "function") {
 			return false;
 		}
-		native_.symbols.setWGPUPointerHandler(wgpuPointerCallback.ptr);
+		setPointerHandler(wgpuPointerCallback.ptr);
 		wgpuPointerEventsEnabled = true;
 		return true;
 	} catch {

--- a/package/src/sdks/main/proc/native.ts
+++ b/package/src/sdks/main/proc/native.ts
@@ -2594,7 +2594,7 @@ export const nativeText = {
 		size: number,
 	): { w: number; h: number; ascent: number } {
 		const measureText = macOSNative?.symbols.uiMeasureText;
-		if (typeof measureText !== "function") {
+		if (!hasFFI || typeof measureText !== "function") {
 			return { w: 0, h: 0, ascent: 0 };
 		}
 		const w = new Float64Array(1);
@@ -2619,6 +2619,7 @@ export const nativeText = {
 		const rasterizeText = macOSNative?.symbols.uiRasterizeText;
 		const freeTextBitmap = macOSNative?.symbols.uiFreeTextBitmap;
 		if (
+			!hasFFI ||
 			typeof rasterizeText !== "function" ||
 			typeof freeTextBitmap !== "function"
 		) {

--- a/package/src/shared/native-platform-ffi.test.ts
+++ b/package/src/shared/native-platform-ffi.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const nativeSource = readFileSync(
+	join(import.meta.dirname, "../sdks/main/proc/native.ts"),
+	"utf8",
+);
+
+function sourceBetween(start: string, end: string) {
+	const startIndex = nativeSource.indexOf(start);
+	const endIndex = nativeSource.indexOf(end, startIndex + start.length);
+	if (startIndex < 0 || endIndex < 0) {
+		throw new Error(`Could not find native source section: ${start} ... ${end}`);
+	}
+	return nativeSource.slice(startIndex, endIndex);
+}
+
+const macOSOnlySymbols = [
+	"wgpuViewSetAlphaBlending",
+	"setWGPUPointerHandler",
+	"setWGPUKeyHandler",
+	"uiMeasureText",
+	"uiRasterizeText",
+	"uiFreeTextBitmap",
+];
+
+describe("platform-specific native FFI", () => {
+	it("binds macOS-only exports only on macOS", () => {
+		const macOSBindings = sourceBetween(
+			"const macOSNative",
+			"export const native",
+		);
+		const commonBindings = sourceBetween(
+			"export const native",
+			"export const hasFFI",
+		);
+
+		expect(macOSBindings).toContain('process.platform !== "darwin"');
+		expect(macOSBindings).toContain("tryDlopenCandidates");
+		for (const symbol of macOSOnlySymbols) {
+			expect(macOSBindings).toContain(`${symbol}: {`);
+			expect(commonBindings).not.toContain(`${symbol}: {`);
+		}
+	});
+
+	it("guards optional macOS capabilities before invoking them", () => {
+		expect(nativeSource).toContain(
+			'if (typeof setAlphaBlending !== "function") return;',
+		);
+		expect(nativeSource).toContain(
+			'if (typeof measureText !== "function")',
+		);
+		expect(nativeSource).toContain(
+			'typeof rasterizeText !== "function"',
+		);
+		expect(nativeSource).toContain(
+			'typeof freeTextBitmap !== "function"',
+		);
+		expect(nativeSource).toContain(
+			'if (typeof setKeyHandler !== "function")',
+		);
+		expect(nativeSource).toContain(
+			'if (typeof setPointerHandler !== "function")',
+		);
+	});
+});

--- a/package/src/shared/native-platform-ffi.test.ts
+++ b/package/src/shared/native-platform-ffi.test.ts
@@ -49,10 +49,10 @@ describe("platform-specific native FFI", () => {
 			'if (typeof setAlphaBlending !== "function") return;',
 		);
 		expect(nativeSource).toContain(
-			'if (typeof measureText !== "function")',
+			'if (!hasFFI || typeof measureText !== "function")',
 		);
 		expect(nativeSource).toContain(
-			'typeof rasterizeText !== "function"',
+			'!hasFFI ||\n\t\t\ttypeof rasterizeText !== "function"',
 		);
 		expect(nativeSource).toContain(
 			'typeof freeTextBitmap !== "function"',


### PR DESCRIPTION
## What changed

- Move six macOS-only native wrapper bindings out of the common `dlopen` symbol table.
- Load them through a separate optional handle only on macOS.
- Guard alpha blending, WGPU input handlers, and native text calls when those optional exports are unavailable.
- Add a source-contract regression test so platform-only exports cannot accidentally return to the common binding table.

## Why

Bun resolves the full symbol table passed to `dlopen` eagerly. The Windows native wrapper does not export these six macOS capabilities, so one missing symbol prevented the entire native wrapper from loading and made otherwise valid core APIs unavailable.

This keeps the common binding table aligned with cross-platform exports while preserving the existing macOS functionality through feature detection.

Closes #520.

## Validation

- `bun test package/src/shared/native-platform-ffi.test.ts`: 2 passed, 0 failed, 20 assertions.
- Targeted FFI and related Windows/DPI tests: 16 passed, 0 failed, 92 assertions.
- End-to-end with `electrobun@1.18.4-beta.25` on Windows at 150% scaling: window starts successfully, Per-Monitor V2 is active, window DPI is 144, and WebView device scale factor is 1.5.
- `git diff --check`: passed.

Broader baseline checks were also run. The shared suite had 161 passing tests and 4 failures unrelated to this patch (including an unavailable `cl.exe` environment check and existing source-contract drift). `hutch typecheck` retained 9 existing main-branch errors involving missing generated/template modules and test typings; this change introduced no platform-FFI type errors.