### PR TITLE
fix: preserve tray image appearance on update

### DIFF
--- a/kitchen/src/playgrounds/tray/index.html
+++ b/kitchen/src/playgrounds/tray/index.html
@@ -49,6 +49,7 @@
             </div>
 
             <div class="button-row">
+                <button id="updateImageBtn" class="secondary-btn">Update Image</button>
                 <button id="startCounterBtn" class="secondary-btn">Start Counter</button>
                 <button id="stopCounterBtn" class="secondary-btn">Stop Counter</button>
             </div>

--- a/kitchen/src/playgrounds/tray/index.ts
+++ b/kitchen/src/playgrounds/tray/index.ts
@@ -26,6 +26,7 @@ function init() {
 
   document.getElementById("createTrayBtn")?.addEventListener("click", createTray);
   document.getElementById("updateTitleBtn")?.addEventListener("click", updateTitle);
+  document.getElementById("updateImageBtn")?.addEventListener("click", updateImage);
   document.getElementById("startCounterBtn")?.addEventListener("click", startCounter);
   document.getElementById("stopCounterBtn")?.addEventListener("click", stopCounter);
   document.getElementById("removeTrayBtn")?.addEventListener("click", removeTray);
@@ -69,6 +70,15 @@ async function updateTitle() {
       title: newTitleInput.value,
     });
     addLog(`Updated title to: "${newTitleInput.value}"`);
+  } catch (err) {
+    addLog(`Error: ${err}`);
+  }
+}
+
+async function updateImage() {
+  try {
+    await (electrobun.rpc as any)?.request.updateImage({});
+    addLog("Updated tray image in place");
   } catch (err) {
     addLog(`Error: ${err}`);
   }

--- a/kitchen/src/playgrounds/tray/index.ts
+++ b/kitchen/src/playgrounds/tray/index.ts
@@ -77,8 +77,14 @@ async function updateTitle() {
 
 async function updateImage() {
   try {
-    await (electrobun.rpc as any)?.request.updateImage({});
-    addLog("Updated tray image in place");
+    const result = await (electrobun.rpc as any)?.request.updateImage({});
+    if (!result?.success) {
+      addLog("Create a tray before updating its image");
+      return;
+    }
+    const button = document.getElementById("updateImageBtn");
+    if (button) button.textContent = `Update Image (#${result.count})`;
+    addLog(`Updated tray image in place (#${result.count})`);
   } catch (err) {
     addLog(`Error: ${err}`);
   }

--- a/kitchen/src/tests/interactive/tray.test.ts
+++ b/kitchen/src/tests/interactive/tray.test.ts
@@ -21,6 +21,7 @@ export const trayTests = [
 
       await new Promise<void>((resolve) => {
         let currentTray: Tray | null = null;
+        let imageUpdateCount = 0;
         let updateInterval: any = null;
         let winRef: BrowserWindow<any> | null = null;
 
@@ -46,6 +47,7 @@ export const trayTests = [
                   width: 32,
                   height: 32,
                 });
+                imageUpdateCount = 0;
 
                 if (opts.showMenu) {
                   const menu: any[] = [
@@ -87,11 +89,13 @@ export const trayTests = [
 
               updateImage: () => {
                 if (!currentTray) return { success: false };
+                imageUpdateCount++;
                 currentTray.setImage(
                   "views://assets/electrobun-logo-32-template.png",
                 );
-                log("Updated tray image in place");
-                return { success: true };
+                currentTray.setTitle(`Image update #${imageUpdateCount}`);
+                log(`Updated tray image in place (#${imageUpdateCount})`);
+                return { success: true, count: imageUpdateCount };
               },
 
               startCounter: () => {

--- a/kitchen/src/tests/interactive/tray.test.ts
+++ b/kitchen/src/tests/interactive/tray.test.ts
@@ -10,7 +10,8 @@ export const trayTests = [
     description: "Interactive playground for testing tray icon, title, and menus",
     instructions: [
       "A tray control panel will open",
-      "Configure tray options and click buttons to test",
+      "Create a tray, then drag its icon to a known position in the system tray",
+      "Click Update Image and verify that its position, size, and appearance stay unchanged",
       "Close the window when done to pass the test",
     ],
     interactive: true,
@@ -81,6 +82,15 @@ export const trayTests = [
                   currentTray.setTitle(opts.title);
                   log(`Updated title to: "${opts.title}"`);
                 }
+                return { success: true };
+              },
+
+              updateImage: () => {
+                if (!currentTray) return { success: false };
+                currentTray.setImage(
+                  "views://assets/electrobun-logo-32-template.png",
+                );
+                log("Updated tray image in place");
                 return { success: true };
               },
 

--- a/package/src/core/main.zig
+++ b/package/src/core/main.zig
@@ -3639,7 +3639,7 @@ export fn setTrayTitle(tray_id: u32, title: [*:0]const u8) void {
 export fn setTrayImage(tray_id: u32, image: [*:0]const u8) void {
     clearLastError();
 
-    const SetNativeTrayImageFn = *const fn (TrayPtr, [*:0]const u8) callconv(.c) void;
+    const SetNativeTrayImageFn = *const fn (TrayPtr, [*:0]const u8, bool, u32, u32) callconv(.c) void;
     const state = tray_registry.getPtr(tray_id) orelse return;
     if (!replaceOwnedZ(&state.image, image)) {
         return;
@@ -3647,7 +3647,13 @@ export fn setTrayImage(tray_id: u32, image: [*:0]const u8) void {
 
     if (state.ptr) |tray_ptr| {
         const set_native_tray_image = lookupNativeSymbol(SetNativeTrayImageFn, "setTrayImage") orelse return;
-        set_native_tray_image(tray_ptr, state.image.ptr);
+        set_native_tray_image(
+            tray_ptr,
+            state.image.ptr,
+            state.is_template,
+            state.width,
+            state.height,
+        );
     }
 }
 

--- a/package/src/native/linux/nativeWrapper.cpp
+++ b/package/src/native/linux/nativeWrapper.cpp
@@ -10336,7 +10336,8 @@ ELECTROBUN_EXPORT void setTrayTitle(void* statusItem, const char* title) {
     });
 }
 
-ELECTROBUN_EXPORT void setTrayImage(void* statusItem, const char* image) {
+ELECTROBUN_EXPORT void setTrayImage(void* statusItem, const char* image, bool /*isTemplate*/,
+                                    uint32_t /*width*/, uint32_t /*height*/) {
     dispatch_sync_main_void([&]() {
         // Find the tray by statusItem pointer
         for (auto& [id, tray] : g_trays) {
@@ -10387,7 +10388,7 @@ ELECTROBUN_EXPORT void* createTray(uint32_t trayId, const char* title, const cha
 }
 
 ELECTROBUN_EXPORT void setTrayTitle(void* statusItem, const char* title) {}
-ELECTROBUN_EXPORT void setTrayImage(void* statusItem, const char* image) {}
+ELECTROBUN_EXPORT void setTrayImage(void*, const char*, bool, uint32_t, uint32_t) {}
 ELECTROBUN_EXPORT void setTrayMenuFromJSON(void* statusItem, const char* jsonString) {}
 ELECTROBUN_EXPORT void setTrayMenu(void* statusItem, const char* menuConfig) {}
 ELECTROBUN_EXPORT void removeTray(void* statusItem) {}

--- a/package/src/native/macos/nativeWrapper.mm
+++ b/package/src/native/macos/nativeWrapper.mm
@@ -8739,11 +8739,15 @@ extern "C" void setTrayTitle(NSStatusItem *statusItem, const char *title) {
     }
 }
 
-extern "C" void setTrayImage(NSStatusItem *statusItem, const char *image) {
+extern "C" void setTrayImage(NSStatusItem *statusItem, const char *image, bool isTemplate,
+                             uint32_t width, uint32_t height) {
     if (statusItem) {
         NSString *imgPath = [NSString stringWithUTF8String:image ?: ""];
         runOnMainThreadAsyncVoid(^{
-            statusItem.button.image = [[NSImage alloc] initWithContentsOfFile:imgPath];
+            NSImage *trayImage = [[NSImage alloc] initWithContentsOfFile:imgPath];
+            [trayImage setTemplate:isTemplate];
+            trayImage.size = NSMakeSize(width, height);
+            statusItem.button.image = trayImage;
         });
     }
 }

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -12737,7 +12737,8 @@ ELECTROBUN_EXPORT void setTrayTitle(NSStatusItem *statusItem, const char *title)
     });
 }
 
-ELECTROBUN_EXPORT void setTrayImage(NSStatusItem *statusItem, const char *image) {
+ELECTROBUN_EXPORT void setTrayImage(NSStatusItem *statusItem, const char *image, bool /*isTemplate*/,
+                                    uint32_t width, uint32_t height) {
     if (!statusItem) return;
     
     MainThreadDispatcher::dispatch_sync([=]() {
@@ -12750,7 +12751,7 @@ ELECTROBUN_EXPORT void setTrayImage(NSStatusItem *statusItem, const char *image)
             std::wstring wImagePath;
             if (electrobun::utf8ToWide(image, wImagePath)) {
                 statusItem->nid.hIcon = (HICON)LoadImageW(NULL, wImagePath.c_str(), IMAGE_ICON,
-                                                         0, 0, LR_LOADFROMFILE | LR_DEFAULTSIZE);
+                                                         width, height, LR_LOADFROMFILE);
             }
         }
         

--- a/package/src/shared/tray-image-update-contract.test.ts
+++ b/package/src/shared/tray-image-update-contract.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const sourceRoot = join(import.meta.dirname, "..");
+const readSource = (relativePath: string) =>
+	readFileSync(join(sourceRoot, relativePath), "utf8");
+
+const core = readSource("core/main.zig");
+const macos = readSource("native/macos/nativeWrapper.mm");
+const windows = readSource("native/win/nativeWrapper.cpp");
+
+function sourceSection(source: string, start: string, end: string): string {
+	const startIndex = source.indexOf(start);
+	const endIndex = source.indexOf(end, startIndex + start.length);
+	if (startIndex === -1 || endIndex === -1) {
+		throw new Error(`Could not find source section: ${start}`);
+	}
+	return source.slice(startIndex, endIndex);
+}
+
+describe("tray image update appearance", () => {
+	test("passes the stored tray appearance through the native ABI", () => {
+		const setTrayImage = sourceSection(
+			core,
+			"export fn setTrayImage(",
+			"export fn setTrayMenu(",
+		);
+
+		expect(setTrayImage).toContain(
+			"*const fn (TrayPtr, [*:0]const u8, bool, u32, u32)",
+		);
+		expect(setTrayImage).toContain("state.is_template");
+		expect(setTrayImage).toContain("state.width");
+		expect(setTrayImage).toContain("state.height");
+	});
+
+	test("restores macOS template mode and size on the replacement image", () => {
+		const setTrayImage = sourceSection(
+			macos,
+			'extern "C" void setTrayImage(',
+			'extern "C" void setTrayMenuFromJSON(',
+		);
+
+		expect(setTrayImage).toContain("[trayImage setTemplate:isTemplate]");
+		expect(setTrayImage).toContain("NSMakeSize(width, height)");
+		expect(setTrayImage).toContain("statusItem.button.image = trayImage");
+	});
+
+	test("uses the configured dimensions for Windows image updates", () => {
+		const setTrayImage = sourceSection(
+			windows,
+			"ELECTROBUN_EXPORT void setTrayImage(",
+			"ELECTROBUN_EXPORT void setTrayMenuFromJSON(",
+		);
+
+		expect(setTrayImage).toContain("width, height, LR_LOADFROMFILE");
+		expect(setTrayImage).not.toContain("LR_DEFAULTSIZE");
+	});
+});


### PR DESCRIPTION
## Summary

- preserve a tray's configured template mode and dimensions when `setImage()` replaces its native image
- update the existing native tray item instead of forcing applications to hide and recreate it
- add an interactive Kitchen reproduction and focused source-contract coverage

## Problem and root cause

Creating a tray and updating its image did not use equivalent native paths.

Tray creation receives `template`, `width`, and `height`. On macOS, it creates an `NSImage`, applies `setTemplate(...)`, sets the configured size, and assigns the image to the `NSStatusItem`.

The image-update path previously received only the replacement image path. It created a fresh `NSImage` and assigned it directly, without restoring template mode or the configured dimensions. This is reproducible even when `setImage()` is called with the same file used at creation.

For a white macOS template asset, the visible result is immediate: the icon is rendered correctly in black when the tray is created, then becomes white and nearly invisible against the light menu bar after `setImage()`.

This also explains a downstream hide/show workaround. Recreating the tray routes the image back through the complete creation path, so template mode and size are restored. However, recreation also produces a new `NSStatusItem`; macOS treats it as a new menu-bar item and discards the position arranged by the user. The image-appearance bug is therefore the upstream defect, while the position jump is a consequence of working around it by recreating the tray.

The discrepancy is visible in the native implementation:

- **create:** load image → apply template mode → apply configured size → assign
- **update before this PR:** load image → assign

## Fix

`ElectrobunCore` already stores `is_template`, `width`, and `height` in `TrayState`. This change reuses those values during every image update and passes them through the internal native ABI.

- **macOS:** apply template mode and configured size to the replacement `NSImage`, then assign it to the existing `NSStatusItem`.
- **Windows:** load the replacement icon using the tray's configured width and height instead of `LR_DEFAULTSIZE`.
- **Linux:** accept the consistent internal ABI while retaining existing AppIndicator behavior; template mode and dimensions remain ignored at creation and update time as they are today.

The existing tray object is never removed or recreated, so its identity and user-arranged position are preserved. The public `Tray.setImage(path)` API is unchanged.

## Minimal reproduction

1. Run Kitchen and open **Tray (Interactive) → Tray playground**.
2. Create a tray with the supplied template icon.
3. On macOS, move it to a clearly visible menu-bar position.
4. Click **Update Image**. The reproduction deliberately supplies the same asset, isolating replacement-image behavior.
5. The button and tray title advance to `Image update #1`, confirming that the update path ran.

On upstream `main`, the icon changes from the normal black template rendering to a white, nearly invisible image. With this PR, its appearance, dimensions, and position remain unchanged.

## Visual evidence

The screenshots use the same Kitchen asset and the same arranged menu-bar position:

**Before update (upstream):** black template icon beside `My Tray`.
<img width="1512" height="90" alt="image" src="https://github.com/user-attachments/assets/b0a429a1-f519-4384-a2e5-3669af5ba684" />


**After update (upstream):** the counter advances to `Image update #1`, but the icon becomes white/ghosted.
<img width="1512" height="90" alt="image" src="https://github.com/user-attachments/assets/e82b4816-37e6-4ded-ad88-bda499603292" />


**After update (this PR):** the counter advances to `Image update #1` and the icon remains a black template image in the same position.

<img width="1512" height="90" alt="image" src="https://github.com/user-attachments/assets/0f221f0b-667a-4038-ba15-28d74d880706" />


## Validation

- `bun test package/src/shared/tray-image-update-contract.test.ts` — 3 passed
- full `hutch dev` native macOS build and Kitchen launch from upstream `main` plus only the reproduction UI: issue reproduced
- full `hutch dev` native macOS build and Kitchen launch from this PR branch: image appearance and arranged position preserved
- isolated downstream macOS harness confirmed that hide/show recreation resets menu-bar placement
- `git diff --check`

A full Windows/Linux native build was not available locally. The focused contract test covers the platform-specific update semantics, and the Linux implementation remains behaviorally unchanged.
