### PR TITLE
fix(webview2/win): pass --remote-debugging-port via the WebView2 API (survives Runtime 150 elevation hardening)

### DIFF
--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -7936,7 +7936,52 @@ static std::shared_ptr<WebView2View> createWebView2View(uint32_t webviewId,
         // Create WebView2 environment with custom scheme support
         try {
             auto options = Microsoft::WRL::Make<CoreWebView2EnvironmentOptions>();
-            options->put_AdditionalBrowserArguments(L"--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection --allow-insecure-localhost --disable-web-security");
+
+            // Build the browser arguments dynamically so remote debugging can be
+            // folded in via the WebView2 API below. WebView2 Runtime 150 stopped
+            // honoring the WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS environment variable
+            // for elevated (high-integrity) host processes, which silently breaks
+            // CDP/WebDriver automation (msedgedriver's --remote-debugging-port is
+            // dropped, so the DevTools endpoint never opens). Args passed through the
+            // API are still honored when elevated.
+            // See https://github.com/MicrosoftEdge/WebView2Feedback/issues/5640.
+            std::string additionalBrowserArgs =
+                "--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection "
+                "--allow-insecure-localhost --disable-web-security";
+
+            // Resolve the remote-debugging port from the same sources as the CEF
+            // renderer (build.json chromiumFlags["remote-debugging-port"], the
+            // ELECTROBUN_CEF_REMOTE_DEBUGGING_PORT env var, or the dev-build default)
+            // and pass it through the API so it survives elevation.
+            {
+                const std::wstring exePath = electrobun::getModuleFileNameWide();
+                if (!exePath.empty()) {
+                    const std::filesystem::path buildJsonPath =
+                        std::filesystem::path(exePath).parent_path() /
+                        L".." / L"Resources" / L"build.json";
+                    const std::string buildJsonContent =
+                        electrobun::readFileToString(buildJsonPath);
+                    const electrobun::ChromiumFlagConfig chromiumFlags =
+                        electrobun::parseChromiumFlags(buildJsonContent);
+                    const auto remoteDebugging = electrobun::resolveRemoteDebugging(
+                        buildJsonContent, chromiumFlags,
+                        getenv(electrobun::kRemoteDebuggingPortEnvironment));
+                    const int selectedPort = electrobun::selectRemoteDebuggingPort(
+                        remoteDebugging, IsPortAvailable);
+                    g_remoteDebugPort = selectedPort;
+                    if (selectedPort != 0) {
+                        additionalBrowserArgs +=
+                            " --remote-debugging-port=" + std::to_string(selectedPort);
+                        std::cout << "[WebView2] Remote debugging enabled on 127.0.0.1:"
+                                  << selectedPort << " ("
+                                  << electrobun::remoteDebuggingSourceName(remoteDebugging.source)
+                                  << ")" << std::endl;
+                    }
+                }
+            }
+
+            options->put_AdditionalBrowserArguments(
+                StringToWString(additionalBrowserArgs).c_str());
 
             // Get the interface that supports custom scheme registration
             Microsoft::WRL::ComPtr<ICoreWebView2EnvironmentOptions4> options4;

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -7133,6 +7133,60 @@ static RECT initialWebView2Bounds(
     return bounds;
 }
 
+// Resolve the WebView2 remote-debugging port once per process.
+//
+// This must not be resolved per view. WebView2 rejects a second environment
+// created against the same user data folder when its AdditionalBrowserArguments
+// differ, failing controller creation with ERROR_INVALID_STATE (0x8007139F),
+// and views share one user data folder unless they opt into a partition. A dev
+// build resolves its port by scanning for a free one, so a per-view resolve
+// would scan past the port the first view had already bound, pass different
+// arguments, and stop the second view from being created at all.
+//
+// g_remoteDebugPort is deliberately not written here. It belongs to CEF, whose
+// OpenRemoteDevToolsFrontend reads it to reach the CEF DevTools endpoint;
+// overwriting it would aim that lookup at the WebView2 port in an app that
+// renders with both.
+static int webView2RemoteDebuggingPort() {
+    // Function-local static: initialized exactly once, thread-safely, when the
+    // first view is created.
+    static const int port = []() -> int {
+        const std::wstring exePath = electrobun::getModuleFileNameWide();
+        if (exePath.empty()) return 0;
+
+        const std::filesystem::path buildJsonPath =
+            std::filesystem::path(exePath).parent_path() /
+            L".." / L"Resources" / L"build.json";
+        const std::string buildJsonContent =
+            electrobun::readFileToString(buildJsonPath);
+        const electrobun::ChromiumFlagConfig chromiumFlags =
+            electrobun::parseChromiumFlags(buildJsonContent);
+        const auto remoteDebugging = electrobun::resolveRemoteDebugging(
+            buildJsonContent, chromiumFlags,
+            getenv(electrobun::kRemoteDebuggingPortEnvironment));
+        const int selectedPort = electrobun::selectRemoteDebuggingPort(
+            remoteDebugging, IsPortAvailable);
+
+        if (selectedPort != 0) {
+            std::cout << "[WebView2] Remote debugging enabled on 127.0.0.1:"
+                      << selectedPort << " ("
+                      << electrobun::remoteDebuggingSourceName(remoteDebugging.source)
+                      << ")" << std::endl;
+        } else if (remoteDebugging.enabled()) {
+            std::cout << "[WebView2] Remote debugging disabled: no free port in "
+                      << electrobun::kDefaultRemoteDebuggingPort << "-"
+                      << electrobun::kLastAutomaticRemoteDebuggingPort << std::endl;
+        } else if (remoteDebugging.source == electrobun::RemoteDebuggingSource::invalid_configuration ||
+                   remoteDebugging.source == electrobun::RemoteDebuggingSource::invalid_environment) {
+            std::cout << "[WebView2] Remote debugging disabled: "
+                      << electrobun::remoteDebuggingSourceName(remoteDebugging.source)
+                      << std::endl;
+        }
+        return selectedPort;
+    }();
+    return port;
+}
+
 // Internal factory method for creating WebView2 instances
 static std::shared_ptr<WebView2View> createWebView2View(uint32_t webviewId,
                                                  HWND hwnd,
@@ -7952,32 +8006,12 @@ static std::shared_ptr<WebView2View> createWebView2View(uint32_t webviewId,
             // Resolve the remote-debugging port from the same sources as the CEF
             // renderer (build.json chromiumFlags["remote-debugging-port"], the
             // ELECTROBUN_CEF_REMOTE_DEBUGGING_PORT env var, or the dev-build default)
-            // and pass it through the API so it survives elevation.
-            {
-                const std::wstring exePath = electrobun::getModuleFileNameWide();
-                if (!exePath.empty()) {
-                    const std::filesystem::path buildJsonPath =
-                        std::filesystem::path(exePath).parent_path() /
-                        L".." / L"Resources" / L"build.json";
-                    const std::string buildJsonContent =
-                        electrobun::readFileToString(buildJsonPath);
-                    const electrobun::ChromiumFlagConfig chromiumFlags =
-                        electrobun::parseChromiumFlags(buildJsonContent);
-                    const auto remoteDebugging = electrobun::resolveRemoteDebugging(
-                        buildJsonContent, chromiumFlags,
-                        getenv(electrobun::kRemoteDebuggingPortEnvironment));
-                    const int selectedPort = electrobun::selectRemoteDebuggingPort(
-                        remoteDebugging, IsPortAvailable);
-                    g_remoteDebugPort = selectedPort;
-                    if (selectedPort != 0) {
-                        additionalBrowserArgs +=
-                            " --remote-debugging-port=" + std::to_string(selectedPort);
-                        std::cout << "[WebView2] Remote debugging enabled on 127.0.0.1:"
-                                  << selectedPort << " ("
-                                  << electrobun::remoteDebuggingSourceName(remoteDebugging.source)
-                                  << ")" << std::endl;
-                    }
-                }
+            // and pass it through the API so it survives elevation. Resolved once
+            // per process; see webView2RemoteDebuggingPort.
+            const int remoteDebugPort = webView2RemoteDebuggingPort();
+            if (remoteDebugPort != 0) {
+                additionalBrowserArgs +=
+                    " --remote-debugging-port=" + std::to_string(remoteDebugPort);
             }
 
             options->put_AdditionalBrowserArguments(

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -7133,24 +7133,19 @@ static RECT initialWebView2Bounds(
     return bounds;
 }
 
-// Resolve the WebView2 remote-debugging port once per process.
+// Resolve the WebView2 remote-debugging port once per process, from the same
+// sources as CEF: build.json chromiumFlags, ELECTROBUN_CEF_REMOTE_DEBUGGING_PORT,
+// or the dev-build default.
 //
-// This must not be resolved per view. WebView2 rejects a second environment
-// created against the same user data folder when its AdditionalBrowserArguments
-// differ, failing controller creation with ERROR_INVALID_STATE (0x8007139F),
-// and views share one user data folder unless they opt into a partition. A dev
-// build resolves its port by scanning for a free one, so a per-view resolve
-// would scan past the port the first view had already bound, pass different
-// arguments, and stop the second view from being created at all.
+// Not per view: WebView2 rejects a second environment on the same user data
+// folder when AdditionalBrowserArguments differ (ERROR_INVALID_STATE, 0x8007139F),
+// and dev builds scan for a free port, so resolving per view would scan past the
+// port view 1 already bound and break view 2.
 //
-// g_remoteDebugPort is deliberately not written here. It belongs to CEF, whose
-// OpenRemoteDevToolsFrontend reads it to reach the CEF DevTools endpoint;
-// overwriting it would aim that lookup at the WebView2 port in an app that
-// renders with both.
+// g_remoteDebugPort belongs to CEF (read by OpenRemoteDevToolsFrontend); a
+// WebView2 port must not overwrite it.
 static int webView2RemoteDebuggingPort() {
-    // Function-local static: initialized exactly once, thread-safely, when the
-    // first view is created.
-    static const int port = []() -> int {
+    static const int port = []() -> int {  // resolved once, thread-safely
         const std::wstring exePath = electrobun::getModuleFileNameWide();
         if (exePath.empty()) return 0;
 
@@ -7991,23 +7986,14 @@ static std::shared_ptr<WebView2View> createWebView2View(uint32_t webviewId,
         try {
             auto options = Microsoft::WRL::Make<CoreWebView2EnvironmentOptions>();
 
-            // Build the browser arguments dynamically so remote debugging can be
-            // folded in via the WebView2 API below. WebView2 Runtime 150 stopped
-            // honoring the WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS environment variable
-            // for elevated (high-integrity) host processes, which silently breaks
-            // CDP/WebDriver automation (msedgedriver's --remote-debugging-port is
-            // dropped, so the DevTools endpoint never opens). Args passed through the
-            // API are still honored when elevated.
+            // Runtime 150 stopped honoring WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS for
+            // elevated hosts, silently breaking CDP automation. Args passed through
+            // the API are still honored, so build them here.
             // See https://github.com/MicrosoftEdge/WebView2Feedback/issues/5640.
             std::string additionalBrowserArgs =
                 "--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection "
                 "--allow-insecure-localhost --disable-web-security";
 
-            // Resolve the remote-debugging port from the same sources as the CEF
-            // renderer (build.json chromiumFlags["remote-debugging-port"], the
-            // ELECTROBUN_CEF_REMOTE_DEBUGGING_PORT env var, or the dev-build default)
-            // and pass it through the API so it survives elevation. Resolved once
-            // per process; see webView2RemoteDebuggingPort.
             const int remoteDebugPort = webView2RemoteDebuggingPort();
             if (remoteDebugPort != 0) {
                 additionalBrowserArgs +=

--- a/package/src/native/win/nativeWrapper.cpp
+++ b/package/src/native/win/nativeWrapper.cpp
@@ -7133,19 +7133,12 @@ static RECT initialWebView2Bounds(
     return bounds;
 }
 
-// Resolve the WebView2 remote-debugging port once per process, from the same
-// sources as CEF: build.json chromiumFlags, ELECTROBUN_CEF_REMOTE_DEBUGGING_PORT,
-// or the dev-build default.
-//
-// Not per view: WebView2 rejects a second environment on the same user data
-// folder when AdditionalBrowserArguments differ (ERROR_INVALID_STATE, 0x8007139F),
-// and dev builds scan for a free port, so resolving per view would scan past the
-// port view 1 already bound and break view 2.
-//
-// g_remoteDebugPort belongs to CEF (read by OpenRemoteDevToolsFrontend); a
-// WebView2 port must not overwrite it.
+// Resolved once per process, not per view: WebView2 rejects a second environment on
+// the same user data folder when AdditionalBrowserArguments differ (0x8007139F), and
+// the dev-build port scan would hand view 2 a different port than view 1 bound.
+// g_remoteDebugPort is left to CEF, which reads it in OpenRemoteDevToolsFrontend.
 static int webView2RemoteDebuggingPort() {
-    static const int port = []() -> int {  // resolved once, thread-safely
+    static const int port = []() -> int {
         const std::wstring exePath = electrobun::getModuleFileNameWide();
         if (exePath.empty()) return 0;
 
@@ -7987,9 +7980,8 @@ static std::shared_ptr<WebView2View> createWebView2View(uint32_t webviewId,
             auto options = Microsoft::WRL::Make<CoreWebView2EnvironmentOptions>();
 
             // Runtime 150 stopped honoring WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS for
-            // elevated hosts, silently breaking CDP automation. Args passed through
-            // the API are still honored, so build them here.
-            // See https://github.com/MicrosoftEdge/WebView2Feedback/issues/5640.
+            // elevated hosts, so the port has to go through the API instead.
+            // https://github.com/MicrosoftEdge/WebView2Feedback/issues/5640
             std::string additionalBrowserArgs =
                 "--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection "
                 "--allow-insecure-localhost --disable-web-security";


### PR DESCRIPTION
Gives the WebView2 backend a `--remote-debugging-port` for the first time, passed through the WebView2 API so it survives Runtime 150's elevation hardening.

## Problem

WebView2 Runtime 150 made **elevated** host processes ignore `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS`. Only args passed through the WebView2 **API** still apply ([WebView2Feedback#5640](https://github.com/MicrosoftEdge/WebView2Feedback/issues/5640)).

Electrobun has never set that env var itself — `createWebView2View` passed a fixed argument string to `put_AdditionalBrowserArguments` with no `--remote-debugging-port` in it. Callers who wanted CDP set the env var externally before launch, and that was the only route a debug port had into the WebView2 renderer.

Runtime 150 closed that route for elevated hosts, so CDP/WebDriver automation breaks silently: the DevTools endpoint never opens and session creation times out. GitHub-hosted Windows runners are affected, since their processes run elevated with UAC disabled, once WebView2 auto-updated 149 → 150.

## Fix

`createWebView2View` now passes `--remote-debugging-port=<port>` through `put_AdditionalBrowserArguments`, which is honored when elevated. The port comes from the same sources as CEF — `build.json` `chromiumFlags`, `ELECTROBUN_CEF_REMOTE_DEBUGGING_PORT`, or the dev-build default — reusing `resolveRemoteDebugging()` / `selectRemoteDebuggingPort()` unchanged.

Two details worth review:

- **Resolved once per process** (`webView2RemoteDebuggingPort()`), not per view. WebView2 rejects a second environment on the same user data folder when `AdditionalBrowserArguments` differ (`ERROR_INVALID_STATE`, `0x8007139F`), and dev builds pick the port by scanning for a free one — so resolving per view would hand view 2 a different port than view 1 already bound, and stop view 2 being created.
- **`g_remoteDebugPort` is left to CEF**, which reads it in `OpenRemoteDevToolsFrontend`. A WebView2 port must not overwrite it in an app using both renderers.

Scope is limited to the remote-debugging port, matching CEF. General `chromiumFlags` passthrough would be a separate change.

## Testing

Windows 11 Pro 26200, MSVC 19.44 (VS Build Tools 2022 17.14.37614.0), WebView2 Runtime **152.0.4191.66** — past the 150 change.

### The regression, both directions

A harness creates two WebView2 environments — one taking the port only via the env var, one via `put_AdditionalBrowserArguments` — then probes `/json/version` on each:

| host | env var (status quo) | API arg (this PR) |
|---|---|---|
| **elevated** | CDP **down** | CDP **up** |
| unelevated | CDP up | CDP up |

Unelevated, the env-var route still works. The failure is precisely elevation-gated, so this is the hardening and not a broken harness.

### End to end, in a real app

Kitchen dev build, launched from an **elevated** shell:

```
[CEF]       Remote debugging enabled on 127.0.0.1:9222 (development default)
[WebView2]  Remote debugging enabled on 127.0.0.1:9223 (development default)
```

- **Both endpoints serve CDP.** WebView2 `/json/version` returns `Edg/152.0.4191.66` with a `webSocketDebuggerUrl`; CEF returns `Chrome/147.0.7727.118`, so the CEF path is unaffected.
- **Port separation holds.** CEF bound 9222; the WebView2 scan took the next free port, 9223. `g_remoteDebugPort` stayed CEF's — both renderers coexist without a clash.
- **Multi-view is clean.** Kitchen's views all initialize with no `0x8007139F`. Resolving per view instead reproduces that error, which is what motivates the once-per-process design.
- **The session is drivable, not just open.** Over the page target's websocket, `Runtime.evaluate` reads (`document.title`, `location.href`, a 1674-node DOM) and writes (mutating `document.title`, reading the new value back), and `DOM.getDocument` returns `nodeId 1` / `#document`.

`chromium_flags.test.cpp` compiles and passes. Warning output is identical to `main`.

Reported downstream against WebdriverIO's Electrobun testing service, where it breaks the Windows WebView2 E2E lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L257fBjb1jQ8RZsz2jZdde
