### PR TITLE
docs: add QoQa Compta and Crypto Tools to project list

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Don't miss our:
 - [PLEXI](https://github.com/ianjamesburke/PLEXI) - a multi-dimensional terminal multiplexer for the agentic era
 - [Prometheus](https://github.com/opensourcectl/prometheus) - desktop utility toolbox for file cleanup, document manipulation, and image processing
 - [qCodelicious](https://github.com/rafaelsouzars/qcodelicious) - a simple code editor
-- [QoQa Compta](https://github.com/nyg/qoqa-compta) - spending dashboard for Swiss deal site QoQa.ch
+- [QoQa Compta](https://github.com/nyg/qoqa-compta) - spending dashboard for the Swiss deal site QoQa.ch
 - [Quiver](https://ataraxy-labs.github.io/quiver/) - desktop app for GitHub PR reviews, merge conflict resolution, and AI commit messages
 - [remotecode.io](https://github.com/samuelfaj/remotecode.io) - continue local AI coding sessions (Claude Code or Codex) from your mobile device
 - [sirene](https://github.com/KevinBonnoron/sirene) - self-hosted multi-backend text-to-speech platform with voice cloning

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Don't miss our:
 - [codlogs](https://github.com/tobitege/codlogs) - search and export local Codex sessions via CLI or desktop app
 - [Codex Agents Composer](https://github.com/MrLesk/codex-agents-composer) - desktop app for managing your Codex agents and their skills
 - [codex-devtools](https://github.com/gulivan/codex-devtools) - desktop inspector for Codex session data; browse conversations, search messages, and analyze agent activity
+- [Crypto Tools](https://github.com/nyg/crypto-tools) - account management & order tools for the Kraken crypto exchange
 - [Deskdown](https://github.com/guarana-studio/deskdown) - transform any web address into a desktop app in under 20 seconds
 - [Dictate](https://github.com/siddhantparadox/dictate) - Windows dictation app with local and BYOK cloud transcription
 - [dev-3.0](https://github.com/h0x91b/dev-3.0) - helps you not get lost while managing multiple AI agents across projects
@@ -112,6 +113,7 @@ Don't miss our:
 - [PLEXI](https://github.com/ianjamesburke/PLEXI) - a multi-dimensional terminal multiplexer for the agentic era
 - [Prometheus](https://github.com/opensourcectl/prometheus) - desktop utility toolbox for file cleanup, document manipulation, and image processing
 - [qCodelicious](https://github.com/rafaelsouzars/qcodelicious) - a simple code editor
+- [QoQa Compta](https://github.com/nyg/qoqa-compta) - spending dashboard for Swiss deal site QoQa.ch
 - [Quiver](https://ataraxy-labs.github.io/quiver/) - desktop app for GitHub PR reviews, merge conflict resolution, and AI commit messages
 - [remotecode.io](https://github.com/samuelfaj/remotecode.io) - continue local AI coding sessions (Claude Code or Codex) from your mobile device
 - [sirene](https://github.com/KevinBonnoron/sirene) - self-hosted multi-backend text-to-speech platform with voice cloning


### PR DESCRIPTION
Hello,

Thanks a lot for Electrobun, I've been trying other similar tools to provide desktop version of my apps but they were a pain.

I'm building two apps with Electrobun:
* [QoQa Compta](https://github.com/nyg/qoqa-compta) — spending dashboard for the Swiss deal site QoQa.ch (uses Electrobun v2, created March 2026, 150 commits, 16 releases)
* [Crypto Tools](https://github.com/nyg/crypto-tools) — account management & order tools for the Kraken crypto exchange (still on v1, created in 2022, 300 commits, 17 releases)

Screenshots available in their respective READMEs.

Thanks,
nyg